### PR TITLE
Fix BSOD: Use-after-free in lock-free process cache

### DIFF
--- a/swifttunnel-windows/Cargo.toml
+++ b/swifttunnel-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-fps-booster"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel - Game Booster with PC Optimizations"
@@ -124,6 +124,10 @@ parking_lot = "0.12"
 
 # Per-CPU parallel packet processing
 crossbeam-channel = "0.5"
+
+# Lock-free Arc swapping for BSOD-safe RCU pattern
+arc-swap = "1.7"
+
 num_cpus = "1.16"
 
 # Stack-allocated buffers for zero-alloc packet processing

--- a/swifttunnel-windows/installer/SwiftTunnel.wxs
+++ b/swifttunnel-windows/installer/SwiftTunnel.wxs
@@ -3,7 +3,7 @@
     <Product Id="*"
              Name="SwiftTunnel"
              Language="1033"
-             Version="0.7.1.0"
+             Version="0.7.2.0"
              Manufacturer="SwiftTunnel"
              UpgradeCode="8B5E7A12-4F3D-4A2B-9C5E-1D2F3A4B5C6D">
 

--- a/swifttunnel-windows/src/vpn/process_cache.rs
+++ b/swifttunnel-windows/src/vpn/process_cache.rs
@@ -3,15 +3,18 @@
 //! Achieves <0.1ms lookup latency by eliminating locks entirely:
 //! - Single writer thread creates new snapshots atomically
 //! - Multiple reader threads access snapshots without any locks
-//! - Uses Arc atomic swap for O(1) snapshot updates
+//! - Uses arc-swap for safe atomic Arc operations (NO use-after-free!)
 //!
-//! This is modeled after WireGuard's approach where per-CPU structures
-//! avoid contention entirely.
+//! BSOD FIX (v0.7.2): Replaced unsafe AtomicPtr with arc-swap crate.
+//! The old implementation had a race condition where the writer could
+//! free memory while readers were still accessing it, causing
+//! IRQL_NOT_LESS_OR_EQUAL kernel crashes.
 
 use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
-use std::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use arc_swap::ArcSwap;
 use super::process_tracker::{ConnectionKey, Protocol, TrackerStats};
 
 /// Immutable snapshot of process state
@@ -127,15 +130,20 @@ impl ProcessSnapshot {
     }
 }
 
-/// Lock-free process cache using RCU pattern
+/// Lock-free process cache using RCU pattern with arc-swap
+///
+/// SAFETY: Uses arc-swap crate which provides correct hazard pointer
+/// implementation. Old snapshots are only freed when ALL readers have
+/// released their references (via Arc refcount).
 ///
 /// Key insight: We can have ONE writer and MANY readers without any locks
-/// by using atomic pointer swap. Readers grab a reference to the current
+/// by using atomic Arc swap. Readers grab a reference to the current
 /// snapshot and use it for their entire operation. Writer creates a new
 /// snapshot and atomically swaps the pointer.
 pub struct LockFreeProcessCache {
-    /// Current snapshot (atomically swapped)
-    current: AtomicPtr<Arc<ProcessSnapshot>>,
+    /// Current snapshot (atomically swapped via arc-swap)
+    /// arc-swap handles all the unsafe pointer magic correctly
+    current: ArcSwap<ProcessSnapshot>,
     /// Snapshot version counter
     version: AtomicU64,
     /// Apps to tunnel
@@ -147,10 +155,9 @@ impl LockFreeProcessCache {
     pub fn new(tunnel_apps: Vec<String>) -> Self {
         let apps: HashSet<String> = tunnel_apps.into_iter().map(|s| s.to_lowercase()).collect();
         let initial = Arc::new(ProcessSnapshot::empty(apps.clone()));
-        let boxed = Box::new(initial);
 
         Self {
-            current: AtomicPtr::new(Box::into_raw(boxed)),
+            current: ArcSwap::from(initial),
             version: AtomicU64::new(0),
             tunnel_apps: apps,
         }
@@ -160,12 +167,13 @@ impl LockFreeProcessCache {
     ///
     /// This is the hot path called by packet workers. It must be as fast as possible.
     /// Returns an Arc reference that the caller can use without any synchronization.
+    ///
+    /// SAFETY: arc-swap's load_full() safely clones the Arc, incrementing the
+    /// refcount atomically. The old snapshot won't be freed until all Arcs are
+    /// dropped, eliminating the use-after-free bug that caused BSOD.
     #[inline(always)]
     pub fn get_snapshot(&self) -> Arc<ProcessSnapshot> {
-        // Load the pointer atomically
-        let ptr = self.current.load(Ordering::Acquire);
-        // Safety: ptr is always valid (we never store null)
-        unsafe { (*ptr).clone() }
+        self.current.load_full()
     }
 
     /// Update snapshot (called by single writer thread)
@@ -175,6 +183,10 @@ impl LockFreeProcessCache {
     ///
     /// PERFORMANCE: Pre-lowercases all process names at insertion time,
     /// eliminating string allocation from the hot path (is_tunnel_pid).
+    ///
+    /// SAFETY: arc-swap's store() handles the atomic swap correctly.
+    /// The old Arc is returned and dropped, decrementing its refcount.
+    /// Memory is only freed when refcount reaches zero (all readers done).
     pub fn update(&self, connections: HashMap<ConnectionKey, u32>, pid_names: HashMap<u32, String>) {
         let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
 
@@ -192,17 +204,8 @@ impl LockFreeProcessCache {
             created_at: std::time::Instant::now(),
         });
 
-        let new_boxed = Box::new(new_snapshot);
-        let new_ptr = Box::into_raw(new_boxed);
-
-        // Atomically swap in new snapshot
-        let old_ptr = self.current.swap(new_ptr, Ordering::AcqRel);
-
-        // Clean up old snapshot (after all readers release their refs)
-        // Safety: old_ptr was created by Box::into_raw
-        unsafe {
-            let _ = Box::from_raw(old_ptr);
-        }
+        // Atomically swap in new snapshot - arc-swap handles cleanup safely
+        self.current.store(new_snapshot);
     }
 
     /// Update tunnel apps list and immediately refresh the snapshot
@@ -226,16 +229,8 @@ impl LockFreeProcessCache {
             created_at: std::time::Instant::now(),
         });
 
-        let new_boxed = Box::new(new_snapshot);
-        let new_ptr = Box::into_raw(new_boxed);
-
-        // Atomically swap in new snapshot
-        let old_ptr = self.current.swap(new_ptr, Ordering::AcqRel);
-
-        // Clean up old snapshot
-        unsafe {
-            let _ = Box::from_raw(old_ptr);
-        }
+        // Atomically swap in new snapshot - arc-swap handles cleanup safely
+        self.current.store(new_snapshot);
 
         log::info!(
             "set_tunnel_apps: Updated snapshot with {} tunnel apps: {:?}",
@@ -250,20 +245,8 @@ impl LockFreeProcessCache {
     }
 }
 
-impl Drop for LockFreeProcessCache {
-    fn drop(&mut self) {
-        let ptr = self.current.load(Ordering::Relaxed);
-        if !ptr.is_null() {
-            unsafe {
-                let _ = Box::from_raw(ptr);
-            }
-        }
-    }
-}
-
-// Safety: LockFreeProcessCache can be shared across threads
-unsafe impl Send for LockFreeProcessCache {}
-unsafe impl Sync for LockFreeProcessCache {}
+// Note: No manual Drop impl needed - ArcSwap handles cleanup automatically
+// Note: No unsafe impl Send/Sync needed - ArcSwap is already Send+Sync
 
 #[cfg(test)]
 mod tests {
@@ -320,5 +303,52 @@ mod tests {
 
         // Packet has actual interface IP, should still match via 0.0.0.0 fallback
         assert!(snap.should_tunnel(Ipv4Addr::new(192, 168, 1, 100), 50000, Protocol::Udp));
+    }
+
+    #[test]
+    fn test_concurrent_read_write_safety() {
+        // This test verifies that arc-swap prevents use-after-free
+        use std::thread;
+        use std::time::Duration;
+
+        let cache = Arc::new(LockFreeProcessCache::new(vec!["test.exe".to_string()]));
+
+        // Spawn reader threads that continuously get snapshots
+        let readers: Vec<_> = (0..4).map(|i| {
+            let cache_clone = Arc::clone(&cache);
+            thread::spawn(move || {
+                for _ in 0..1000 {
+                    let snap = cache_clone.get_snapshot();
+                    // Access the snapshot data - this would crash with old implementation
+                    let _ = snap.version;
+                    let _ = snap.connections.len();
+                    thread::sleep(Duration::from_micros(10));
+                }
+                log::debug!("Reader {} finished", i);
+            })
+        }).collect();
+
+        // Writer thread that continuously updates
+        let cache_writer = Arc::clone(&cache);
+        let writer = thread::spawn(move || {
+            for i in 0..100 {
+                let mut connections = HashMap::new();
+                connections.insert(
+                    ConnectionKey::new(Ipv4Addr::new(192, 168, 1, 1), i as u16, Protocol::Tcp),
+                    i,
+                );
+                let mut pid_names = HashMap::new();
+                pid_names.insert(i, format!("process_{}.exe", i));
+                cache_writer.update(connections, pid_names);
+                thread::sleep(Duration::from_micros(100));
+            }
+            log::debug!("Writer finished");
+        });
+
+        // Wait for all threads - if there's a use-after-free, this would crash
+        for reader in readers {
+            reader.join().expect("Reader thread panicked");
+        }
+        writer.join().expect("Writer thread panicked");
     }
 }


### PR DESCRIPTION
## Summary

Fixes critical BSOD (`IRQL_NOT_LESS_OR_EQUAL`) caused by use-after-free race condition in the lock-free process cache.

## Root Cause

The `process_cache.rs` used unsafe `AtomicPtr<Arc<ProcessSnapshot>>` with manual `Box::into_raw/from_raw`. When the writer thread called `update()`, it would swap the pointer and **immediately free the old memory** via `Box::from_raw()`. 

If a reader thread had loaded the pointer but not yet cloned the Arc, it would dereference freed memory → kernel page fault at elevated IRQL → **BSOD**.

```
Race condition timeline:
1. Reader: ptr = current.load()     // Load pointer
2. Writer: old = current.swap(new)  // Swap in new
3. Writer: Box::from_raw(old)       // FREE MEMORY!
4. Reader: (*ptr).clone()           // USE-AFTER-FREE → BSOD
```

## Solution

Replace unsafe pointer manipulation with the `arc-swap` crate (v1.7), which provides a battle-tested hazard pointer implementation. Old snapshots are now only freed when **ALL** readers have released their Arc references (via Arc refcount).

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Added `arc-swap = "1.7"` dependency |
| `installer/SwiftTunnel.wxs` | Bumped version to 0.7.2.0 |
| `src/vpn/process_cache.rs` | Rewrote using ArcSwap |

### Key Code Changes

- `AtomicPtr<Arc<ProcessSnapshot>>` → `ArcSwap<ProcessSnapshot>`
- `get_snapshot()` now uses `load_full()` which safely clones the Arc
- `update()` now uses `store()` which handles cleanup via Arc refcount
- Removed `unsafe impl Send/Sync` (arc-swap handles this)
- Removed manual `Drop` impl (arc-swap handles cleanup)
- Added concurrent read/write stress test

## Test Plan

- [ ] Build on Windows testbench: `cargo build --release`
- [ ] Run unit tests: `cargo test`
- [ ] Test split tunnel with Roblox
- [ ] Stress test: Multiple connect/disconnect cycles
- [ ] Monitor for BSOD reports after release