### PR TITLE
Fix TSO crash recovery and thread join timeout

### DIFF
--- a/swifttunnel-windows/Cargo.toml
+++ b/swifttunnel-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-fps-booster"
-version = "0.9.34"
+version = "1.0.0"
 edition = "2021"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel - Game Booster with PC Optimizations"

--- a/swifttunnel-windows/installer/SwiftTunnel.wxs
+++ b/swifttunnel-windows/installer/SwiftTunnel.wxs
@@ -3,7 +3,7 @@
     <Product Id="*"
              Name="SwiftTunnel"
              Language="1033"
-             Version="0.9.34.0"
+             Version="1.0.0.0"
              Manufacturer="SwiftTunnel"
              UpgradeCode="8B5E7A12-4F3D-4A2B-9C5E-1D2F3A4B5C6D">
 

--- a/swifttunnel-windows/src/gui/layout.rs
+++ b/swifttunnel-windows/src/gui/layout.rs
@@ -24,16 +24,6 @@ impl NavItem {
         }
     }
 
-    /// Simple ASCII icon fallback (uses Unicode symbols that render well in most fonts)
-    pub fn icon_simple(&self) -> &'static str {
-        match self {
-            NavItem::Connect => "\u{1F310}", // 🌐 Globe (WiFi/connection)
-            NavItem::Boost => "\u{26A1}",    // ⚡ Lightning (FPS boost)
-            NavItem::Network => "\u{1F4CA}", // 📊 Chart (network analyzer)
-            NavItem::Settings => "\u{2699}", // ⚙ Gear (settings)
-        }
-    }
-
     /// Tooltip text
     pub fn tooltip(&self) -> &'static str {
         match self {

--- a/swifttunnel-windows/src/network_booster.rs
+++ b/swifttunnel-windows/src/network_booster.rs
@@ -159,18 +159,8 @@ impl NetworkBooster {
     /// Enable external network boost (integration point for SwiftTunnel)
     fn enable_external_network_boost(&self) -> Result<()> {
         info!("Enabling external network boost integration");
-
-        // This is a placeholder for integrating with your existing network booster
-        // You would call your SwiftTunnel API or executable here
-
-        // Example: Start your network booster process
-        // let output = Command::new("SwiftTunnel.exe")
-        //     .args(&["--enable", "--game", "roblox"])
-        //     .spawn()?;
-
-        // For now, just log that we would enable it
+        // Integration point - connect your network booster here
         info!("Network boost integration point - connect your SwiftTunnel here");
-
         Ok(())
     }
 

--- a/swifttunnel-windows/src/vpn/mod.rs
+++ b/swifttunnel-windows/src/vpn/mod.rs
@@ -37,8 +37,10 @@ pub mod connection;
 pub mod servers;
 pub mod error_messages;
 pub mod udp_relay;
+pub mod tso_recovery;
 
 pub use config::{fetch_vpn_config, update_latency, VpnConfigRequest};
+pub use tso_recovery::{recover_tso_on_startup, emergency_tso_restore};
 pub use adapter::WintunAdapter;
 pub use tunnel::{WireguardTunnel, InboundHandler};
 pub use packet_interceptor::WireguardContext;

--- a/swifttunnel-windows/src/vpn/split_tunnel.rs
+++ b/swifttunnel-windows/src/vpn/split_tunnel.rs
@@ -946,57 +946,6 @@ impl Drop for SplitTunnelDriver {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-//  HELPER FUNCTIONS
-// ═══════════════════════════════════════════════════════════════════════════════
-
-/// Get default tunnel apps (Roblox by default)
-pub fn get_default_tunnel_apps() -> Vec<String> {
-    GamePreset::Roblox.process_names().iter().map(|s| s.to_string()).collect()
-}
-
-/// Find Roblox player path
-pub fn find_roblox_path() -> Option<PathBuf> {
-    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
-    let roblox_dir = PathBuf::from(local_app_data).join("Roblox").join("Versions");
-
-    if !roblox_dir.exists() {
-        return None;
-    }
-
-    // Find the version folder with RobloxPlayerBeta.exe
-    for entry in std::fs::read_dir(&roblox_dir).ok()? {
-        let entry = entry.ok()?;
-        let player_exe = entry.path().join("RobloxPlayerBeta.exe");
-        if player_exe.exists() {
-            return Some(player_exe);
-        }
-    }
-
-    None
-}
-
-/// Find Roblox Studio path
-pub fn find_roblox_studio_path() -> Option<PathBuf> {
-    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
-    let roblox_dir = PathBuf::from(local_app_data).join("Roblox").join("Versions");
-
-    if !roblox_dir.exists() {
-        return None;
-    }
-
-    // Find the version folder with RobloxStudioBeta.exe
-    for entry in std::fs::read_dir(&roblox_dir).ok()? {
-        let entry = entry.ok()?;
-        let studio_exe = entry.path().join("RobloxStudioBeta.exe");
-        if studio_exe.exists() {
-            return Some(studio_exe);
-        }
-    }
-
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/swifttunnel-windows/src/vpn/tso_recovery.rs
+++ b/swifttunnel-windows/src/vpn/tso_recovery.rs
@@ -1,0 +1,201 @@
+//! TSO (TCP Segmentation Offload) crash recovery
+//!
+//! When SwiftTunnel disables TSO on the physical network adapter for split tunneling,
+//! it creates a marker file. If the app crashes before re-enabling TSO, the marker
+//! file persists. On next startup, we detect this and restore TSO settings.
+//!
+//! This prevents users from being stuck with degraded network performance after a crash.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Marker file name stored in %LOCALAPPDATA%/SwiftTunnel/
+const TSO_MARKER_FILE: &str = "tso_disabled.marker";
+
+/// Get the path to the TSO marker file
+fn get_marker_path() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|d| d.join("SwiftTunnel").join(TSO_MARKER_FILE))
+}
+
+/// Write TSO disabled marker with adapter name
+///
+/// Called when TSO is disabled on an adapter. Stores the adapter name
+/// so we can restore it on crash recovery.
+pub fn write_tso_marker(adapter_name: &str) {
+    if let Some(marker_path) = get_marker_path() {
+        // Ensure directory exists
+        if let Some(parent) = marker_path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+
+        if let Err(e) = fs::write(&marker_path, adapter_name) {
+            log::warn!("Failed to write TSO marker file: {}", e);
+        } else {
+            log::debug!("TSO marker written for adapter: {}", adapter_name);
+        }
+    }
+}
+
+/// Delete TSO marker file
+///
+/// Called when TSO is successfully re-enabled.
+pub fn delete_tso_marker() {
+    if let Some(marker_path) = get_marker_path() {
+        if marker_path.exists() {
+            if let Err(e) = fs::remove_file(&marker_path) {
+                log::warn!("Failed to delete TSO marker file: {}", e);
+            } else {
+                log::debug!("TSO marker file deleted");
+            }
+        }
+    }
+}
+
+/// Check if TSO marker exists and return adapter name if so
+pub fn read_tso_marker() -> Option<String> {
+    let marker_path = get_marker_path()?;
+    if marker_path.exists() {
+        // Trim whitespace for consistent handling across all callers
+        fs::read_to_string(&marker_path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    } else {
+        None
+    }
+}
+
+/// Restore TSO settings for an adapter
+///
+/// Re-enables TCP Segmentation Offload and checksum offload on the specified adapter.
+/// This is the same PowerShell command used in `enable_adapter_offload()`.
+fn restore_tso_for_adapter(adapter_name: &str) -> bool {
+    log::info!("Restoring TSO for adapter: {}", adapter_name);
+
+    let script = format!(
+        r#"
+        $adapter = '{}'
+        # Re-enable LSO v2
+        Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv4' -RegistryValue 1 2>$null
+        Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv6' -RegistryValue 1 2>$null
+        # Re-enable checksum offload
+        Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv4' -RegistryValue 3 2>$null
+        Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv4' -RegistryValue 3 2>$null
+        Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv6' -RegistryValue 3 2>$null
+        Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv6' -RegistryValue 3 2>$null
+        "#,
+        adapter_name.replace('\'', "''") // Escape single quotes
+    );
+
+    match Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+    {
+        Ok(output) => {
+            if output.status.success() {
+                log::info!("TSO restored successfully for adapter: {}", adapter_name);
+                true
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                log::warn!("TSO restore may have failed: {}", stderr);
+                // Still return true - the commands may partially succeed
+                true
+            }
+        }
+        Err(e) => {
+            log::error!("Failed to run PowerShell for TSO restore: {}", e);
+            false
+        }
+    }
+}
+
+/// Recover TSO settings on application startup
+///
+/// Call this early in main() to restore TSO if the app previously crashed
+/// while TSO was disabled.
+pub fn recover_tso_on_startup() {
+    if let Some(adapter_name) = read_tso_marker() {
+        log::warn!(
+            "TSO marker found - app may have crashed while TSO was disabled. Adapter: {}",
+            adapter_name
+        );
+
+        if restore_tso_for_adapter(&adapter_name) {
+            delete_tso_marker();
+            log::info!("TSO recovery complete");
+        } else {
+            log::error!("TSO recovery failed - user may need to re-enable manually or reboot");
+            // Still delete marker to avoid repeated attempts
+            delete_tso_marker();
+        }
+    }
+}
+
+/// Emergency TSO restore for panic handler
+///
+/// This is a simplified version that runs synchronously and doesn't log
+/// (since logging may not work during panic). Best-effort attempt to
+/// restore TSO before the process terminates.
+pub fn emergency_tso_restore() {
+    if let Some(marker_path) = get_marker_path() {
+        if let Ok(adapter_name) = fs::read_to_string(&marker_path) {
+            let adapter_name = adapter_name.trim();
+            if !adapter_name.is_empty() {
+                // Best-effort restore - no logging, just try
+                let script = format!(
+                    r#"
+                    $adapter = '{}'
+                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv4' -RegistryValue 1 2>$null
+                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv6' -RegistryValue 1 2>$null
+                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv4' -RegistryValue 3 2>$null
+                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv4' -RegistryValue 3 2>$null
+                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv6' -RegistryValue 3 2>$null
+                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv6' -RegistryValue 3 2>$null
+                    "#,
+                    adapter_name.replace('\'', "''")
+                );
+
+                let _ = Command::new("powershell")
+                    .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+                    .output();
+
+                // Delete marker
+                let _ = fs::remove_file(&marker_path);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_marker_path() {
+        let path = get_marker_path();
+        assert!(path.is_some());
+        let path = path.unwrap();
+        assert!(path.to_string_lossy().contains("SwiftTunnel"));
+        assert!(path.to_string_lossy().contains(TSO_MARKER_FILE));
+    }
+
+    #[test]
+    fn test_marker_write_read_delete() {
+        let test_adapter = "TestAdapter123";
+
+        // Write marker
+        write_tso_marker(test_adapter);
+
+        // Read it back
+        let read_back = read_tso_marker();
+        assert_eq!(read_back, Some(test_adapter.to_string()));
+
+        // Delete it
+        delete_tso_marker();
+
+        // Should be gone
+        let after_delete = read_tso_marker();
+        assert_eq!(after_delete, None);
+    }
+}


### PR DESCRIPTION
## Summary
- **TSO Crash Recovery**: If the app crashes while TSO (TCP Segmentation Offload) is disabled, users were stuck with degraded network performance until reboot. Now:
  - A marker file tracks when TSO is disabled
  - On startup, checks for marker and restores TSO if needed
  - Panic hook calls `emergency_tso_restore()` before exit

- **Thread Join Timeout**: `ParallelInterceptor::stop()` could hang indefinitely if a worker thread was stuck. Now:
  - Added `join_with_timeout()` helper with 3 second timeout
  - Logs warning and continues if timeout reached
  - Prevents app from freezing on disconnect

## Test plan
- [ ] Build and run on Windows testbench
- [ ] Verify TSO marker file is created when connecting VPN
- [ ] Verify TSO marker file is deleted when disconnecting VPN
- [ ] Force-kill app while connected, verify TSO is restored on next startup
- [ ] Verify thread join completes normally in typical disconnect flow