### PR TITLE
chore(release): 1.5.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "swifttunnel-desktop"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "base64 0.22.1",
  "env_logger",

--- a/swifttunnel-desktop/package-lock.json
+++ b/swifttunnel-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swifttunnel-desktop",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swifttunnel-desktop",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-notification": "^2.3.3",

--- a/swifttunnel-desktop/package.json
+++ b/swifttunnel-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swifttunnel-desktop",
   "private": true,
-  "version": "1.5.8",
+  "version": "1.5.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "1.5.8"
+version = "1.5.9"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel desktop app - Tauri v2 frontend"

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Bumps desktop app version to 1.5.9 across:
- Tauri config (tauri.conf.json)
- Rust backend crate (Cargo.toml)
- Frontend package.json + package-lock
- Cargo.lock

After merge, create and push tag `v1.5.9` on the merge commit to trigger the GitHub Release workflow.