### PR TITLE
chore(release): 1.5.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "swifttunnel-desktop"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "base64 0.22.1",
  "env_logger",

--- a/swifttunnel-desktop/package-lock.json
+++ b/swifttunnel-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swifttunnel-desktop",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swifttunnel-desktop",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-notification": "^2.3.3",

--- a/swifttunnel-desktop/package.json
+++ b/swifttunnel-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swifttunnel-desktop",
   "private": true,
-  "version": "1.5.10",
+  "version": "1.5.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "1.5.10"
+version = "1.5.11"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel desktop app - Tauri v2 frontend"

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Release 1.5.11

Version bump only (ships boost system overhaul from #50).

## Tests
- macOS: `npm test` (swifttunnel-desktop)
- macOS: `npm run build` (swifttunnel-desktop)
