### PR TITLE
Replace blocked FFlags with Ultraboost allowlisted preset

### DIFF
--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -44,10 +44,7 @@ function getPresetConfig(profile: OptimizationProfile, current: Config): Config 
           graphics_quality: "Level1",
           unlock_fps: true,
           target_fps: 360,
-          disable_shadows: true,
-          reduce_texture_quality: true,
-          disable_post_processing: true,
-          dynamic_render_optimization: "High",
+          ultraboost: true,
         },
         network_settings: {
           ...current.network_settings,
@@ -76,10 +73,7 @@ function getPresetConfig(profile: OptimizationProfile, current: Config): Config 
           graphics_quality: "Manual",
           unlock_fps: true,
           target_fps: 144,
-          disable_shadows: false,
-          reduce_texture_quality: false,
-          disable_post_processing: false,
-          dynamic_render_optimization: "Off",
+          ultraboost: false,
         },
         network_settings: {
           ...current.network_settings,
@@ -108,10 +102,7 @@ function getPresetConfig(profile: OptimizationProfile, current: Config): Config 
           graphics_quality: "Level8",
           unlock_fps: true,
           target_fps: 60,
-          disable_shadows: false,
-          reduce_texture_quality: false,
-          disable_post_processing: false,
-          dynamic_render_optimization: "Off",
+          ultraboost: false,
         },
         network_settings: {
           ...current.network_settings,
@@ -125,10 +116,6 @@ function getPresetConfig(profile: OptimizationProfile, current: Config): Config 
       return base;
   }
 }
-
-// ── Dynamic render options ──
-
-const RENDER_MODES = ["Off", "Low", "Medium", "High"] as const;
 
 // ── Helpers ──
 
@@ -385,45 +372,13 @@ export function BoostTab() {
           </div>
         )}
 
-        <div className="rounded-[var(--radius-card)] border border-border-subtle bg-bg-card px-4 py-3">
-          <div className="flex items-center justify-between">
-            <div>
-              <div className="text-sm font-medium text-text-primary">
-                Dynamic Render
-              </div>
-              <div className="text-xs text-text-muted">
-                Adaptive render resolution
-              </div>
-            </div>
-            <div className="flex gap-1">
-              {RENDER_MODES.map((mode) => (
-                <button
-                  key={mode}
-                  onClick={() =>
-                    updateRblxOpt({
-                      dynamic_render_optimization: mode,
-                    })
-                  }
-                  className="rounded px-2.5 py-1 text-xs transition-colors"
-                  style={{
-                    backgroundColor:
-                      draft.roblox_settings.dynamic_render_optimization ===
-                      mode
-                        ? "var(--color-accent-primary)"
-                        : "var(--color-bg-hover)",
-                    color:
-                      draft.roblox_settings.dynamic_render_optimization ===
-                      mode
-                        ? "white"
-                        : "var(--color-text-secondary)",
-                  }}
-                >
-                  {mode}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
+        <BoostCard
+          title="Ultraboost"
+          desc="All allowlisted performance FFlags for max FPS"
+          impact="+20-40% FPS"
+          enabled={draft.roblox_settings.ultraboost}
+          onChange={(v) => updateRblxOpt({ ultraboost: v })}
+        />
       </Section>
 
       {/* ── Sticky Apply Bar ── */}

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -121,8 +121,6 @@ export type GraphicsQuality =
   | "Level8"
   | "Level9"
   | "Level10";
-export type DynamicRenderMode = "Off" | "Low" | "Medium" | "High";
-
 export interface SystemOptimizationConfig {
   set_high_priority: boolean;
   set_cpu_affinity: boolean;
@@ -140,10 +138,7 @@ export interface RobloxSettingsConfig {
   graphics_quality: GraphicsQuality;
   unlock_fps: boolean;
   target_fps: number;
-  disable_shadows: boolean;
-  reduce_texture_quality: boolean;
-  disable_post_processing: boolean;
-  dynamic_render_optimization: DynamicRenderMode;
+  ultraboost: boolean;
 }
 
 export interface NetworkConfig {

--- a/swifttunnel-desktop/src/mocks/tauri-core.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-core.ts
@@ -20,10 +20,7 @@ const MOCK_SETTINGS = {
       graphics_quality: "Manual",
       unlock_fps: true,
       target_fps: 144,
-      disable_shadows: false,
-      reduce_texture_quality: false,
-      disable_post_processing: false,
-      dynamic_render_optimization: "Off",
+      ultraboost: false,
     },
     network_settings: {
       enable_network_boost: true,

--- a/swifttunnel-desktop/src/stores/settingsStore.ts
+++ b/swifttunnel-desktop/src/stores/settingsStore.ts
@@ -22,10 +22,7 @@ const DEFAULT_SETTINGS: AppSettings = {
       graphics_quality: "Manual",
       unlock_fps: true,
       target_fps: 144,
-      disable_shadows: false,
-      reduce_texture_quality: false,
-      disable_post_processing: false,
-      dynamic_render_optimization: "Off",
+      ultraboost: false,
     },
     network_settings: {
       enable_network_boost: true,


### PR DESCRIPTION
## Summary
- Roblox introduced an FFlag allowlist (Sept 2025) that silently blocks 4 of 5 FFlags SwiftTunnel previously wrote (`FIntRenderShadowIntensity`, `FFlagDisablePostFx`, `FIntDebugTextureManagerSkipMips`, `DFIntDebugDynamicRenderKiloPixels`)
- Replaces the per-flag toggles (`disable_shadows`, `reduce_texture_quality`, `disable_post_processing`, `dynamic_render_optimization`) with a single **Ultraboost** toggle that applies all 11 allowlisted performance FFlags
- Old blocked FFlags are automatically cleaned up from existing installations

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --all-targets --all-features` — 242 passed, 0 failed
- [x] `tsc && vite build` — clean, no type errors
- [ ] Manual: toggle Ultraboost on, verify `ClientAppSettings.json` contains all 11 FFlags
- [ ] Manual: toggle Ultraboost off, verify all FFlags removed (including legacy blocked ones)
- [ ] Manual: upgrade from previous version, verify old blocked FFlags get cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)