### PR TITLE
Tighten stability test thresholds + 5min test with ping timeline

### DIFF
--- a/swifttunnel-desktop/src-tauri/src/commands/network.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/network.rs
@@ -5,14 +5,22 @@ use tauri::State;
 use crate::state::AppState;
 
 #[derive(Serialize)]
+pub struct PingSampleResponse {
+    pub elapsed_secs: f32,
+    pub latency_ms: Option<u32>,
+}
+
+#[derive(Serialize)]
 pub struct StabilityResultResponse {
     pub avg_ping: f32,
     pub min_ping: u32,
     pub max_ping: u32,
     pub jitter: f32,
     pub packet_loss: f32,
+    pub ping_spread: f32,
     pub quality: String,
     pub sample_count: usize,
+    pub ping_samples: Vec<PingSampleResponse>,
 }
 
 #[derive(Serialize)]
@@ -55,8 +63,17 @@ pub async fn network_start_stability_test(
         max_ping: result.max_ping,
         jitter: result.jitter,
         packet_loss: result.packet_loss,
+        ping_spread: result.ping_spread,
         quality: result.quality.label().to_string(),
         sample_count: result.sample_count,
+        ping_samples: result
+            .ping_samples
+            .into_iter()
+            .map(|s| PingSampleResponse {
+                elapsed_secs: s.elapsed_secs,
+                latency_ms: s.latency_ms,
+            })
+            .collect(),
     })
 }
 

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -166,14 +166,21 @@ export interface Config {
 
 // ── Network Tests ──
 
+export interface PingSample {
+  elapsed_secs: number;
+  latency_ms: number | null;
+}
+
 export interface StabilityResultResponse {
   avg_ping: number;
   min_ping: number;
   max_ping: number;
   jitter: number;
   packet_loss: number;
+  ping_spread: number;
   quality: string;
   sample_count: number;
+  ping_samples: PingSample[];
 }
 
 export interface SpeedResultResponse {


### PR DESCRIPTION
## Summary
- Tighten `ConnectionQuality` thresholds — Excellent now requires <20ms avg, <0.5% loss, <2ms jitter, <10ms ping spread (was <30ms/<1%/<5ms with no spread check)
- Add `ping_spread` (max - min) as a new quality metric in `from_metrics()`
- Add `PingSample` struct recording each ping with elapsed timestamp for timeline visualization
- Add 5-minute duration option to stability test (previously max was 30s)
- Add inline SVG ping timeline chart showing latency over time with red markers for packet loss

## Test plan
- [x] All 241 workspace tests pass on Windows testbench
- [x] Frontend `tsc && vite build` passes
- [x] New `test_calculate_statistics_records_ping_samples` test validates sample recording
- [x] Updated threshold boundary tests for all 5 quality tiers including spread
- [x] `serde(default)` on new fields for backwards-compatible deserialization of cached results

🤖 Generated with [Claude Code](https://claude.com/claude-code)