### PR TITLE
Release v1.5.17: PPPoE/VLAN traffic tunneling fix

### DIFF
--- a/swifttunnel-desktop/package.json
+++ b/swifttunnel-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swifttunnel-desktop",
   "private": true,
-  "version": "1.5.16",
+  "version": "1.5.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "1.5.16"
+version = "1.5.17"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel desktop app - Tauri v2 frontend"

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary\n- fix split-tunnel packet parsing for PPPoE session frames (0x8864, IPv4 PPP protocol 0x0021)\n- fix split-tunnel packet parsing for VLAN-tagged frames (single/double tags)\n- use parsed IPv4 offset in routing/relay paths instead of hard-coded offset\n- add regression tests for VLAN + PPPoE frames\n- bump desktop versions to 1.5.17\n\n## User impact\n- resolves cases where users appear connected with game process detected but tunneled traffic remains at 0 B on PPPoE/VLAN networks\n\n## Validation\n- Windows testbench:  (10 passed)\n- Windows testbench:  (236 passed, 0 failed, 1 ignored)\n