### PR TITLE
fix: harden PPPoE/WAN split tunneling (v1.5.18)

### DIFF
--- a/swifttunnel-desktop/package.json
+++ b/swifttunnel-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swifttunnel-desktop",
   "private": true,
-  "version": "1.5.17",
+  "version": "1.5.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "1.5.17"
+version = "1.5.18"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel desktop app - Tauri v2 frontend"

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary\n- harden adapter selection for PPP/WAN by allowing unnamed default-route adapters\n- accept PPP default routes where next hop is 0.0.0.0\n- extend packet parsing to support VLAN, PPPoE, raw IPv4, and PPP-framed IPv4\n- add deterministic unit tests for route selection and parser/routing coverage\n- bump desktop app version to 1.5.18\n\n## Validation\n- cargo test -p swifttunnel-core parallel_interceptor::tests -- --nocapture (Windows testbench)\n- cargo test -p swifttunnel-core --all-targets --all-features (Windows testbench)\n