### PR TITLE
chore(release): 1.15.20

### DIFF
--- a/swifttunnel-desktop/package.json
+++ b/swifttunnel-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swifttunnel-desktop",
   "private": true,
-  "version": "1.15.18",
+  "version": "1.15.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "1.15.19"
+version = "1.15.20"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel desktop app - Tauri v2 frontend"

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "1.15.19",
+  "version": "1.15.20",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary
- bump desktop version to `1.15.20` in all required files
- fix version consistency between frontend package metadata and Tauri backend metadata

## Files
- `swifttunnel-desktop/package.json`
- `swifttunnel-desktop/src-tauri/Cargo.toml`
- `swifttunnel-desktop/src-tauri/tauri.conf.json`

## Validation
- checked all version fields resolve to `1.15.20`
