### PR TITLE
release: v1.15.26 diagnostics bundle + server HUD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,6 +4248,7 @@ name = "swifttunnel-desktop"
 version = "1.15.25"
 dependencies = [
  "base64 0.22.1",
+ "chrono",
  "env_logger",
  "log",
  "parking_lot",

--- a/swifttunnel-desktop/package.json
+++ b/swifttunnel-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swifttunnel-desktop",
   "private": true,
-  "version": "1.15.25",
+  "version": "1.15.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "1.15.25"
+version = "1.15.26"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel desktop app - Tauri v2 frontend"
@@ -24,6 +24,7 @@ sha2 = "0.10"
 base64 = "0.22"
 ring = "0.17"
 url = "2"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/swifttunnel-desktop/src-tauri/src/commands/settings.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/settings.rs
@@ -1,11 +1,45 @@
 use serde::Serialize;
-use tauri::{AppHandle, State};
+use std::path::PathBuf;
+use std::process::Output;
+use tauri::{AppHandle, Manager, State};
 
 use crate::state::AppState;
 
 #[derive(Serialize)]
 pub struct SettingsResponse {
     pub json: String,
+}
+
+#[derive(Serialize)]
+pub struct NetworkDiagnosticsBundleResponse {
+    pub file_path: String,
+    pub folder_path: String,
+}
+
+#[derive(Debug, Clone)]
+struct DiagnosticsCommand {
+    title: &'static str,
+    program: &'static str,
+    args: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CommandCapture {
+    stdout: String,
+    stderr: String,
+    status_code: Option<i32>,
+    success: bool,
+    execution_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct BundleContext {
+    generated_at: String,
+    app_version: String,
+    platform: String,
+    settings: swifttunnel_core::settings::AppSettings,
+    vpn_state: swifttunnel_core::vpn::ConnectionState,
+    split_tunnel_diag: Option<(Option<String>, bool, u64, u64)>,
 }
 
 #[tauri::command]
@@ -46,4 +80,466 @@ pub fn settings_save(
     }
 
     Ok(())
+}
+
+fn current_timestamp_utc() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+fn current_filename_timestamp() -> String {
+    chrono::Local::now().format("%Y%m%d_%H%M%S").to_string()
+}
+
+fn build_diagnostics_filename_from_timestamp(timestamp: &str) -> String {
+    format!("SwiftTunnel_NetworkDiagnostics_{timestamp}.txt")
+}
+
+fn build_diagnostics_filename() -> String {
+    build_diagnostics_filename_from_timestamp(&current_filename_timestamp())
+}
+
+fn resolve_output_dir(app: &AppHandle) -> PathBuf {
+    app.path()
+        .desktop_dir()
+        .or_else(|_| app.path().download_dir())
+        .unwrap_or_else(|_| std::env::temp_dir())
+}
+
+fn format_section(title: &str, body: &str) -> String {
+    let mut section = String::new();
+    section.push_str("## ");
+    section.push_str(title);
+    section.push('\n');
+    section.push_str(body.trim_end());
+    section.push('\n');
+    section
+}
+
+fn capture_from_output(result: Result<Output, std::io::Error>) -> CommandCapture {
+    match result {
+        Ok(output) => CommandCapture {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            status_code: output.status.code(),
+            success: output.status.success(),
+            execution_error: None,
+        },
+        Err(e) => CommandCapture {
+            stdout: String::new(),
+            stderr: String::new(),
+            status_code: None,
+            success: false,
+            execution_error: Some(e.to_string()),
+        },
+    }
+}
+
+fn format_command_section(title: &str, capture: &CommandCapture) -> String {
+    let mut body = String::new();
+
+    if let Some(error) = &capture.execution_error {
+        body.push_str(&format!("Execution error: {error}\n"));
+        return format_section(title, &body);
+    }
+
+    if !capture.success {
+        match capture.status_code {
+            Some(code) => body.push_str(&format!("Command failed (exit code: {code})\n")),
+            None => body.push_str("Command failed (unknown exit code)\n"),
+        }
+    }
+
+    if !capture.stdout.trim().is_empty() {
+        body.push_str(&capture.stdout);
+        if !capture.stdout.ends_with('\n') {
+            body.push('\n');
+        }
+    }
+
+    if !capture.stderr.trim().is_empty() {
+        if !body.is_empty() {
+            body.push('\n');
+        }
+        body.push_str("[stderr]\n");
+        body.push_str(&capture.stderr);
+        if !capture.stderr.ends_with('\n') {
+            body.push('\n');
+        }
+    }
+
+    if body.trim().is_empty() {
+        body.push_str("(no output)\n");
+    }
+
+    format_section(title, &body)
+}
+
+fn run_diagnostics_command(command: &DiagnosticsCommand) -> CommandCapture {
+    let mut process = swifttunnel_core::hidden_command(command.program);
+    for arg in &command.args {
+        process.arg(arg);
+    }
+    capture_from_output(process.output())
+}
+
+fn run_windows_diagnostics_sections() -> Vec<String> {
+    #[cfg(windows)]
+    {
+        windows_diagnostics_commands()
+            .into_iter()
+            .map(|command| {
+                let capture = run_diagnostics_command(&command);
+                format_command_section(command.title, &capture)
+            })
+            .collect()
+    }
+
+    #[cfg(not(windows))]
+    {
+        vec![format_section(
+            "Windows Diagnostics",
+            "Windows-specific diagnostics are unavailable on this platform.",
+        )]
+    }
+}
+
+fn isp_lookup_script() -> &'static str {
+    "$ErrorActionPreference='Stop'; \
+     $ProgressPreference='SilentlyContinue'; \
+     Invoke-RestMethod -Uri 'https://ipinfo.io/json' -TimeoutSec 6 | ConvertTo-Json -Depth 8"
+}
+
+#[cfg(windows)]
+fn windows_diagnostics_commands() -> Vec<DiagnosticsCommand> {
+    vec![
+        DiagnosticsCommand {
+            title: "Get-NetAdapter",
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-NetAdapter | Format-Table Name,InterfaceDescription,ifIndex,Status,MacAddress,LinkSpeed -AutoSize | Out-String -Width 220".to_string(),
+            ],
+        },
+        DiagnosticsCommand {
+            title: "Get-NetIPInterface",
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-NetIPInterface | Sort-Object InterfaceMetric | Format-Table InterfaceAlias,InterfaceIndex,AddressFamily,NlMtu,InterfaceMetric,ConnectionState -AutoSize | Out-String -Width 220".to_string(),
+            ],
+        },
+        DiagnosticsCommand {
+            title: "Get-NetRoute Default Routes",
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-NetRoute -DestinationPrefix '0.0.0.0/0','::/0' | Sort-Object RouteMetric,InterfaceMetric | Format-Table DestinationPrefix,NextHop,InterfaceIndex,RouteMetric,InterfaceMetric -AutoSize | Out-String -Width 220".to_string(),
+            ],
+        },
+        DiagnosticsCommand {
+            title: "Get-DnsClientServerAddress",
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-DnsClientServerAddress | Format-Table InterfaceAlias,AddressFamily,ServerAddresses -AutoSize | Out-String -Width 220".to_string(),
+            ],
+        },
+        DiagnosticsCommand {
+            title: "Get-NetOffloadGlobalSetting",
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-NetOffloadGlobalSetting | Out-String -Width 220".to_string(),
+            ],
+        },
+        DiagnosticsCommand {
+            title: "Get-NetAdapterAdvancedProperty (offload/checksum)",
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-NetAdapterAdvancedProperty | Where-Object { $_.DisplayName -match 'offload|checksum|large send|udp|tcp' } | Format-Table Name,DisplayName,DisplayValue -AutoSize | Out-String -Width 260".to_string(),
+            ],
+        },
+        DiagnosticsCommand {
+            title: "ipconfig /all",
+            program: "ipconfig",
+            args: vec!["/all".to_string()],
+        },
+        DiagnosticsCommand {
+            title: "route print -4",
+            program: "route",
+            args: vec!["print".to_string(), "-4".to_string()],
+        },
+        DiagnosticsCommand {
+            title: "route print -6",
+            program: "route",
+            args: vec!["print".to_string(), "-6".to_string()],
+        },
+        DiagnosticsCommand {
+            title: "External ISP Lookup (ipinfo.io)",
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                isp_lookup_script().to_string(),
+            ],
+        },
+    ]
+}
+
+#[cfg(not(windows))]
+fn windows_diagnostics_commands() -> Vec<DiagnosticsCommand> {
+    Vec::new()
+}
+
+fn format_settings_snapshot(settings: &swifttunnel_core::settings::AppSettings) -> String {
+    let selected_games = if settings.selected_game_presets.is_empty() {
+        "none".to_string()
+    } else {
+        settings.selected_game_presets.join(", ")
+    };
+    let whitelisted_regions = if settings.whitelisted_regions.is_empty() {
+        "none".to_string()
+    } else {
+        settings.whitelisted_regions.join(", ")
+    };
+    let custom_relay = if settings.custom_relay_server.trim().is_empty() {
+        "auto".to_string()
+    } else {
+        settings.custom_relay_server.trim().to_string()
+    };
+
+    format!(
+        "selected_region: {}\nselected_game_presets: {}\nauto_routing_enabled: {}\nwhitelisted_regions: {}\nupdate_channel: {:?}\ncustom_relay_server: {}",
+        settings.selected_region,
+        selected_games,
+        settings.auto_routing_enabled,
+        whitelisted_regions,
+        settings.update_channel,
+        custom_relay
+    )
+}
+
+fn format_vpn_snapshot(vpn_state: &swifttunnel_core::vpn::ConnectionState) -> String {
+    match vpn_state {
+        swifttunnel_core::vpn::ConnectionState::Disconnected => "state: disconnected".to_string(),
+        swifttunnel_core::vpn::ConnectionState::FetchingConfig => {
+            "state: fetching_config".to_string()
+        }
+        swifttunnel_core::vpn::ConnectionState::ConfiguringSplitTunnel => {
+            "state: configuring_split_tunnel".to_string()
+        }
+        swifttunnel_core::vpn::ConnectionState::Connected {
+            server_region,
+            server_endpoint,
+            assigned_ip,
+            relay_auth_mode,
+            split_tunnel_active,
+            tunneled_processes,
+            ..
+        } => {
+            let tunneled = if tunneled_processes.is_empty() {
+                "none".to_string()
+            } else {
+                tunneled_processes.join(", ")
+            };
+            format!(
+                "state: connected\nserver_region: {server_region}\nserver_endpoint: {server_endpoint}\nassigned_ip: {assigned_ip}\nrelay_auth_mode: {relay_auth_mode}\nsplit_tunnel_active: {split_tunnel_active}\ntunneled_processes: {tunneled}"
+            )
+        }
+        swifttunnel_core::vpn::ConnectionState::Disconnecting => "state: disconnecting".to_string(),
+        swifttunnel_core::vpn::ConnectionState::Error(message) => {
+            format!("state: error\nerror: {message}")
+        }
+    }
+}
+
+fn format_split_tunnel_snapshot(diag: Option<(Option<String>, bool, u64, u64)>) -> String {
+    match diag {
+        Some((adapter_name, has_default_route, packets_tunneled, packets_bypassed)) => format!(
+            "adapter_name: {}\nhas_default_route: {}\npackets_tunneled: {}\npackets_bypassed: {}",
+            adapter_name.unwrap_or_else(|| "unknown".to_string()),
+            has_default_route,
+            packets_tunneled,
+            packets_bypassed
+        ),
+        None => "split tunnel diagnostics unavailable".to_string(),
+    }
+}
+
+fn compose_bundle_text(context: &BundleContext, command_sections: &[String]) -> String {
+    let mut content = String::new();
+    content.push_str("SwiftTunnel Network Diagnostics Bundle\n");
+    content.push_str("====================================\n\n");
+
+    content.push_str(&format_section(
+        "App Metadata",
+        &format!(
+            "generated_at: {}\napp_version: {}\nplatform: {}",
+            context.generated_at, context.app_version, context.platform
+        ),
+    ));
+    content.push('\n');
+    content.push_str(&format_section(
+        "Settings Snapshot",
+        &format_settings_snapshot(&context.settings),
+    ));
+    content.push('\n');
+    content.push_str(&format_section(
+        "VPN Snapshot",
+        &format_vpn_snapshot(&context.vpn_state),
+    ));
+    content.push('\n');
+    content.push_str(&format_section(
+        "Split Tunnel Diagnostics",
+        &format_split_tunnel_snapshot(context.split_tunnel_diag.clone()),
+    ));
+    content.push('\n');
+
+    for (idx, section) in command_sections.iter().enumerate() {
+        content.push_str(section);
+        if idx + 1 != command_sections.len() {
+            content.push('\n');
+        }
+    }
+
+    content
+}
+
+#[tauri::command]
+pub async fn settings_generate_network_diagnostics_bundle(
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<NetworkDiagnosticsBundleResponse, String> {
+    let settings = state.settings.lock().clone();
+
+    let (vpn_state, split_tunnel_diag) = {
+        let vpn = state.vpn_connection.lock().await;
+        let snapshot = vpn.state().await;
+        let diagnostics = vpn.get_split_tunnel_diagnostics();
+        (snapshot, diagnostics)
+    };
+
+    let bundle_context = BundleContext {
+        generated_at: current_timestamp_utc(),
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+        settings,
+        vpn_state,
+        split_tunnel_diag,
+    };
+
+    let command_sections = run_windows_diagnostics_sections();
+    let bundle_text = compose_bundle_text(&bundle_context, &command_sections);
+
+    let output_dir = resolve_output_dir(&app);
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| format!("Failed to create diagnostics output directory: {e}"))?;
+
+    let file_path = output_dir.join(build_diagnostics_filename());
+    std::fs::write(&file_path, bundle_text)
+        .map_err(|e| format!("Failed to write diagnostics bundle: {e}"))?;
+
+    Ok(NetworkDiagnosticsBundleResponse {
+        file_path: file_path.to_string_lossy().to_string(),
+        folder_path: output_dir.to_string_lossy().to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn build_diagnostics_filename_has_expected_format() {
+        let fixed = build_diagnostics_filename_from_timestamp("20260219_154500");
+        assert_eq!(fixed, "SwiftTunnel_NetworkDiagnostics_20260219_154500.txt");
+
+        let generated = build_diagnostics_filename();
+        assert!(generated.starts_with("SwiftTunnel_NetworkDiagnostics_"));
+        assert!(generated.ends_with(".txt"));
+
+        let stamp = generated
+            .trim_start_matches("SwiftTunnel_NetworkDiagnostics_")
+            .trim_end_matches(".txt");
+        assert_eq!(stamp.len(), 15);
+        assert_eq!(&stamp[8..9], "_");
+        assert!(stamp.chars().enumerate().all(|(idx, ch)| {
+            if idx == 8 {
+                ch == '_'
+            } else {
+                ch.is_ascii_digit()
+            }
+        }));
+    }
+
+    #[test]
+    fn compose_bundle_text_contains_required_sections() {
+        let mut settings = swifttunnel_core::settings::AppSettings::default();
+        settings.selected_region = "mumbai".to_string();
+        settings.selected_game_presets = vec!["roblox".to_string(), "valorant".to_string()];
+        settings.auto_routing_enabled = true;
+        settings.custom_relay_server = "relay.example.com:51821".to_string();
+
+        let context = BundleContext {
+            generated_at: "2026-02-19T15:45:00Z".to_string(),
+            app_version: "1.15.25".to_string(),
+            platform: "windows-x86_64".to_string(),
+            settings,
+            vpn_state: swifttunnel_core::vpn::ConnectionState::Connected {
+                since: Instant::now(),
+                server_region: "mumbai".to_string(),
+                server_endpoint: "1.2.3.4:51821".to_string(),
+                assigned_ip: "100.64.0.12".to_string(),
+                relay_auth_mode: "preflight-ok".to_string(),
+                split_tunnel_active: true,
+                tunneled_processes: vec!["robloxplayerbeta.exe".to_string()],
+            },
+            split_tunnel_diag: Some((Some("Ethernet".to_string()), true, 77, 12)),
+        };
+
+        let bundle = compose_bundle_text(
+            &context,
+            &[format_section("Get-NetAdapter", "sample adapter output")],
+        );
+
+        assert!(bundle.contains("## App Metadata"));
+        assert!(bundle.contains("## Settings Snapshot"));
+        assert!(bundle.contains("## VPN Snapshot"));
+        assert!(bundle.contains("## Split Tunnel Diagnostics"));
+        assert!(bundle.contains("selected_region: mumbai"));
+        assert!(bundle.contains("state: connected"));
+        assert!(bundle.contains("packets_tunneled: 77"));
+        assert!(bundle.contains("## Get-NetAdapter"));
+    }
+
+    #[test]
+    fn command_section_includes_errors_without_panicking() {
+        let capture = CommandCapture {
+            stdout: String::new(),
+            stderr: "Access is denied".to_string(),
+            status_code: Some(1),
+            success: false,
+            execution_error: None,
+        };
+
+        let section = format_command_section("Get-NetAdapter", &capture);
+        assert!(section.contains("Command failed (exit code: 1)"));
+        assert!(section.contains("[stderr]"));
+        assert!(section.contains("Access is denied"));
+    }
+
+    #[test]
+    fn isp_lookup_script_targets_ipinfo() {
+        let script = isp_lookup_script();
+        assert!(script.contains("ipinfo.io/json"));
+        assert!(script.contains("Invoke-RestMethod"));
+    }
 }

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -174,6 +174,7 @@ pub fn run() {
             // Settings
             commands::settings::settings_load,
             commands::settings::settings_save,
+            commands::settings::settings_generate_network_diagnostics_bundle,
             // Updater
             commands::updater::updater_check_channel,
             commands::updater::updater_install_channel,

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "1.15.25",
+  "version": "1.15.26",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/swifttunnel-desktop/src/components/connect/ConnectTab.icon.test.ts
+++ b/swifttunnel-desktop/src/components/connect/ConnectTab.icon.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import connectTabSource from "./ConnectTab.tsx?raw";
+
+describe("ConnectTab power button icon", () => {
+  it("uses a power glyph instead of the old wifi glyph", () => {
+    expect(connectTabSource).toContain('<path d="M12 2v10" />');
+    expect(connectTabSource).toContain(
+      '<path d="M18.36 6.64a9 9 0 1 1-12.73 0" />',
+    );
+
+    expect(connectTabSource).not.toContain(
+      '<path d="M5 12.55a11 11 0 0 1 14.08 0" />',
+    );
+    expect(connectTabSource).not.toContain(
+      '<path d="M1.42 9a16 16 0 0 1 21.16 0" />',
+    );
+    expect(connectTabSource).not.toContain(
+      '<path d="M8.53 16.11a6 6 0 0 1 6.95 0" />',
+    );
+  });
+});

--- a/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
+++ b/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
@@ -4,6 +4,7 @@ import { useVpnStore } from "../../stores/vpnStore";
 import { useSettingsStore } from "../../stores/settingsStore";
 import { useServerStore } from "../../stores/serverStore";
 import { countryFlag, getLatencyColor, formatBytes } from "../../lib/utils";
+import { formatConnectedServerLabel } from "../../lib/connectedServer";
 import {
   isAdminPrivilegeError,
   shouldResetElevationState,
@@ -53,6 +54,7 @@ function stateLabel(state: string): string {
 export function ConnectTab() {
   const vpnState = useVpnStore((s) => s.state);
   const vpnRegion = useVpnStore((s) => s.region);
+  const vpnServerEndpoint = useVpnStore((s) => s.serverEndpoint);
   const splitActive = useVpnStore((s) => s.splitTunnelActive);
   const tunneled = useVpnStore((s) => s.tunneledProcesses);
   const vpnError = useVpnStore((s) => s.error);
@@ -70,6 +72,7 @@ export function ConnectTab() {
   const save = useSettingsStore((s) => s.save);
 
   const regions = useServerStore((s) => s.regions);
+  const servers = useServerStore((s) => s.servers);
   const serversLoading = useServerStore((s) => s.isLoading);
   const serversError = useServerStore((s) => s.error);
   const getLatency = useServerStore((s) => s.getLatency);
@@ -83,6 +86,11 @@ export function ConnectTab() {
   const selectedRegion = regions.find((r) => r.id === settings.selected_region);
   const selectedLatency = getLatency(settings.selected_region);
   const connectedRegion = findRegionForVpnRegion(regions, vpnRegion);
+  const connectedServerLabel = formatConnectedServerLabel(
+    vpnServerEndpoint,
+    servers,
+    vpnRegion,
+  );
 
   useEffect(() => {
     if (!isConnected) return;
@@ -433,15 +441,13 @@ export function ConnectTab() {
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="white"
-                strokeWidth="1.8"
+                strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 style={{ filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.15))" }}
               >
-                <path d="M5 12.55a11 11 0 0 1 14.08 0" />
-                <path d="M1.42 9a16 16 0 0 1 21.16 0" />
-                <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
-                <circle cx="12" cy="20" r="1" fill="white" />
+                <path d="M12 2v10" />
+                <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
               </svg>
             )}
           </motion.button>
@@ -526,7 +532,7 @@ export function ConnectTab() {
               style={{ backgroundColor: "var(--color-border-subtle)" }}
             >
               <div className="grid grid-cols-3 gap-px">
-                <HudCell label="Mode" value="V3 Relay" accent />
+                <HudCell label="Server" value={connectedServerLabel} />
                 <HudCell
                   label="Ping"
                   value={

--- a/swifttunnel-desktop/src/lib/commands.test.ts
+++ b/swifttunnel-desktop/src/lib/commands.test.ts
@@ -9,6 +9,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 import {
+  settingsGenerateNetworkDiagnosticsBundle,
   systemRestartAsAdmin,
   systemInstallDriver,
   updaterCheckChannel,
@@ -63,5 +64,18 @@ describe("lib/commands", () => {
     invoke.mockResolvedValue(42);
     await expect(vpnGetPing()).resolves.toEqual(42);
     expect(invoke).toHaveBeenCalledWith("vpn_get_ping");
+  });
+
+  it("settingsGenerateNetworkDiagnosticsBundle invokes backend with expected args", async () => {
+    const resp = {
+      file_path: "C:\\Users\\test\\Desktop\\SwiftTunnel_NetworkDiagnostics_20260219_160000.txt",
+      folder_path: "C:\\Users\\test\\Desktop",
+    };
+    invoke.mockResolvedValue(resp);
+
+    await expect(settingsGenerateNetworkDiagnosticsBundle()).resolves.toEqual(resp);
+    expect(invoke).toHaveBeenCalledWith(
+      "settings_generate_network_diagnostics_bundle",
+    );
   });
 });

--- a/swifttunnel-desktop/src/lib/commands.ts
+++ b/swifttunnel-desktop/src/lib/commands.ts
@@ -14,6 +14,7 @@ import type {
   BufferbloatResultResponse,
   AdminCheckResponse,
   DriverCheckResponse,
+  NetworkDiagnosticsBundleResponse,
   UpdaterCheckResponse,
   UpdaterInstallResponse,
   UpdateChannel,
@@ -113,6 +114,11 @@ export const settingsLoad = () =>
 
 export const settingsSave = (settingsJson: string) =>
   invoke<void>("settings_save", { settingsJson });
+
+export const settingsGenerateNetworkDiagnosticsBundle = () =>
+  invoke<NetworkDiagnosticsBundleResponse>(
+    "settings_generate_network_diagnostics_bundle",
+  );
 
 // ── Updater ──
 

--- a/swifttunnel-desktop/src/lib/connectedServer.test.ts
+++ b/swifttunnel-desktop/src/lib/connectedServer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatConnectedServerLabel } from "./connectedServer";
+import type { ServerInfo } from "./types";
+
+const SERVERS: ServerInfo[] = [
+  {
+    region: "mumbai",
+    name: "mumbai-02",
+    country_code: "IN",
+    ip: "1.2.3.4",
+    port: 51821,
+  },
+  {
+    region: "singapore",
+    name: "singapore-01",
+    country_code: "SG",
+    ip: "8.8.8.8",
+    port: 51821,
+  },
+];
+
+describe("formatConnectedServerLabel", () => {
+  it("shows matched server name with exact endpoint", () => {
+    const label = formatConnectedServerLabel("1.2.3.4:51821", SERVERS, "mumbai");
+    expect(label).toBe("mumbai-02 (1.2.3.4:51821)");
+  });
+
+  it("falls back to raw endpoint when server is unknown", () => {
+    const label = formatConnectedServerLabel("9.9.9.9:51821", SERVERS, "mumbai");
+    expect(label).toBe("9.9.9.9:51821");
+  });
+
+  it("falls back to region when endpoint is missing", () => {
+    const label = formatConnectedServerLabel(null, SERVERS, "mumbai");
+    expect(label).toBe("mumbai");
+  });
+});

--- a/swifttunnel-desktop/src/lib/connectedServer.ts
+++ b/swifttunnel-desktop/src/lib/connectedServer.ts
@@ -1,0 +1,43 @@
+import type { ServerInfo } from "./types";
+
+function parseEndpoint(endpoint: string): { host: string; port: number | null } {
+  const normalized = endpoint.includes("://") ? endpoint : `udp://${endpoint}`;
+  try {
+    const parsed = new URL(normalized);
+    const port = parsed.port ? Number(parsed.port) : null;
+    return {
+      host: parsed.hostname,
+      port: Number.isFinite(port) ? port : null,
+    };
+  } catch {
+    return { host: endpoint.trim(), port: null };
+  }
+}
+
+export function formatConnectedServerLabel(
+  endpoint: string | null,
+  servers: ServerInfo[],
+  fallbackRegion: string | null,
+): string {
+  if (!endpoint) {
+    return fallbackRegion ?? "Unknown";
+  }
+
+  const { host, port } = parseEndpoint(endpoint);
+  const target = host || endpoint;
+  const endpointLabel = `${target}${port !== null ? `:${port}` : ""}`;
+
+  const exactMatch = servers.find(
+    (server) => server.ip === host && (port === null || server.port === port),
+  );
+  if (exactMatch) {
+    return `${exactMatch.name} (${endpointLabel})`;
+  }
+
+  const ipMatch = servers.find((server) => server.ip === host);
+  if (ipMatch) {
+    return `${ipMatch.name} (${endpointLabel})`;
+  }
+
+  return endpointLabel;
+}

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -210,6 +210,11 @@ export interface WindowState {
   maximized: boolean;
 }
 
+export interface NetworkDiagnosticsBundleResponse {
+  file_path: string;
+  folder_path: string;
+}
+
 export interface UpdaterCheckResponse {
   current_version: string;
   available_version: string | null;


### PR DESCRIPTION
## Summary\n- add one-click network diagnostics bundle export in Settings (txt + output path)\n- include Windows network/route/offload diagnostics and ipinfo ISP lookup\n- open diagnostics folder from Settings and display saved path\n- change connect icon to power button\n- show exact connected server in HUD (matched name + endpoint)\n- bump desktop versions to 1.15.26\n\n## Validation\n- Windows testbench: cargo fmt --all -- --check\n- Windows testbench: cargo test -p swifttunnel-core --all-targets --all-features\n- Windows testbench: cargo test --workspace --all-targets --all-features\n- Windows testbench: npm ci && npm run test && npm run build\n