### PR TITLE
Fix split-tunnel adapter selection on multi-NIC/PPPoE paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "swifttunnel-desktop"
-version = "1.15.25"
+version = "1.15.26"
 dependencies = [
  "base64 0.22.1",
  "chrono",


### PR DESCRIPTION
## Summary
- fix split-tunnel physical adapter ifindex resolution by using Windows IP Helper conversions (GUID/alias -> LUID -> IfIndex)
- harden default-route detection by preferring `GetBestInterfaceEx` (with route-table fallback)
- mark `has_default_route` true only when selected adapter ifindex matches the active default-route ifindex
- add tests for internal GUID parsing and diagnostics default-route match behavior

## Why
Some users reported `connected` with `0 B` tunneled and no intercepted traffic. Diagnostics showed the interceptor selecting a disconnected NIC while real internet traffic flowed on Wi-Fi/PPPoE. This patch makes adapter selection deterministic against the active route interface.

## Validation
- Windows testbench: `cargo fmt --all -- --check`
- Windows testbench: `cargo test -p swifttunnel-core --all-targets --all-features`
- Windows testbench: `cargo test --workspace --all-targets --all-features`
- Windows testbench: `cmd /c npm ci`
- Windows testbench: `cmd /c npm run test`
- Windows testbench: `cmd /c npm run build`
