### PR TITLE
chore(release): bump version to 1.20.2

### DIFF
--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "1.20.1"
+version = "1.20.2"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]
 description = "SwiftTunnel desktop app - Tauri v2 frontend"

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Bumps release version metadata for the next tag-triggered release.\n\n- Cargo.toml: 1.20.1 -> 1.20.2\n- tauri.conf.json: 1.20.1 -> 1.20.2\n\nThis is required by .github/workflows/release.yml (tag/version consistency check).