### PR TITLE
fix(v3): prevent fragmented UDP checksum corruption on PPPoE

### DIFF
--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -4807,14 +4807,18 @@ fn calculate_tcp_checksum(packet: &[u8], ihl: usize) -> u16 {
         return 0;
     }
 
-    let tcp_len = u16::from_be_bytes([packet[ihl + 12], packet[ihl + 13]]) as usize;
-    if tcp_len < 20 || packet.len() < ihl + tcp_len {
+    let total_len = match ipv4_total_len(packet, ihl) {
+        Some(total_len) => total_len,
+        None => return 0,
+    };
+    let tcp_len = total_len - ihl;
+    if tcp_len < 20 {
         return 0;
     }
 
     let src_ip = &packet[12..16];
     let dst_ip = &packet[16..20];
-    let tcp_segment = &packet[ihl..ihl + tcp_len];
+    let tcp_segment = &packet[ihl..total_len];
 
     let mut sum: u32 = 0;
 
@@ -6486,7 +6490,11 @@ mod tests {
             53100,
             54100,
         );
+        packet.resize(40, 0);
+        packet[2..4].copy_from_slice(&40u16.to_be_bytes());
+
         let ihl = ((packet[0] & 0x0F) as usize) * 4;
+        packet[ihl + 12] = 0x50; // data offset: 5 (20-byte TCP header)
         packet[ihl + 16] = 0;
         packet[ihl + 17] = 0;
 


### PR DESCRIPTION
## Summary
This PR fixes a high-confidence PPPoE-sensitive dataplane bug in V3 split tunnel checksum handling.

## Root cause
In `fix_packet_checksums`, transport checksum rewrite was being attempted for fragmented IPv4 packets. For fragments, transport headers are incomplete (or absent), so rewriting TCP/UDP checksum bytes can corrupt fragmented datagrams.

Also, UDP checksum calculation used trailing buffer length instead of strict IPv4/UDP declared lengths, which can include non-packet bytes in checksum math.

## Changes (KISS/DRY)
- Keep existing checksum path, but make it fragment-safe:
  - add `ipv4_is_fragment(...)`
  - skip transport checksum rewrite on fragmented IPv4 packets
  - still repair IPv4 header checksum
- Clamp checksum working slice to IPv4 `total_length`:
  - add `ipv4_total_len(...)`
- In `calculate_udp_checksum(...)`, use UDP length field (and validate bounds).

## Files changed
- `swifttunnel-core/src/vpn/parallel_interceptor.rs`

## Tests added
- `test_fix_packet_checksums_preserves_udp_checksum_on_first_fragment`
- `test_fix_packet_checksums_preserves_non_initial_fragment_payload`
- `test_fix_packet_checksums_uses_ipv4_total_len_for_udp_checksum`

## Notes
I could not run cargo tests in this environment because `cargo` is unavailable. The tests are included and should run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv4 packet handling to validate total-length before processing, limit checksum calculation to actual IP payload bounds, and avoid corrupting TCP/UDP checksums. Added fragment-aware behavior: skip transport-layer rewrites for non-initial fragments, preserve payloads, and safely fix only the IP header checksum when appropriate.

* **Tests**
  * Added tests covering fragment detection, total-length constrained checksum processing, and preservation of transport checksums/payloads for fragmented packets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->