### PR TITLE
feat(boost): one-button RAM cleaner + live RAM meter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "swifttunnel-desktop"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/swifttunnel-core/src/lib.rs
+++ b/swifttunnel-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod network_analyzer;
 pub mod network_booster;
 pub mod notification;
 pub mod performance_monitor;
+pub mod ram_cleaner;
 pub mod roblox_optimizer;
 pub mod roblox_watcher;
 pub mod settings;

--- a/swifttunnel-core/src/ram_cleaner.rs
+++ b/swifttunnel-core/src/ram_cleaner.rs
@@ -1,0 +1,443 @@
+use crate::structs::Result;
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SystemMemorySnapshot {
+    pub total_mb: u64,
+    pub available_mb: u64,
+    pub used_mb: u64,
+    pub load_pct: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StandbyPurgeResult {
+    pub attempted: bool,
+    pub success: bool,
+    pub skipped_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RamCleanResult {
+    pub before: SystemMemorySnapshot,
+    pub after: SystemMemorySnapshot,
+    pub trimmed_count: u32,
+    pub standby_purge: StandbyPurgeResult,
+    pub duration_ms: u64,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ProcessSample {
+    pid: u32,
+    name: String,
+    memory_bytes: u64,
+    cpu_usage: f32,
+}
+
+const MIN_PROCESS_BYTES: u64 = 200 * 1024 * 1024;
+const MAX_TRIM_PROCESSES: usize = 20;
+const MAX_CPU_PERCENT: f32 = 2.0;
+
+const DENYLIST_NAMES_LOWER: &[&str] = &[
+    "system",
+    "registry",
+    "idle",
+    "smss.exe",
+    "csrss.exe",
+    "wininit.exe",
+    "winlogon.exe",
+    "services.exe",
+    "lsass.exe",
+    "svchost.exe",
+    "dwm.exe",
+    "audiodg.exe",
+    "fontdrvhost.exe",
+    "sihost.exe",
+    "taskhostw.exe",
+    "conhost.exe",
+    "msmpeng.exe",
+];
+
+fn select_trim_candidates(
+    processes: Vec<ProcessSample>,
+    exclude_pids: &HashSet<u32>,
+) -> Vec<ProcessSample> {
+    let mut candidates: Vec<ProcessSample> = processes
+        .into_iter()
+        .filter(|p| !exclude_pids.contains(&p.pid))
+        .filter(|p| {
+            let name = p.name.to_ascii_lowercase();
+            !DENYLIST_NAMES_LOWER.contains(&name.as_str())
+        })
+        .filter(|p| p.memory_bytes >= MIN_PROCESS_BYTES)
+        .filter(|p| {
+            let cpu = if p.cpu_usage.is_finite() {
+                p.cpu_usage
+            } else {
+                0.0
+            };
+            cpu <= MAX_CPU_PERCENT
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| b.memory_bytes.cmp(&a.memory_bytes));
+    candidates.truncate(MAX_TRIM_PROCESSES);
+    candidates
+}
+
+pub fn get_system_memory_snapshot() -> Result<SystemMemorySnapshot> {
+    #[cfg(windows)]
+    {
+        windows_impl::get_system_memory_snapshot()
+    }
+
+    #[cfg(not(windows))]
+    {
+        Err(anyhow::anyhow!("RAM cleaner is only supported on Windows"))
+    }
+}
+
+pub fn clean_ram<F>(exclude_pids: &[u32], mut on_progress: F) -> Result<RamCleanResult>
+where
+    F: FnMut(&str, SystemMemorySnapshot, u32, Option<String>, Option<String>),
+{
+    #[cfg(windows)]
+    {
+        windows_impl::clean_ram(exclude_pids, &mut on_progress)
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = exclude_pids;
+        let _ = on_progress;
+        Err(anyhow::anyhow!("RAM cleaner is only supported on Windows"))
+    }
+}
+
+#[cfg(windows)]
+mod windows_impl {
+    use super::*;
+    use std::ffi::c_void;
+
+    use sysinfo::{ProcessesToUpdate, System};
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::Security::{
+        AdjustTokenPrivileges, LUID_AND_ATTRIBUTES, LookupPrivilegeValueW, SE_PRIVILEGE_ENABLED,
+        TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES, TOKEN_QUERY,
+    };
+    use windows::Win32::System::ProcessStatus::EmptyWorkingSet;
+    use windows::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    use windows::Win32::System::Threading::{
+        GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
+        PROCESS_SET_QUOTA,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId};
+    use windows::core::PCWSTR;
+
+    unsafe extern "system" {
+        fn NtSetSystemInformation(
+            SystemInformationClass: u32,
+            SystemInformation: *const c_void,
+            SystemInformationLength: u32,
+        ) -> i32;
+    }
+
+    const SYSTEM_MEMORY_LIST_INFORMATION: u32 = 80;
+    const MEMORY_PURGE_STANDBY_LIST: u32 = 4;
+
+    pub(super) fn get_system_memory_snapshot() -> Result<SystemMemorySnapshot> {
+        unsafe {
+            let mut status = MEMORYSTATUSEX::default();
+            status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+
+            GlobalMemoryStatusEx(&mut status)?;
+
+            let total_mb = status.ullTotalPhys / 1024 / 1024;
+            let available_mb = status.ullAvailPhys / 1024 / 1024;
+            let used_mb = total_mb.saturating_sub(available_mb);
+
+            Ok(SystemMemorySnapshot {
+                total_mb,
+                available_mb,
+                used_mb,
+                load_pct: status.dwMemoryLoad as u8,
+            })
+        }
+    }
+
+    fn foreground_pid() -> Option<u32> {
+        unsafe {
+            let hwnd = GetForegroundWindow();
+            if hwnd.0.is_null() {
+                return None;
+            }
+            let mut pid: u32 = 0;
+            GetWindowThreadProcessId(hwnd, Some(&mut pid));
+            if pid == 0 { None } else { Some(pid) }
+        }
+    }
+
+    fn snapshot_or_warn(warnings: &mut Vec<String>) -> SystemMemorySnapshot {
+        match get_system_memory_snapshot() {
+            Ok(snap) => snap,
+            Err(e) => {
+                warnings.push(format!("Failed to read system memory stats: {}", e));
+                SystemMemorySnapshot {
+                    total_mb: 0,
+                    available_mb: 0,
+                    used_mb: 0,
+                    load_pct: 0,
+                }
+            }
+        }
+    }
+
+    fn sample_processes() -> Vec<ProcessSample> {
+        let mut system = System::new();
+        system.refresh_processes(ProcessesToUpdate::All, true);
+        std::thread::sleep(Duration::from_millis(200));
+        system.refresh_processes(ProcessesToUpdate::All, true);
+
+        system
+            .processes()
+            .iter()
+            .map(|(pid, p)| ProcessSample {
+                pid: pid.as_u32(),
+                name: p.name().to_string_lossy().to_string(),
+                memory_bytes: p.memory(),
+                cpu_usage: p.cpu_usage(),
+            })
+            .collect()
+    }
+
+    fn trim_working_set(pid: u32) -> Result<()> {
+        unsafe {
+            let handle = OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SET_QUOTA,
+                false,
+                pid,
+            )?;
+
+            if handle.is_invalid() {
+                return Err(anyhow::anyhow!("Failed to open process"));
+            }
+
+            let result = EmptyWorkingSet(handle);
+            let _ = CloseHandle(handle);
+
+            result.map_err(|e| anyhow::anyhow!("EmptyWorkingSet failed: {}", e))
+        }
+    }
+
+    fn enable_privilege(privilege_name: &str) -> Result<()> {
+        unsafe {
+            let mut token = windows::Win32::Foundation::HANDLE::default();
+            OpenProcessToken(
+                GetCurrentProcess(),
+                TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+                &mut token,
+            )?;
+
+            let wide_name: Vec<u16> = privilege_name
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .collect();
+
+            let mut luid = windows::Win32::Foundation::LUID::default();
+            LookupPrivilegeValueW(PCWSTR::null(), PCWSTR(wide_name.as_ptr()), &mut luid)?;
+
+            let tp = TOKEN_PRIVILEGES {
+                PrivilegeCount: 1,
+                Privileges: [LUID_AND_ATTRIBUTES {
+                    Luid: luid,
+                    Attributes: SE_PRIVILEGE_ENABLED,
+                }],
+            };
+
+            AdjustTokenPrivileges(token, false, Some(&tp), 0, None, None)?;
+            let _ = CloseHandle(token);
+            Ok(())
+        }
+    }
+
+    fn purge_standby_list() -> StandbyPurgeResult {
+        if !crate::is_administrator() {
+            return StandbyPurgeResult {
+                attempted: false,
+                success: false,
+                skipped_reason: Some("Requires Administrator".to_string()),
+            };
+        }
+
+        unsafe {
+            if let Err(e) = enable_privilege("SeProfileSingleProcessPrivilege") {
+                return StandbyPurgeResult {
+                    attempted: false,
+                    success: false,
+                    skipped_reason: Some(format!(
+                        "Could not enable SeProfileSingleProcessPrivilege: {}",
+                        e
+                    )),
+                };
+            }
+
+            let command: u32 = MEMORY_PURGE_STANDBY_LIST;
+            let status = NtSetSystemInformation(
+                SYSTEM_MEMORY_LIST_INFORMATION,
+                &command as *const u32 as *const c_void,
+                std::mem::size_of::<u32>() as u32,
+            );
+
+            if status == 0 {
+                StandbyPurgeResult {
+                    attempted: true,
+                    success: true,
+                    skipped_reason: None,
+                }
+            } else {
+                StandbyPurgeResult {
+                    attempted: true,
+                    success: false,
+                    skipped_reason: Some(format!("NtSetSystemInformation failed (0x{status:08X})")),
+                }
+            }
+        }
+    }
+
+    pub(super) fn clean_ram<F>(exclude_pids: &[u32], on_progress: &mut F) -> Result<RamCleanResult>
+    where
+        F: FnMut(&str, SystemMemorySnapshot, u32, Option<String>, Option<String>),
+    {
+        let started = Instant::now();
+        let mut warnings: Vec<String> = Vec::new();
+
+        let mut exclude_set: HashSet<u32> = exclude_pids.iter().copied().collect();
+        exclude_set.insert(std::process::id());
+        if let Some(pid) = foreground_pid() {
+            exclude_set.insert(pid);
+        }
+
+        let before = snapshot_or_warn(&mut warnings);
+        on_progress("start", before, 0, None, None);
+
+        info!("Sampling processes for RAM clean...");
+        let processes = sample_processes();
+        let candidates = select_trim_candidates(processes, &exclude_set);
+        info!("RAM clean: {} trim candidates selected", candidates.len());
+
+        let mut trimmed_count: u32 = 0;
+        for candidate in candidates {
+            let current_name = candidate.name.clone();
+            match trim_working_set(candidate.pid) {
+                Ok(()) => {
+                    trimmed_count = trimmed_count.saturating_add(1);
+                    let snap = snapshot_or_warn(&mut warnings);
+                    on_progress("trimming", snap, trimmed_count, Some(current_name), None);
+                }
+                Err(e) => {
+                    let msg = format!("{} (pid {}): {}", candidate.name, candidate.pid, e);
+                    warn!("RAM clean warning: {}", msg);
+                    warnings.push(msg.clone());
+                    let snap = snapshot_or_warn(&mut warnings);
+                    on_progress(
+                        "trimming",
+                        snap,
+                        trimmed_count,
+                        Some(current_name),
+                        Some(msg),
+                    );
+                }
+            }
+        }
+
+        let snap = snapshot_or_warn(&mut warnings);
+        on_progress("standby_purge", snap, trimmed_count, None, None);
+
+        let standby_purge = purge_standby_list();
+        if !standby_purge.success {
+            if let Some(reason) = standby_purge.skipped_reason.clone() {
+                warnings.push(format!("Standby purge: {}", reason));
+            }
+        }
+
+        let after = snapshot_or_warn(&mut warnings);
+        on_progress("done", after, trimmed_count, None, None);
+
+        Ok(RamCleanResult {
+            before,
+            after,
+            trimmed_count,
+            standby_purge,
+            duration_ms: started.elapsed().as_millis() as u64,
+            warnings,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proc(pid: u32, name: &str, memory_mb: u64, cpu: f32) -> ProcessSample {
+        ProcessSample {
+            pid,
+            name: name.to_string(),
+            memory_bytes: memory_mb * 1024 * 1024,
+            cpu_usage: cpu,
+        }
+    }
+
+    #[test]
+    fn select_candidates_excludes_denylist_names_case_insensitive() {
+        let processes = vec![
+            proc(10, "svchost.exe", 800, 0.0),
+            proc(11, "Chrome.exe", 900, 0.0),
+        ];
+        let exclude = HashSet::new();
+        let selected = select_trim_candidates(processes, &exclude);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].pid, 11);
+    }
+
+    #[test]
+    fn select_candidates_excludes_explicit_pids() {
+        let processes = vec![
+            proc(10, "chrome.exe", 900, 0.0),
+            proc(11, "discord.exe", 700, 0.0),
+        ];
+        let exclude: HashSet<u32> = [11].into_iter().collect();
+        let selected = select_trim_candidates(processes, &exclude);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].pid, 10);
+    }
+
+    #[test]
+    fn select_candidates_skips_busy_processes() {
+        let processes = vec![
+            proc(10, "chrome.exe", 900, 10.0),
+            proc(11, "discord.exe", 700, 1.0),
+        ];
+        let exclude = HashSet::new();
+        let selected = select_trim_candidates(processes, &exclude);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].pid, 11);
+    }
+
+    #[test]
+    fn select_candidates_applies_memory_threshold_and_caps_max() {
+        let mut processes = Vec::new();
+        processes.push(proc(1, "small.exe", 199, 0.0));
+        for i in 0..25 {
+            processes.push(proc(100 + i, &format!("p{i}.exe"), 200 + i as u64, 0.0));
+        }
+        let exclude = HashSet::new();
+        let selected = select_trim_candidates(processes, &exclude);
+        assert_eq!(selected.len(), MAX_TRIM_PROCESSES);
+        assert!(selected.iter().all(|p| p.memory_bytes >= MIN_PROCESS_BYTES));
+        // Highest memory first (200+24)
+        assert_eq!(selected[0].pid, 124);
+    }
+}

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -4,10 +4,6 @@ use log::{info, warn};
 use std::process::Command;
 use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::Media::{timeBeginPeriod, timeEndPeriod};
-use windows::Win32::Security::{
-    AdjustTokenPrivileges, LUID_AND_ATTRIBUTES, LookupPrivilegeValueW, SE_PRIVILEGE_ENABLED,
-    TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES, TOKEN_QUERY,
-};
 use windows::Win32::System::Threading::*;
 
 // ntdll.dll functions for low-level system control
@@ -18,19 +14,7 @@ unsafe extern "system" {
         SetResolution: u8,
         CurrentResolution: *mut u32,
     ) -> i32;
-
-    // Standby memory purge (actual RAM clearing)
-    fn NtSetSystemInformation(
-        SystemInformationClass: u32,
-        SystemInformation: *const std::ffi::c_void,
-        SystemInformationLength: u32,
-    ) -> i32;
 }
-
-/// SystemMemoryListInformation class for NtSetSystemInformation
-const SYSTEM_MEMORY_LIST_INFORMATION: u32 = 80;
-/// Command to purge the standby list (free cached RAM)
-const MEMORY_PURGE_STANDBY_LIST: u32 = 4;
 
 pub struct SystemOptimizer {
     original_priority: Option<u32>,
@@ -78,10 +62,6 @@ impl SystemOptimizer {
                     process_id, e
                 );
             }
-        }
-
-        if config.clear_standby_memory {
-            self.clear_standby_memory()?;
         }
 
         if config.disable_game_bar {
@@ -179,75 +159,6 @@ impl SystemOptimizer {
                 Err(anyhow::anyhow!("Failed to set CPU affinity"))
             }
         }
-    }
-
-    /// Clear standby memory to free up RAM
-    ///
-    /// Uses NtSetSystemInformation with MemoryPurgeStandbyList to actually
-    /// release cached pages back to the free list. Requires admin privileges
-    /// (SeProfileSingleProcessPrivilege).
-    fn clear_standby_memory(&self) -> Result<()> {
-        info!("Clearing standby memory via NtSetSystemInformation");
-
-        unsafe {
-            // Enable SeProfileSingleProcessPrivilege (required for standby purge)
-            if let Err(e) = Self::enable_privilege("SeProfileSingleProcessPrivilege") {
-                warn!("Could not enable memory privilege (not admin?): {}", e);
-                return Ok(()); // Non-critical, continue with other boosts
-            }
-
-            let command: u32 = MEMORY_PURGE_STANDBY_LIST;
-            let status = NtSetSystemInformation(
-                SYSTEM_MEMORY_LIST_INFORMATION,
-                &command as *const u32 as *const std::ffi::c_void,
-                std::mem::size_of::<u32>() as u32,
-            );
-
-            if status == 0 {
-                info!("Standby memory purged successfully");
-            } else {
-                warn!(
-                    "NtSetSystemInformation failed (0x{:08X}) — requires admin privileges",
-                    status as u32
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Enable a Windows privilege by name (e.g. "SeProfileSingleProcessPrivilege")
-    unsafe fn enable_privilege(privilege_name: &str) -> Result<()> {
-        use windows::core::PCWSTR;
-
-        let mut token = windows::Win32::Foundation::HANDLE::default();
-        OpenProcessToken(
-            GetCurrentProcess(),
-            TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
-            &mut token,
-        )?;
-
-        // Convert privilege name to wide string
-        let wide_name: Vec<u16> = privilege_name
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
-
-        let mut luid = windows::Win32::Foundation::LUID::default();
-        LookupPrivilegeValueW(PCWSTR::null(), PCWSTR(wide_name.as_ptr()), &mut luid)?;
-
-        let tp = TOKEN_PRIVILEGES {
-            PrivilegeCount: 1,
-            Privileges: [LUID_AND_ATTRIBUTES {
-                Luid: luid,
-                Attributes: SE_PRIVILEGE_ENABLED,
-            }],
-        };
-
-        AdjustTokenPrivileges(token, false, Some(&tp), 0, None, None)?;
-        let _ = CloseHandle(token);
-
-        Ok(())
     }
 
     /// Disable Windows Game Bar

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
-use tauri::State;
+use tauri::{Emitter, State};
 
+use crate::events;
 use crate::state::AppState;
 
 #[derive(Serialize)]
@@ -28,6 +29,80 @@ pub fn boost_get_metrics(state: State<'_, AppState>) -> PerformanceMetricsRespon
         ping: metrics.ping,
         roblox_running: metrics.roblox_running,
         process_id: metrics.process_id,
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct SystemMemorySnapshotResponse {
+    pub total_mb: u64,
+    pub used_mb: u64,
+    pub available_mb: u64,
+    pub load_pct: u8,
+}
+
+impl From<swifttunnel_core::ram_cleaner::SystemMemorySnapshot> for SystemMemorySnapshotResponse {
+    fn from(value: swifttunnel_core::ram_cleaner::SystemMemorySnapshot) -> Self {
+        Self {
+            total_mb: value.total_mb,
+            used_mb: value.used_mb,
+            available_mb: value.available_mb,
+            load_pct: value.load_pct,
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct StandbyPurgeResultResponse {
+    pub attempted: bool,
+    pub success: bool,
+    pub skipped_reason: Option<String>,
+}
+
+impl From<swifttunnel_core::ram_cleaner::StandbyPurgeResult> for StandbyPurgeResultResponse {
+    fn from(value: swifttunnel_core::ram_cleaner::StandbyPurgeResult) -> Self {
+        Self {
+            attempted: value.attempted,
+            success: value.success,
+            skipped_reason: value.skipped_reason,
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct RamCleanResultResponse {
+    pub before: SystemMemorySnapshotResponse,
+    pub after: SystemMemorySnapshotResponse,
+    pub trimmed_count: u32,
+    pub standby_purge: StandbyPurgeResultResponse,
+    pub duration_ms: u64,
+    pub warnings: Vec<String>,
+}
+
+impl From<swifttunnel_core::ram_cleaner::RamCleanResult> for RamCleanResultResponse {
+    fn from(value: swifttunnel_core::ram_cleaner::RamCleanResult) -> Self {
+        Self {
+            before: value.before.into(),
+            after: value.after.into(),
+            trimmed_count: value.trimmed_count,
+            standby_purge: value.standby_purge.into(),
+            duration_ms: value.duration_ms,
+            warnings: value.warnings,
+        }
+    }
+}
+
+#[tauri::command]
+pub fn boost_get_system_memory() -> Result<SystemMemorySnapshotResponse, String> {
+    #[cfg(windows)]
+    {
+        swifttunnel_core::ram_cleaner::get_system_memory_snapshot()
+            .map(SystemMemorySnapshotResponse::from)
+            .map_err(|e| e.to_string())
+    }
+
+    #[cfg(not(windows))]
+    {
+        Err("System memory stats are only supported on Windows".to_string())
     }
 }
 
@@ -92,6 +167,58 @@ pub fn boost_update_config(state: State<'_, AppState>, config_json: String) -> R
     }
 
     Ok(())
+}
+
+#[tauri::command]
+pub async fn boost_clean_ram(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<RamCleanResultResponse, String> {
+    #[cfg(windows)]
+    {
+        // Exclude Roblox PID to avoid stutters; foreground PID is excluded inside core.
+        let roblox_pid = {
+            let mut monitor = state.performance_monitor.lock();
+            monitor.get_roblox_pid().unwrap_or(0)
+        };
+
+        let mut exclude_pids: Vec<u32> = Vec::new();
+        if roblox_pid != 0 {
+            exclude_pids.push(roblox_pid);
+        }
+
+        let app_handle = app.clone();
+        let result = tauri::async_runtime::spawn_blocking(move || {
+            swifttunnel_core::ram_cleaner::clean_ram(
+                &exclude_pids,
+                |stage, snapshot, trimmed, current, warning| {
+                    let payload = events::RamCleanProgressEvent {
+                        stage: stage.to_string(),
+                        total_mb: snapshot.total_mb,
+                        used_mb: snapshot.used_mb,
+                        available_mb: snapshot.available_mb,
+                        load_pct: snapshot.load_pct,
+                        trimmed_count: trimmed,
+                        current_process: current,
+                        warning,
+                    };
+                    let _ = app_handle.emit(events::RAM_CLEAN_PROGRESS, payload);
+                },
+            )
+        })
+        .await
+        .map_err(|e| format!("RAM clean task failed: {}", e))?
+        .map_err(|e| e.to_string())?;
+
+        Ok(RamCleanResultResponse::from(result))
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = state;
+        let _ = app;
+        Err("RAM cleaner is only supported on Windows".to_string())
+    }
 }
 
 #[derive(Serialize)]

--- a/swifttunnel-desktop/src-tauri/src/events.rs
+++ b/swifttunnel-desktop/src-tauri/src/events.rs
@@ -6,6 +6,7 @@ pub const AUTH_STATE_CHANGED: &str = "auth-state-changed";
 pub const SERVER_LIST_UPDATED: &str = "server-list-updated";
 pub const THROUGHPUT_UPDATE: &str = "throughput-update";
 pub const PERFORMANCE_METRICS_UPDATE: &str = "performance-metrics-update";
+pub const RAM_CLEAN_PROGRESS: &str = "ram-clean-progress";
 
 /// VPN state change event payload
 #[derive(Clone, Serialize)]
@@ -42,4 +43,17 @@ pub struct PerformanceMetricsEvent {
     pub ram_total: f64,
     pub fps: f32,
     pub roblox_running: bool,
+}
+
+/// RAM cleaner progress event payload
+#[derive(Clone, Serialize)]
+pub struct RamCleanProgressEvent {
+    pub stage: String,
+    pub total_mb: u64,
+    pub used_mb: u64,
+    pub available_mb: u64,
+    pub load_pct: u8,
+    pub trimmed_count: u32,
+    pub current_process: Option<String>,
+    pub warning: Option<String>,
 }

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -171,7 +171,9 @@ pub fn run() {
             commands::vpn::server_smart_select,
             // Optimizer
             commands::optimizer::boost_get_metrics,
+            commands::optimizer::boost_get_system_memory,
             commands::optimizer::boost_update_config,
+            commands::optimizer::boost_clean_ram,
             commands::optimizer::boost_get_system_info,
             commands::optimizer::boost_restart_roblox,
             // Network

--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState, useCallback, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useSettingsStore } from "../../stores/settingsStore";
 import { useBoostStore } from "../../stores/boostStore";
+import { systemRestartAsAdmin } from "../../lib/commands";
+import { notify } from "../../lib/notifications";
 import { Toggle } from "../common/Toggle";
 import type {
   Config,
@@ -165,6 +167,13 @@ export function BoostTab() {
 
   const boost = useBoostStore();
 
+  const [restartAdminState, setRestartAdminState] = useState<
+    "idle" | "restarting" | "error"
+  >("idle");
+  const [restartAdminError, setRestartAdminError] = useState<string | null>(
+    null,
+  );
+
   // Draft config — local buffer until user hits Apply
   const savedConfig = settings.config;
   const [draft, setDraft] = useState<Config>(savedConfig);
@@ -208,6 +217,18 @@ export function BoostTab() {
     return () => clearInterval(id);
   }, [boost.fetchMetrics]);
 
+  useEffect(() => {
+    void boost.fetchSystemMemory();
+  }, [boost.fetchSystemMemory]);
+
+  useEffect(() => {
+    const intervalMs = boost.isCleaningRam ? 250 : 1000;
+    const id = setInterval(() => {
+      void boost.fetchSystemMemory();
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [boost.fetchSystemMemory, boost.isCleaningRam]);
+
   // Apply: persist draft to settings + backend
   const applyChanges = useCallback(() => {
     if (windowValidationError) {
@@ -230,6 +251,19 @@ export function BoostTab() {
     boost,
     windowValidationError,
   ]);
+
+  const restartAsAdmin = useCallback(async () => {
+    try {
+      setRestartAdminState("restarting");
+      setRestartAdminError(null);
+      await systemRestartAsAdmin();
+    } catch (e) {
+      const message = String(e);
+      setRestartAdminState("error");
+      setRestartAdminError(message);
+      await notify("Restart canceled", "Could not restart as Administrator.");
+    }
+  }, []);
 
   // Restart & Apply: close Roblox, apply, relaunch
   const restartAndApply = useCallback(async () => {
@@ -303,6 +337,20 @@ export function BoostTab() {
       {boost.error && (
         <p className="text-xs text-status-error">{boost.error}</p>
       )}
+
+      <RamCleanerCard
+        systemMem={boost.systemMem}
+        isCleaning={boost.isCleaningRam}
+        stage={boost.ramCleanStage}
+        trimmedCount={boost.ramCleanTrimmedCount}
+        currentProcess={boost.ramCleanCurrentProcess}
+        result={boost.ramCleanResult}
+        isAdmin={boost.isAdmin}
+        restartState={restartAdminState}
+        restartError={restartAdminError}
+        onRestartAsAdmin={() => void restartAsAdmin()}
+        onClean={() => void boost.cleanRam()}
+      />
 
       {/* ── Profile Selector ── */}
       <Section title="Profile">
@@ -613,6 +661,202 @@ export function BoostTab() {
 }
 
 // ── Sub-components ──
+
+function formatGbFromMb(mb: number): string {
+  if (!Number.isFinite(mb) || mb <= 0) return "0.0";
+  return (mb / 1024).toFixed(1);
+}
+
+function formatDeltaMb(delta: number): string {
+  if (!Number.isFinite(delta)) return "0 MB";
+  const sign = delta >= 0 ? "+" : "-";
+  return `${sign}${Math.abs(Math.round(delta))} MB`;
+}
+
+function deepCleanLabel(
+  standby: { attempted: boolean; success: boolean; skipped_reason: string | null },
+): string {
+  if (standby.success) return "Success";
+  const reason = standby.skipped_reason ? ` (${standby.skipped_reason})` : "";
+  if (!standby.attempted) return `Skipped${reason}`;
+  return `Failed${reason}`;
+}
+
+function RamCleanerCard({
+  systemMem,
+  isCleaning,
+  stage,
+  trimmedCount,
+  currentProcess,
+  result,
+  isAdmin,
+  restartState,
+  restartError,
+  onRestartAsAdmin,
+  onClean,
+}: {
+  systemMem: {
+    total_mb: number;
+    used_mb: number;
+    available_mb: number;
+    load_pct: number;
+  } | null;
+  isCleaning: boolean;
+  stage: string | null;
+  trimmedCount: number;
+  currentProcess: string | null;
+  result: {
+    before: {
+      total_mb: number;
+      used_mb: number;
+      available_mb: number;
+      load_pct: number;
+    };
+    after: {
+      total_mb: number;
+      used_mb: number;
+      available_mb: number;
+      load_pct: number;
+    };
+    trimmed_count: number;
+    standby_purge: {
+      attempted: boolean;
+      success: boolean;
+      skipped_reason: string | null;
+    };
+    duration_ms: number;
+    warnings: string[];
+  } | null;
+  isAdmin: boolean;
+  restartState: "idle" | "restarting" | "error";
+  restartError: string | null;
+  onRestartAsAdmin: () => void;
+  onClean: () => void;
+}) {
+  const totalMb = systemMem?.total_mb ?? 0;
+  const usedMb = systemMem?.used_mb ?? 0;
+  const availableMb = systemMem?.available_mb ?? 0;
+  const percent =
+    totalMb > 0 ? Math.max(0, Math.min(100, (usedMb / totalMb) * 100)) : 0;
+
+  const deltaAvailableMb = result
+    ? result.after.available_mb - result.before.available_mb
+    : null;
+
+  return (
+    <div className="rounded-[var(--radius-card)] border border-border-subtle bg-bg-card px-4 py-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col">
+          <div className="text-sm font-medium text-text-primary">
+            RAM Cleaner
+          </div>
+          <div className="mt-0.5 text-xs text-text-muted">
+            Frees memory by trimming background apps. Deep clean runs when Administrator.
+          </div>
+        </div>
+        <button
+          onClick={onClean}
+          disabled={isCleaning}
+          className="rounded-[var(--radius-button)] px-5 py-2 text-xs font-semibold text-white transition-all disabled:opacity-60"
+          style={{
+            background: "linear-gradient(145deg, #3c82f6, #5a9fff)",
+            boxShadow: "0 2px 8px rgba(60,130,246,0.25)",
+          }}
+        >
+          {isCleaning ? "Cleaning\u2026" : "Clean RAM"}
+        </button>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-text-muted">
+          <span>
+            Used:{" "}
+            <span className="font-mono text-text-primary">
+              {formatGbFromMb(usedMb)} GB / {formatGbFromMb(totalMb)} GB
+            </span>
+          </span>
+          <span>
+            Available:{" "}
+            <span className="font-mono text-text-primary">
+              {formatGbFromMb(availableMb)} GB
+            </span>
+          </span>
+        </div>
+
+        <div className="h-2 w-full overflow-hidden rounded-full bg-bg-elevated">
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${percent}%`,
+              background: "linear-gradient(90deg, #3c82f6, #22c55e)",
+            }}
+          />
+        </div>
+
+        {isCleaning && (
+          <div className="text-xs text-text-muted">
+            {stage ? `Stage: ${stage}` : "Cleaning\u2026"}{" "}
+            {trimmedCount > 0 ? `• Trimmed: ${trimmedCount}` : ""}
+            {currentProcess ? ` • ${currentProcess}` : ""}
+          </div>
+        )}
+
+        {!isAdmin && (
+          <div className="text-xs text-text-muted">
+            Deep clean requires Administrator.{" "}
+            <button
+              type="button"
+              onClick={onRestartAsAdmin}
+              disabled={restartState === "restarting"}
+              className="rounded px-1.5 py-0.5 font-semibold text-accent-secondary hover:underline disabled:opacity-60"
+            >
+              {restartState === "restarting"
+                ? "Restarting\u2026"
+                : "Restart as Admin"}
+            </button>
+            {restartState === "error" && restartError && (
+              <div className="mt-1 text-xs text-status-error">
+                {restartError}
+              </div>
+            )}
+          </div>
+        )}
+
+        {result && (
+          <div className="mt-2 rounded-[var(--radius-card)] border border-border-subtle bg-bg-elevated px-3 py-2 text-xs text-text-muted">
+            <div className="flex flex-wrap gap-x-4 gap-y-1">
+              <span>
+                Freed (approx):{" "}
+                <span className="font-mono text-text-primary">
+                  {deltaAvailableMb !== null
+                    ? formatDeltaMb(deltaAvailableMb)
+                    : "+0 MB"}
+                </span>
+              </span>
+              <span>
+                Trimmed:{" "}
+                <span className="font-mono text-text-primary">
+                  {result.trimmed_count}
+                </span>
+              </span>
+              <span>
+                Deep clean:{" "}
+                <span className="font-mono text-text-primary">
+                  {deepCleanLabel(result.standby_purge)}
+                </span>
+              </span>
+            </div>
+            {result.warnings.length > 0 && (
+              <div className="mt-1 text-[11px] text-status-warning">
+                Warnings: {result.warnings.length}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function Section({
   title,

--- a/swifttunnel-desktop/src/lib/commands.ts
+++ b/swifttunnel-desktop/src/lib/commands.ts
@@ -10,6 +10,8 @@ import type {
   LatencyEntry,
   PerformanceMetricsResponse,
   SystemInfoResponse,
+  SystemMemorySnapshot,
+  RamCleanResultResponse,
   StabilityResultResponse,
   SpeedResultResponse,
   BufferbloatResultResponse,
@@ -86,8 +88,14 @@ export const serverSmartSelect = (regionId: string) =>
 export const boostGetMetrics = () =>
   invoke<PerformanceMetricsResponse>("boost_get_metrics");
 
+export const boostGetSystemMemory = () =>
+  invoke<SystemMemorySnapshot>("boost_get_system_memory");
+
 export const boostUpdateConfig = (configJson: string) =>
   invoke<void>("boost_update_config", { configJson });
+
+export const boostCleanRam = () =>
+  invoke<RamCleanResultResponse>("boost_clean_ram");
 
 export const boostGetSystemInfo = () =>
   invoke<SystemInfoResponse>("boost_get_system_info");

--- a/swifttunnel-desktop/src/lib/events.ts
+++ b/swifttunnel-desktop/src/lib/events.ts
@@ -4,6 +4,7 @@ import type {
   AuthStateEvent,
   ThroughputEvent,
   PerformanceMetricsEvent,
+  RamCleanProgressEvent,
 } from "./types";
 import { useVpnStore } from "../stores/vpnStore";
 import { useAuthStore } from "../stores/authStore";
@@ -14,6 +15,7 @@ const EVENT_VPN_STATE_CHANGED = "vpn-state-changed";
 const EVENT_AUTH_STATE_CHANGED = "auth-state-changed";
 const EVENT_THROUGHPUT_UPDATE = "throughput-update";
 const EVENT_PERFORMANCE_METRICS_UPDATE = "performance-metrics-update";
+const EVENT_RAM_CLEAN_PROGRESS = "ram-clean-progress";
 const EVENT_SERVER_LIST_UPDATED = "server-list-updated";
 
 let unlisteners: UnlistenFn[] = [];
@@ -47,6 +49,12 @@ export async function initEventListeners() {
         useBoostStore.getState().handleMetricsEvent(event.payload);
       },
     ),
+  );
+
+  unlisteners.push(
+    await listen<RamCleanProgressEvent>(EVENT_RAM_CLEAN_PROGRESS, (event) => {
+      useBoostStore.getState().handleRamCleanProgress(event.payload);
+    }),
   );
 
   unlisteners.push(

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -123,6 +123,28 @@ export interface SystemInfoResponse {
   cpu_count: number;
 }
 
+export interface SystemMemorySnapshot {
+  total_mb: number;
+  used_mb: number;
+  available_mb: number;
+  load_pct: number;
+}
+
+export interface StandbyPurgeResult {
+  attempted: boolean;
+  success: boolean;
+  skipped_reason: string | null;
+}
+
+export interface RamCleanResultResponse {
+  before: SystemMemorySnapshot;
+  after: SystemMemorySnapshot;
+  trimmed_count: number;
+  standby_purge: StandbyPurgeResult;
+  duration_ms: number;
+  warnings: string[];
+}
+
 export type OptimizationProfile = "LowEnd" | "Balanced" | "HighEnd" | "Custom";
 export type PowerPlan = "Balanced" | "HighPerformance" | "Ultimate";
 export type GraphicsQuality =
@@ -320,6 +342,17 @@ export interface PerformanceMetricsEvent {
   ram_total: number;
   fps: number;
   roblox_running: boolean;
+}
+
+export interface RamCleanProgressEvent {
+  stage: string;
+  total_mb: number;
+  used_mb: number;
+  available_mb: number;
+  load_pct: number;
+  trimmed_count: number;
+  current_process: string | null;
+  warning: string | null;
 }
 
 // ── Tabs ──

--- a/swifttunnel-desktop/src/mocks/tauri-core.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-core.ts
@@ -64,6 +64,8 @@ const MOCK_SETTINGS = {
 };
 
 let mockVpnConnected = false;
+let mockSystemMemTotalMb = 16384;
+let mockSystemMemUsedMb = 9800;
 
 const handlers: Record<string, (...args: unknown[]) => unknown> = {
   auth_get_state: () => ({
@@ -189,7 +191,48 @@ const handlers: Record<string, (...args: unknown[]) => unknown> = {
     process_id: 12480,
   }),
 
+  boost_get_system_memory: () => {
+    const total = mockSystemMemTotalMb;
+    const used = Math.min(mockSystemMemUsedMb, total);
+    const available = Math.max(0, total - used);
+    const loadPct = Math.max(0, Math.min(100, Math.round((used / total) * 100)));
+    return {
+      total_mb: total,
+      used_mb: used,
+      available_mb: available,
+      load_pct: loadPct,
+    };
+  },
+
   boost_update_config: () => {},
+  boost_clean_ram: async () => {
+    const before = handlers.boost_get_system_memory() as {
+      total_mb: number;
+      used_mb: number;
+      available_mb: number;
+      load_pct: number;
+    };
+
+    await new Promise((r) => setTimeout(r, 900));
+    const freedMb = 400 + Math.floor(Math.random() * 600);
+    mockSystemMemUsedMb = Math.max(2000, before.used_mb - freedMb);
+
+    const after = handlers.boost_get_system_memory() as {
+      total_mb: number;
+      used_mb: number;
+      available_mb: number;
+      load_pct: number;
+    };
+
+    return {
+      before,
+      after,
+      trimmed_count: 12,
+      standby_purge: { attempted: true, success: true, skipped_reason: null },
+      duration_ms: 1100,
+      warnings: [],
+    };
+  },
   boost_restart_roblox: async () => {
     await new Promise((r) => setTimeout(r, 1200));
   },

--- a/swifttunnel-desktop/src/stores/boostStore.test.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { boostUpdateConfig, boostRestartRoblox } = vi.hoisted(() => ({
+const { boostUpdateConfig, boostRestartRoblox, boostGetSystemMemory, boostCleanRam } = vi.hoisted(() => ({
   boostUpdateConfig: vi.fn(),
   boostRestartRoblox: vi.fn(),
+  boostGetSystemMemory: vi.fn(),
+  boostCleanRam: vi.fn(),
 }));
 
 vi.mock("../lib/commands", () => ({
   boostGetMetrics: vi.fn(),
   boostGetSystemInfo: vi.fn(),
+  boostGetSystemMemory,
+  boostCleanRam,
   boostUpdateConfig,
   boostRestartRoblox,
 }));
@@ -29,6 +33,8 @@ describe("stores/boostStore", () => {
   beforeEach(() => {
     boostUpdateConfig.mockReset();
     boostRestartRoblox.mockReset();
+    boostGetSystemMemory.mockReset();
+    boostCleanRam.mockReset();
     notify.mockReset();
   });
 
@@ -56,5 +62,77 @@ describe("stores/boostStore", () => {
       "Boost config failed",
       "Could not save optimization profile.",
     );
+  });
+
+  it("cleans RAM and updates state without notifications on success", async () => {
+    const resp = {
+      before: { total_mb: 16000, used_mb: 10000, available_mb: 6000, load_pct: 63 },
+      after: { total_mb: 16000, used_mb: 9000, available_mb: 7000, load_pct: 56 },
+      trimmed_count: 8,
+      standby_purge: { attempted: true, success: true, skipped_reason: null },
+      duration_ms: 900,
+      warnings: [],
+    };
+
+    let resolveClean: (value: typeof resp) => void;
+    boostCleanRam.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveClean = resolve;
+        }),
+    );
+
+    const useBoostStore = await loadStore();
+    const promise = useBoostStore.getState().cleanRam();
+
+    expect(useBoostStore.getState().isCleaningRam).toBe(true);
+    resolveClean!(resp);
+    await promise;
+
+    expect(boostCleanRam).toHaveBeenCalledTimes(1);
+    expect(useBoostStore.getState().isCleaningRam).toBe(false);
+    expect(useBoostStore.getState().ramCleanResult).toEqual(resp);
+    expect(useBoostStore.getState().systemMem).toEqual(resp.after);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("stores error and notifies when RAM clean fails", async () => {
+    boostCleanRam.mockRejectedValue(new Error("boom"));
+
+    const useBoostStore = await loadStore();
+    await useBoostStore.getState().cleanRam();
+
+    expect(useBoostStore.getState().error).toBe("Error: boom");
+    expect(useBoostStore.getState().isCleaningRam).toBe(false);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith(
+      "RAM cleaner failed",
+      "Could not clean memory.",
+    );
+  });
+
+  it("updates system memory snapshot from ram-clean-progress events", async () => {
+    const useBoostStore = await loadStore();
+
+    useBoostStore.getState().handleRamCleanProgress({
+      stage: "trimming",
+      total_mb: 16000,
+      used_mb: 11000,
+      available_mb: 5000,
+      load_pct: 69,
+      trimmed_count: 3,
+      current_process: "chrome.exe",
+      warning: null,
+    });
+
+    expect(useBoostStore.getState().systemMem).toEqual({
+      total_mb: 16000,
+      used_mb: 11000,
+      available_mb: 5000,
+      load_pct: 69,
+    });
+    expect(useBoostStore.getState().ramCleanStage).toBe("trimming");
+    expect(useBoostStore.getState().ramCleanTrimmedCount).toBe(3);
+    expect(useBoostStore.getState().ramCleanCurrentProcess).toBe("chrome.exe");
   });
 });

--- a/swifttunnel-desktop/src/stores/boostStore.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.ts
@@ -1,7 +1,14 @@
 import { create } from "zustand";
-import type { PerformanceMetricsEvent } from "../lib/types";
+import type {
+  PerformanceMetricsEvent,
+  RamCleanProgressEvent,
+  RamCleanResultResponse,
+  SystemMemorySnapshot,
+} from "../lib/types";
 import {
   boostGetMetrics,
+  boostGetSystemMemory,
+  boostCleanRam,
   boostGetSystemInfo,
   boostUpdateConfig,
   boostRestartRoblox,
@@ -18,6 +25,14 @@ interface BoostStore {
   robloxRunning: boolean;
   processId: number | null;
 
+  // System memory (RAM cleaner)
+  systemMem: SystemMemorySnapshot | null;
+  isCleaningRam: boolean;
+  ramCleanStage: string | null;
+  ramCleanTrimmedCount: number;
+  ramCleanCurrentProcess: string | null;
+  ramCleanResult: RamCleanResultResponse | null;
+
   error: string | null;
 
   // System info
@@ -27,11 +42,14 @@ interface BoostStore {
 
   // Actions
   fetchMetrics: () => Promise<void>;
+  fetchSystemMemory: () => Promise<void>;
   fetchSystemInfo: () => Promise<void>;
   updateConfig: (configJson: string) => Promise<void>;
   restartRoblox: () => Promise<void>;
+  cleanRam: () => Promise<void>;
   clearError: () => void;
   handleMetricsEvent: (event: PerformanceMetricsEvent) => void;
+  handleRamCleanProgress: (event: RamCleanProgressEvent) => void;
 }
 
 export const useBoostStore = create<BoostStore>((set) => ({
@@ -42,6 +60,12 @@ export const useBoostStore = create<BoostStore>((set) => ({
   ping: 0,
   robloxRunning: false,
   processId: null,
+  systemMem: null,
+  isCleaningRam: false,
+  ramCleanStage: null,
+  ramCleanTrimmedCount: 0,
+  ramCleanCurrentProcess: null,
+  ramCleanResult: null,
   error: null,
   isAdmin: false,
   osVersion: "",
@@ -59,6 +83,15 @@ export const useBoostStore = create<BoostStore>((set) => ({
         robloxRunning: m.roblox_running,
         processId: m.process_id,
       });
+    } catch {
+      // Silently ignore
+    }
+  },
+
+  fetchSystemMemory: async () => {
+    try {
+      const mem = await boostGetSystemMemory();
+      set({ systemMem: mem });
     } catch {
       // Silently ignore
     }
@@ -88,6 +121,32 @@ export const useBoostStore = create<BoostStore>((set) => ({
     }
   },
 
+  cleanRam: async () => {
+    try {
+      set({
+        error: null,
+        isCleaningRam: true,
+        ramCleanStage: "start",
+        ramCleanTrimmedCount: 0,
+        ramCleanCurrentProcess: null,
+        ramCleanResult: null,
+      });
+      const result = await boostCleanRam();
+      set({
+        isCleaningRam: false,
+        ramCleanStage: "done",
+        ramCleanResult: result,
+        systemMem: result.after,
+        ramCleanTrimmedCount: result.trimmed_count,
+        ramCleanCurrentProcess: null,
+      });
+    } catch (e) {
+      const message = String(e);
+      set({ error: message, isCleaningRam: false });
+      await notify("RAM cleaner failed", "Could not clean memory.");
+    }
+  },
+
   restartRoblox: async () => {
     try {
       await boostRestartRoblox();
@@ -109,6 +168,20 @@ export const useBoostStore = create<BoostStore>((set) => ({
       ramUsage: event.ram_usage,
       ramTotal: event.ram_total,
       robloxRunning: event.roblox_running,
+    });
+  },
+
+  handleRamCleanProgress: (event) => {
+    set({
+      systemMem: {
+        total_mb: event.total_mb,
+        used_mb: event.used_mb,
+        available_mb: event.available_mb,
+        load_pct: event.load_pct,
+      },
+      ramCleanStage: event.stage,
+      ramCleanTrimmedCount: event.trimmed_count,
+      ramCleanCurrentProcess: event.current_process,
     });
   },
 }));


### PR DESCRIPTION
## Summary
Adds a RAM Cleaner card at the top of the Boost tab with a live system RAM meter and a single "Clean RAM" button. While cleaning runs, the meter updates live via a new progress event.

## Safety
- Trims working sets only for background-ish processes (>=200MB, CPU <=2%, max 20).
- Excludes foreground process, Roblox PID, and a denylist of critical Windows processes.
- Deep clean (standby list purge) only runs when elevated; otherwise it is skipped with a clear reason + "Restart as Admin" action.
- Removes automatic standby purge from boost profile apply/startup (manual-only).

## Backend
- New core module: `swifttunnel-core/src/ram_cleaner.rs`
- New Tauri commands: `boost_get_system_memory`, `boost_clean_ram`
- New event: `ram-clean-progress` (payload includes stage + memory snapshot + trimmed count)

## Frontend
- Boost tab RAM Cleaner card (top) + store wiring for live progress updates

## Tests
- Vitest: `npm test` (`swifttunnel-desktop`)
- Frontend build: `npm run build` (`swifttunnel-desktop`)
- Windows testbench:
  - `cargo fmt --all -- --check`
  - `cargo test -p swifttunnel-core --all-targets --all-features`
  - `cargo test --workspace --all-targets --all-features`
  - `npm ci && npm run build` (`swifttunnel-desktop`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Windows RAM cleaning feature with real-time system memory monitoring
  * Displays memory metrics and tracks freed memory during cleanup
  * Provides live progress updates with trimmed process details and warnings
  * Includes admin restart capability for enhanced optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->