### PR TITLE
[codex] fix in-app uninstall sequencing

### DIFF
--- a/swifttunnel-core/src/auth/storage.rs
+++ b/swifttunnel-core/src/auth/storage.rs
@@ -652,8 +652,10 @@ mod tests {
 
     #[test]
     fn test_storage_roundtrip_via_file() {
-        let storage = SecureStorage::new().unwrap();
-        let _ = storage.clear_session();
+        // Use an isolated data directory so this test doesn't race with
+        // `test_legacy_file_migrated_on_load` over the real user data dir
+        // when cargo's default thread pool runs them in parallel.
+        let storage = SecureStorage::with_isolated_data_dir();
 
         let session = make_session("file");
         storage.store_session(&session).unwrap();
@@ -667,8 +669,8 @@ mod tests {
 
     #[test]
     fn test_legacy_file_migrated_on_load() {
-        let storage = SecureStorage::new().unwrap();
-        let _ = storage.clear_session();
+        // Isolated data dir — see `test_storage_roundtrip_via_file` for why.
+        let storage = SecureStorage::with_isolated_data_dir();
 
         let session = make_session("migrate");
         let json = serde_json::to_string(&session).unwrap();

--- a/swifttunnel-desktop/src-tauri/src/commands/system.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/system.rs
@@ -694,25 +694,12 @@ pub async fn system_uninstall(
             conn_state,
             swifttunnel_core::vpn::ConnectionState::Disconnected
         ) {
-            let mut vpn = state.vpn_connection.lock().await;
-            vpn.disconnect()
-                .await
-                .map_err(|e| swifttunnel_core::vpn::user_friendly_error(&e))?;
-            *state.split_tunnel_handle.write() = None;
-            drop(vpn);
-
-            {
-                let mut discord = state.discord_manager.lock();
-                discord.set_idle();
-            }
-
-            let mut settings = state.settings.lock();
-            settings.resume_vpn_on_startup = false;
-            let snapshot = settings.clone();
-            drop(settings);
-            if let Err(e) = swifttunnel_core::settings::save_settings(&snapshot) {
-                log::warn!("Failed to persist disconnected session settings: {}", e);
-            }
+            // Tear down the live session before touching the uninstaller.
+            // The shared helper always clears the split-tunnel handle, sets
+            // Discord idle, and persists `resume_vpn_on_startup = false` even
+            // if the driver-level disconnect errors — which is what we want
+            // here since the app is about to exit and hand off to NSIS.
+            crate::commands::vpn::disconnect_and_persist(&state).await?;
         }
 
         // Find and launch the NSIS uninstaller

--- a/swifttunnel-desktop/src-tauri/src/commands/system.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/system.rs
@@ -288,6 +288,18 @@ fn build_restart_as_admin_script(exe_path: &str, current_pid: u32) -> String {
     )
 }
 
+#[cfg(windows)]
+fn build_launch_uninstaller_after_exit_script(uninstaller_path: &str, current_pid: u32) -> String {
+    let escaped_uninstaller = uninstaller_path.replace('\'', "''");
+
+    format!(
+        "$ErrorActionPreference='Stop'; \
+         $pidToWait={current_pid}; \
+         while (Get-Process -Id $pidToWait -ErrorAction SilentlyContinue) {{ Start-Sleep -Milliseconds 200 }}; \
+         Start-Process -FilePath '{escaped_uninstaller}'"
+    )
+}
+
 #[derive(Serialize)]
 pub struct AdminCheckResponse {
     pub is_admin: bool,
@@ -644,6 +656,21 @@ mod tests {
         assert!(script.contains("-Verb RunAs"));
         assert!(script.contains("-EncodedCommand"));
     }
+
+    #[test]
+    fn build_launch_uninstaller_after_exit_script_waits_for_pid_and_escapes_path() {
+        let script = build_launch_uninstaller_after_exit_script(
+            "C:\\Program Files\\Swift'Tunnel\\uninstall.exe",
+            4242,
+        );
+        assert!(script.contains("$pidToWait=4242"));
+        assert!(script.contains("Get-Process -Id $pidToWait"));
+        assert!(
+            script.contains(
+                "Start-Process -FilePath 'C:\\Program Files\\Swift''Tunnel\\uninstall.exe'"
+            )
+        );
+    }
 }
 
 #[tauri::command]
@@ -656,17 +683,38 @@ pub async fn system_cleanup() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn system_uninstall(app: tauri::AppHandle) -> Result<(), String> {
-    // Run cleanup first to revert all system modifications (blocking work offloaded)
-    tauri::async_runtime::spawn_blocking(|| {
-        swifttunnel_core::network_booster::cleanup_all_system_state()
-            .map_err(|e| format!("Cleanup failed before uninstall: {}", e))
-    })
-    .await
-    .map_err(|e| format!("Cleanup task failed: {}", e))??;
-
+pub async fn system_uninstall(
+    state: tauri::State<'_, crate::state::AppState>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
     #[cfg(windows)]
     {
+        let conn_state = state.vpn_state_handle.lock().await.clone();
+        if !matches!(
+            conn_state,
+            swifttunnel_core::vpn::ConnectionState::Disconnected
+        ) {
+            let mut vpn = state.vpn_connection.lock().await;
+            vpn.disconnect()
+                .await
+                .map_err(|e| swifttunnel_core::vpn::user_friendly_error(&e))?;
+            *state.split_tunnel_handle.write() = None;
+            drop(vpn);
+
+            {
+                let mut discord = state.discord_manager.lock();
+                discord.set_idle();
+            }
+
+            let mut settings = state.settings.lock();
+            settings.resume_vpn_on_startup = false;
+            let snapshot = settings.clone();
+            drop(settings);
+            if let Err(e) = swifttunnel_core::settings::save_settings(&snapshot) {
+                log::warn!("Failed to persist disconnected session settings: {}", e);
+            }
+        }
+
         // Find and launch the NSIS uninstaller
         let exe_path =
             std::env::current_exe().map_err(|e| format!("Failed to resolve executable: {e}"))?;
@@ -682,9 +730,15 @@ pub async fn system_uninstall(app: tauri::AppHandle) -> Result<(), String> {
             );
         }
 
-        std::process::Command::new(&uninstaller)
+        let uninstaller_script = build_launch_uninstaller_after_exit_script(
+            &uninstaller.to_string_lossy(),
+            std::process::id(),
+        );
+
+        swifttunnel_core::hidden_command("powershell")
+            .args(["-NoProfile", "-Command", &uninstaller_script])
             .spawn()
-            .map_err(|e| format!("Failed to launch uninstaller: {e}"))?;
+            .map_err(|e| format!("Failed to queue uninstaller launch: {e}"))?;
 
         app.exit(0);
         Ok(())
@@ -692,6 +746,7 @@ pub async fn system_uninstall(app: tauri::AppHandle) -> Result<(), String> {
 
     #[cfg(not(windows))]
     {
+        let _ = state;
         let _ = app;
         Err("Uninstall is only supported on Windows".to_string())
     }

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -215,6 +215,43 @@ fn persist_session_settings(
     swifttunnel_core::settings::save_settings(&snapshot)
 }
 
+/// Tear down the live VPN session and drop all in-memory state that points at
+/// it. Always clears the published split-tunnel handle, sets Discord idle, and
+/// persists the disconnected session — even when the driver-level disconnect
+/// returns an error, because at that point the driver state is undefined and
+/// we'd rather report `None` to the UI (and refuse to auto-resume on next
+/// launch) than leave a stale handle or a stale `resume_vpn_on_startup` flag.
+///
+/// Shared between `vpn_disconnect` (explicit user action) and the in-app
+/// uninstall path in `commands::system`, which needs the same teardown
+/// ordering before it queues the NSIS uninstaller.
+pub(crate) async fn disconnect_and_persist(state: &AppState) -> Result<(), String> {
+    let mut vpn = state.vpn_connection.lock().await;
+    let result = vpn
+        .disconnect()
+        .await
+        .map_err(|e| swifttunnel_core::vpn::user_friendly_error(&e));
+    // Clear the published handle whether disconnect succeeded or not — on
+    // failure the driver state is undefined and we'd rather report None to
+    // the UI than hand it a stale pointer.
+    *state.split_tunnel_handle.write() = None;
+    drop(vpn);
+
+    {
+        let mut discord = state.discord_manager.lock();
+        discord.set_idle();
+    }
+
+    // Always persist the disconnected session. If disconnect failed the
+    // driver is in an unknown state, so clearing `resume_vpn_on_startup` is
+    // safer than letting the app auto-resume into it on next launch.
+    if let Err(e) = persist_session_settings(state, None) {
+        log::warn!("Failed to persist disconnected session settings: {}", e);
+    }
+
+    result
+}
+
 async fn emit_vpn_state(app: &AppHandle, state: &AppState) {
     let conn_state = state.vpn_state_handle.lock().await.clone();
 
@@ -388,28 +425,7 @@ pub async fn vpn_connect(
 
 #[tauri::command]
 pub async fn vpn_disconnect(state: State<'_, AppState>, app: AppHandle) -> Result<(), String> {
-    let mut vpn = state.vpn_connection.lock().await;
-    let result = vpn
-        .disconnect()
-        .await
-        .map_err(|e| swifttunnel_core::vpn::user_friendly_error(&e));
-    // Clear the published handle whether disconnect succeeded or not — on
-    // failure the driver state is undefined and we'd rather report None to
-    // the UI than hand it a stale pointer.
-    *state.split_tunnel_handle.write() = None;
-    drop(vpn);
-
-    {
-        let mut discord = state.discord_manager.lock();
-        discord.set_idle();
-    }
-
-    if result.is_ok() {
-        if let Err(e) = persist_session_settings(&state, None) {
-            log::warn!("Failed to persist disconnected session settings: {}", e);
-        }
-    }
-
+    let result = disconnect_and_persist(&state).await;
     emit_vpn_state(&app, &state).await;
     result
 }


### PR DESCRIPTION
## What changed
- changed the in-app uninstall flow to disconnect the live VPN/split-tunnel session before uninstall starts
- removed the duplicate pre-cleanup step from `system_uninstall`, since NSIS already runs cleanup in the uninstall hook
- queued `uninstall.exe` from a detached PowerShell helper that waits for the current app PID to exit before launching the uninstaller
- added a focused unit test for the helper script builder

## Why
The app-side uninstall path was running uninstall-critical cleanup while the app could still be connected and holding the split-tunnel driver open. That made WinpkFilter removal fail, and NSIS aborts the uninstall on any non-zero cleanup exit.

## User impact
Users uninstalling from inside the app should no longer get stuck on the app's own uninstaller when SwiftTunnel is still connected or still owns live split-tunnel state.

## Validation
- `cargo fmt --package swifttunnel-desktop`
- `cargo test -p swifttunnel-desktop` *(fails locally before reaching this change because the environment hits an existing `windows-future` / `windows_core::imp` build error on macOS)*
