### PR TITLE
fix: make uninstall best-effort so stuck state can't block it

### DIFF
--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -822,7 +822,6 @@ impl NetworkBooster {
 /// uninstaller) and the `system_cleanup` Tauri command.
 pub fn cleanup_all_system_state() -> Result<()> {
     info!("Running full stateless system cleanup");
-    let mut critical_errors: Vec<String> = Vec::new();
 
     // 1. Remove hosts file entries
     if let Err(e) = crate::roblox_proxy::hosts::remove_overrides() {
@@ -932,9 +931,14 @@ pub fn cleanup_all_system_state() -> Result<()> {
     crate::vpn::recover_ipv6_on_startup();
 
     // 11. Remove the WinpkFilter driver package and NDISRD service during
-    // uninstall/explicit cleanup so the app does not leave kernel artifacts behind.
+    // uninstall/explicit cleanup so the app does not leave kernel artifacts
+    // behind. Best-effort: if this fails we log it and continue rather than
+    // aborting the uninstall. Blocking uninstall entirely leaves the user
+    // permanently stuck (often the reason they are uninstalling in the first
+    // place), which is worse than a stale driver that a subsequent install
+    // will replace.
     if let Err(e) = crate::vpn::split_tunnel::SplitTunnelDriver::remove_driver_for_uninstall() {
-        critical_errors.push(format!("driver cleanup failed: {}", e));
+        warn!("Cleanup: driver removal failed (non-fatal): {}", e);
     }
 
     // 12. Remove Roblox FFlag entries from ClientAppSettings.json
@@ -951,17 +955,8 @@ pub fn cleanup_all_system_state() -> Result<()> {
         ])
         .output();
 
-    if critical_errors.is_empty() {
-        info!("Full system cleanup completed");
-        Ok(())
-    } else {
-        let message = critical_errors.join("; ");
-        warn!(
-            "Full system cleanup completed with critical errors: {}",
-            message
-        );
-        Err(anyhow::anyhow!(message))
-    }
+    info!("Full system cleanup completed");
+    Ok(())
 }
 
 /// Reset MTU to 1500 on all active network adapters.

--- a/swifttunnel-core/src/vpn/split_tunnel.rs
+++ b/swifttunnel-core/src/vpn/split_tunnel.rs
@@ -776,10 +776,16 @@ impl SplitTunnelDriver {
     }
 
     pub fn remove_driver_for_uninstall() -> Result<(), String> {
-        Self::disable_winpkfilter_bindings_for_uninstall()?;
-
         let mut issues = Vec::new();
         let mut any_msi_found = false;
+
+        // Best-effort: if binding removal fails we still try the MSI uninstall
+        // below. Returning early used to skip the MSI step entirely, which
+        // left both the bindings and the driver package installed when the
+        // binding call hiccupped — strictly worse than attempting the MSI.
+        if let Err(e) = Self::disable_winpkfilter_bindings_for_uninstall() {
+            issues.push(format!("binding removal failed: {}", e));
+        }
 
         // Try to uninstall all known MSI variants (handles machines that may
         // have had either or both architectures installed at some point).

--- a/swifttunnel-desktop/src-tauri/src/commands/system.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/system.rs
@@ -695,11 +695,14 @@ pub async fn system_uninstall(
             swifttunnel_core::vpn::ConnectionState::Disconnected
         ) {
             // Tear down the live session before touching the uninstaller.
-            // The shared helper always clears the split-tunnel handle, sets
-            // Discord idle, and persists `resume_vpn_on_startup = false` even
-            // if the driver-level disconnect errors — which is what we want
-            // here since the app is about to exit and hand off to NSIS.
-            crate::commands::vpn::disconnect_and_persist(&state).await?;
+            // Best-effort: swallow any error so a stuck driver never blocks
+            // the uninstall. The shared helper has already cleared the split
+            // tunnel handle, set Discord idle, and persisted
+            // `resume_vpn_on_startup = false` by this point, so continuing
+            // is safe even when the driver-level disconnect errored.
+            if let Err(e) = crate::commands::vpn::disconnect_and_persist(&state).await {
+                log::warn!("Uninstall proceeding despite disconnect error: {}", e);
+            }
         }
 
         // Find and launch the NSIS uninstaller


### PR DESCRIPTION
## Summary

Users report the in-app Uninstall button silently erroring and the Add/Remove Programs route popping "Uninstall has been aborted to avoid leaving system changes behind." Three places on the uninstall critical path hard-failed on the first error they hit — any single one leaves the user permanently stuck. This PR makes all three best-effort.

- **`system_uninstall`** ([system.rs:703](../blob/fix/uninstall-best-effort-cleanup/swifttunnel-desktop/src-tauri/src/commands/system.rs#L703)) — the `?` on `disconnect_and_persist` aborted the Uninstall button if the VPN driver was stuck. The shared helper has already cleared handles, set Discord idle, and persisted `resume_vpn_on_startup=false` by the time it returns, so swallow the disconnect error and keep going. `vpn_disconnect` still propagates errors — only the uninstall path is relaxed.
- **`cleanup_all_system_state`** ([network_booster.rs:823](../blob/fix/uninstall-best-effort-cleanup/swifttunnel-core/src/network_booster.rs#L823)) — step 11 (driver removal) was the only thing pushing to a `critical_errors` vec that caused the whole function to `Err`, which made `--cleanup` exit non-zero, which made the NSIS hook Abort. Replaced with `warn!` + `Ok(())`. Every other step in this function is already best-effort (`let _ =` or `if let Err … warn!`); this brings step 11 in line.
- **`remove_driver_for_uninstall`** ([split_tunnel.rs:778](../blob/fix/uninstall-best-effort-cleanup/swifttunnel-core/src/vpn/split_tunnel.rs#L778)) — the `?` on `disable_winpkfilter_bindings_for_uninstall` short-circuited before `msiexec /x` ran, so a binding-removal hiccup left both the bindings AND the MSI installed. Collect the error into the existing `issues` vec and fall through to the MSI loop.

Net effect: stuck VPN state, missing bindings, broken ndisapi service, or half-removed MSI now result in "cleanup did what it could, NSIS proceeds, app uninstalls with logged warnings" instead of permanent uninstall deadlock. Auto-update will deliver the fix to currently-affected users on next launch (tested: `auto_check` defaults to `true` and startup bootstrap kicks `checkForUpdates(false, true)` unconditionally).

## Test plan

- [ ] Build on Windows testbench (`npm run tauri build` in `swifttunnel-desktop/`) and confirm it still compiles
- [ ] Fresh install, connect VPN, click in-app Uninstall → app exits, NSIS runs, files removed
- [ ] Repro a stuck disconnect (e.g. kill `ndisrd` mid-session) → Uninstall button still launches NSIS instead of red-toasting
- [ ] Manually delete `WinpkFilter-x64.msi` from `drivers/` → `--cleanup` logs "No WinpkFilter MSI found" but exits 0, NSIS proceeds
- [ ] Control Panel → Add/Remove Programs → Uninstall path also succeeds in the above scenarios
- [ ] Verify the log file (`%APPDATA%\SwiftTunnel\logs\*`) contains the new `warn!` lines when driver cleanup fails, so we still have diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)