### PR TITLE
Fix Roblox API tunneling TCP fallback port persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,32 @@ jobs:
 
       - name: Test desktop backend
         run: cargo test -p swifttunnel-desktop -- --nocapture
+
+  split-tunnel-testbench:
+    name: Split Tunnel Testbench (Windows)
+    runs-on: [self-hosted, Windows, X64, testbench]
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run split tunnel API tunneling testbench
+        shell: powershell
+        env:
+          SWIFTTUNNEL_TEST_EMAIL: ${{ secrets.SWIFTTUNNEL_TEST_EMAIL }}
+          SWIFTTUNNEL_TEST_PASSWORD: ${{ secrets.SWIFTTUNNEL_TEST_PASSWORD }}
+          SWIFTTUNNEL_TEST_ACCESS_TOKEN: ${{ secrets.SWIFTTUNNEL_TEST_ACCESS_TOKEN }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $argsList = @(
+            "-EnableApiTunneling",
+            "-CustomRelay", "45.32.115.254:51821"
+          )
+          if ($env:SWIFTTUNNEL_TEST_EMAIL) {
+            $argsList += @("-Email", $env:SWIFTTUNNEL_TEST_EMAIL)
+          }
+          if ($env:SWIFTTUNNEL_TEST_PASSWORD) {
+            $argsList += @("-Password", $env:SWIFTTUNNEL_TEST_PASSWORD)
+          }
+          .\Windows-testbench\run_split_tunnel_integration_test.ps1 @argsList

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,14 @@ jobs:
           SWIFTTUNNEL_TEST_ACCESS_TOKEN: ${{ secrets.SWIFTTUNNEL_TEST_ACCESS_TOKEN }}
         run: |
           $ErrorActionPreference = "Stop"
-          $argsList = @(
-            "-EnableApiTunneling",
-            "-CustomRelay", "45.32.115.254:51821"
-          )
+          $params = @{
+            EnableApiTunneling = $true
+            CustomRelay = "45.32.115.254:51821"
+          }
           if ($env:SWIFTTUNNEL_TEST_EMAIL) {
-            $argsList += @("-Email", $env:SWIFTTUNNEL_TEST_EMAIL)
+            $params.Email = $env:SWIFTTUNNEL_TEST_EMAIL
           }
           if ($env:SWIFTTUNNEL_TEST_PASSWORD) {
-            $argsList += @("-Password", $env:SWIFTTUNNEL_TEST_PASSWORD)
+            $params.Password = $env:SWIFTTUNNEL_TEST_PASSWORD
           }
-          .\Windows-testbench\run_split_tunnel_integration_test.ps1 @argsList
+          .\Windows-testbench\run_split_tunnel_integration_test.ps1 @params

--- a/Windows-testbench/README.md
+++ b/Windows-testbench/README.md
@@ -40,6 +40,16 @@ cd <repo-root>
   -Password $env:SWIFTTUNNEL_TEST_PASSWORD
 ```
 
+To validate Roblox TCP/API tunneling as well as the UDP split-tunnel path:
+
+```powershell
+.\\Windows-testbench\\run_split_tunnel_integration_test.ps1 `
+  -EnableApiTunneling `
+  -CustomRelay "45.32.115.254:51821" `
+  -Email $env:SWIFTTUNNEL_TEST_EMAIL `
+  -Password $env:SWIFTTUNNEL_TEST_PASSWORD
+```
+
 To include a full connect / disconnect pass in the desktop harness:
 
 ```powershell
@@ -92,6 +102,8 @@ credentials.
 - optional `--custom-relay` / `SWIFTTUNNEL_TEST_CUSTOM_RELAY` targets a specific relay
 - the test process stays on the original public IP after connect
 - a selected helper process (`ip_checker.exe`) generates tunneled UDP packets
+- when API tunneling is enabled, the same helper generates a long-lived TCP
+  probe so the refresher must publish tunnel-owned TCP source ports
 - split tunnel diagnostics show tunneled packet counters increasing
 
 This matches the current V3 architecture more closely than the retired

--- a/swifttunnel-core/src/bin/ip_checker.rs
+++ b/swifttunnel-core/src/bin/ip_checker.rs
@@ -1,8 +1,9 @@
 mod testbench_shared;
 
 use testbench_shared::{
-    DEFAULT_UDP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS, DEFAULT_UDP_PROBE_TARGET,
-    get_public_ip, init_logging, run_udp_probe,
+    DEFAULT_TCP_PROBE_COUNT, DEFAULT_TCP_PROBE_TARGET, DEFAULT_UDP_PROBE_COUNT,
+    DEFAULT_UDP_PROBE_STARTUP_DELAY_MS, DEFAULT_UDP_PROBE_TARGET, get_public_ip, init_logging,
+    run_tcp_probe, run_udp_probe,
 };
 
 fn print_usage() {
@@ -12,6 +13,10 @@ fn print_usage() {
     println!(
         "  ip_checker.exe --udp-probe [--target {}] [--count {}] [--startup-delay-ms {}] [--port-file path]",
         DEFAULT_UDP_PROBE_TARGET, DEFAULT_UDP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS
+    );
+    println!(
+        "  ip_checker.exe --tcp-probe [--target {}] [--count {}] [--startup-delay-ms {}] [--port-file path]",
+        DEFAULT_TCP_PROBE_TARGET, DEFAULT_TCP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS
     );
 }
 
@@ -94,6 +99,79 @@ fn main() {
             std::process::exit(1);
         }
         println!("UDP probe complete: target={} count={}", target, count);
+        return;
+    }
+
+    if args.iter().any(|arg| arg == "--tcp-probe") {
+        let mut target = DEFAULT_TCP_PROBE_TARGET.to_string();
+        let mut count = DEFAULT_TCP_PROBE_COUNT;
+        let mut startup_delay_ms = DEFAULT_UDP_PROBE_STARTUP_DELAY_MS;
+        let mut port_file = None;
+        let mut idx = 0usize;
+
+        while idx < args.len() {
+            match args[idx].as_str() {
+                "--tcp-probe" => idx += 1,
+                "--target" => {
+                    idx += 1;
+                    let Some(value) = args.get(idx) else {
+                        eprintln!("Missing value for --target");
+                        std::process::exit(2);
+                    };
+                    target = value.clone();
+                    idx += 1;
+                }
+                "--count" => {
+                    idx += 1;
+                    let Some(value) = args.get(idx) else {
+                        eprintln!("Missing value for --count");
+                        std::process::exit(2);
+                    };
+                    match value.parse::<usize>() {
+                        Ok(parsed) => count = parsed,
+                        Err(_) => {
+                            eprintln!("Invalid integer for --count: {}", value);
+                            std::process::exit(2);
+                        }
+                    }
+                    idx += 1;
+                }
+                "--startup-delay-ms" => {
+                    idx += 1;
+                    let Some(value) = args.get(idx) else {
+                        eprintln!("Missing value for --startup-delay-ms");
+                        std::process::exit(2);
+                    };
+                    match value.parse::<u64>() {
+                        Ok(parsed) => startup_delay_ms = parsed,
+                        Err(_) => {
+                            eprintln!("Invalid integer for --startup-delay-ms: {}", value);
+                            std::process::exit(2);
+                        }
+                    }
+                    idx += 1;
+                }
+                "--port-file" => {
+                    idx += 1;
+                    let Some(value) = args.get(idx) else {
+                        eprintln!("Missing value for --port-file");
+                        std::process::exit(2);
+                    };
+                    port_file = Some(std::path::PathBuf::from(value));
+                    idx += 1;
+                }
+                other => {
+                    eprintln!("Unknown argument: {}", other);
+                    std::process::exit(2);
+                }
+            }
+        }
+
+        if let Err(err) = run_tcp_probe(&target, count, startup_delay_ms, port_file.as_deref()) {
+            eprintln!("TCP probe failed: {}", err);
+            std::process::exit(1);
+        }
+        println!("TCP probe complete: target={} count={}", target, count);
         return;
     }
 

--- a/swifttunnel-core/src/bin/split_tunnel_integration_test.rs
+++ b/swifttunnel-core/src/bin/split_tunnel_integration_test.rs
@@ -154,7 +154,7 @@ async fn run_connected_checks(
         udp_target,
         udp_count
     );
-    let mut child = Command::new(&test_exe)
+    let child = Command::new(&test_exe)
         .args([
             "--udp-probe",
             "--target",
@@ -244,7 +244,7 @@ async fn run_tcp_api_probe_check(
         DEFAULT_TCP_PROBE_TARGET,
         DEFAULT_TCP_PROBE_COUNT
     );
-    let mut child = Command::new(&test_exe)
+    let child = Command::new(&test_exe)
         .args([
             "--tcp-probe",
             "--target",

--- a/swifttunnel-core/src/bin/split_tunnel_integration_test.rs
+++ b/swifttunnel-core/src/bin/split_tunnel_integration_test.rs
@@ -5,11 +5,12 @@ use std::process::Command;
 use std::time::Duration;
 
 use swifttunnel_core::settings::load_settings;
-use swifttunnel_core::vpn::VpnConnection;
+use swifttunnel_core::vpn::{SplitTunnelDiagnostics, VpnConnection};
 use testbench_shared::{
-    DEFAULT_UDP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS, DEFAULT_UDP_PROBE_TARGET,
-    connect_vpn, get_public_ip, init_logging, parse_common_cli_options, print_diagnostics,
-    print_preflight_summary, resolve_binding_preference, resolve_region, resolve_test_exe,
+    DEFAULT_TCP_PROBE_COUNT, DEFAULT_TCP_PROBE_TARGET, DEFAULT_UDP_PROBE_COUNT,
+    DEFAULT_UDP_PROBE_STARTUP_DELAY_MS, DEFAULT_UDP_PROBE_TARGET, connect_vpn, get_public_ip,
+    init_logging, parse_common_cli_options, print_diagnostics, print_preflight_summary,
+    resolve_binding_preference, resolve_enable_api_tunneling, resolve_region, resolve_test_exe,
 };
 
 fn print_usage() {
@@ -81,13 +82,15 @@ async fn main() {
     println!("Baseline IP: {}", baseline_ip);
 
     let settings = load_settings();
+    let api_tunneling_enabled = resolve_enable_api_tunneling(&options, &settings);
     let mut vpn = VpnConnection::new();
     if let Err(err) = connect_vpn(&mut vpn, &options, &settings, binding_preference).await {
         eprintln!("FAIL: vpn connect failed: {}", err);
         std::process::exit(1);
     }
 
-    let result = run_connected_checks(&mut vpn, &options, &baseline_ip).await;
+    let result =
+        run_connected_checks(&mut vpn, &options, &baseline_ip, api_tunneling_enabled).await;
 
     if let Err(err) = vpn.disconnect().await {
         eprintln!("WARN: vpn disconnect failed: {}", err);
@@ -105,6 +108,7 @@ async fn run_connected_checks(
     vpn: &mut VpnConnection,
     options: &testbench_shared::CommonCliOptions,
     baseline_ip: &str,
+    api_tunneling_enabled: bool,
 ) -> Result<(), String> {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
@@ -203,6 +207,93 @@ async fn run_connected_checks(
     if after.packets_tunneled <= before.packets_tunneled {
         return Err(format!(
             "expected tunneled packet counter to increase (before={}, after={})",
+            before.packets_tunneled, after.packets_tunneled
+        ));
+    }
+
+    if api_tunneling_enabled {
+        run_tcp_api_probe_check(vpn, options, &after).await?;
+    } else {
+        println!("Skipping TCP/API probe because API tunneling is disabled");
+    }
+
+    Ok(())
+}
+
+async fn run_tcp_api_probe_check(
+    vpn: &mut VpnConnection,
+    options: &testbench_shared::CommonCliOptions,
+    before: &SplitTunnelDiagnostics,
+) -> Result<(), String> {
+    let test_exe = resolve_test_exe(options)?;
+    let startup_delay_ms = DEFAULT_UDP_PROBE_STARTUP_DELAY_MS.to_string();
+    let port_file = std::env::temp_dir().join(format!(
+        "swifttunnel-probe-tcp-port-{}-{}.txt",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or_default()
+    ));
+    let port_file_arg = port_file.display().to_string();
+    let _ = std::fs::remove_file(&port_file);
+
+    println!(
+        "Running tunneled TCP/API probe via {} to {} ({} writes)",
+        test_exe.display(),
+        DEFAULT_TCP_PROBE_TARGET,
+        DEFAULT_TCP_PROBE_COUNT
+    );
+    let mut child = Command::new(&test_exe)
+        .args([
+            "--tcp-probe",
+            "--target",
+            DEFAULT_TCP_PROBE_TARGET,
+            "--count",
+            &DEFAULT_TCP_PROBE_COUNT.to_string(),
+            "--startup-delay-ms",
+            &startup_delay_ms,
+            "--port-file",
+            &port_file_arg,
+        ])
+        .spawn()
+        .map_err(|e| format!("failed to spawn TCP probe executable: {}", e))?;
+
+    let child_pid = child.id();
+    println!("TCP probe helper PID: {}", child_pid);
+    vpn.register_tunnel_process(child_pid, "ip_checker.exe")
+        .await
+        .map_err(|e| format!("failed to register TCP probe process for tunneling: {}", e))?;
+
+    let local_port = wait_for_probe_port(&port_file)?;
+    println!("TCP probe helper local port: {}", local_port);
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("failed to wait for TCP probe executable: {}", e))?;
+    let _ = std::fs::remove_file(&port_file);
+
+    if !output.status.success() {
+        return Err(format!(
+            "TCP probe executable failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    if !output.stdout.is_empty() {
+        println!("{}", String::from_utf8_lossy(&output.stdout).trim());
+    }
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let after = vpn
+        .get_split_tunnel_diagnostics()
+        .ok_or_else(|| "missing split tunnel diagnostics after TCP probe".to_string())?;
+    print_diagnostics(&after);
+
+    if after.packets_tunneled <= before.packets_tunneled {
+        return Err(format!(
+            "expected TCP/API probe to increase tunneled packet counter (before={}, after={})",
             before.packets_tunneled, after.packets_tunneled
         ));
     }

--- a/swifttunnel-core/src/bin/testbench_shared/mod.rs
+++ b/swifttunnel-core/src/bin/testbench_shared/mod.rs
@@ -14,6 +14,8 @@ pub const DEFAULT_REGION: &str = "singapore";
 pub const DEFAULT_UDP_PROBE_TARGET: &str = "128.116.1.1:49152";
 pub const DEFAULT_UDP_PROBE_COUNT: usize = 32;
 pub const DEFAULT_UDP_PROBE_STARTUP_DELAY_MS: u64 = 1500;
+pub const DEFAULT_TCP_PROBE_TARGET: &str = "www.roblox.com:80";
+pub const DEFAULT_TCP_PROBE_COUNT: usize = 5;
 
 #[derive(Debug, Clone, Default)]
 pub struct CommonCliOptions {
@@ -334,6 +336,72 @@ pub fn run_udp_probe(
             .send_to(payload.as_bytes(), addr)
             .map_err(|e| format!("UDP send failed: {}", e))?;
         std::thread::sleep(Duration::from_millis(30));
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    Ok(())
+}
+
+pub fn run_tcp_probe(
+    target: &str,
+    count: usize,
+    startup_delay_ms: u64,
+    port_file: Option<&std::path::Path>,
+) -> Result<(), String> {
+    let addr = target
+        .to_socket_addrs()
+        .map_err(|e| format!("TCP target resolution failed for '{}': {}", target, e))?
+        .next()
+        .ok_or_else(|| format!("TCP target '{}' did not resolve to any address", target))?;
+
+    // Give the parent process time to register the helper PID before any TCP
+    // SYN is emitted.
+    std::thread::sleep(Duration::from_millis(startup_delay_ms));
+
+    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_secs(5))
+        .map_err(|e| format!("TCP connect to '{}' failed: {}", target, e))?;
+    stream
+        .set_write_timeout(Some(Duration::from_millis(750)))
+        .map_err(|e| format!("Failed to set TCP write timeout: {}", e))?;
+
+    let local_port = stream
+        .local_addr()
+        .map_err(|e| format!("Failed to query TCP local address: {}", e))?
+        .port();
+
+    if let Some(path) = port_file {
+        std::fs::write(path, local_port.to_string())
+            .map_err(|e| format!("Failed to write TCP port file '{}': {}", path.display(), e))?;
+    }
+
+    // Keep the connection established long enough for the cache refresher to
+    // observe and publish the TCP source port, then emit payload packets.
+    std::thread::sleep(Duration::from_millis(startup_delay_ms));
+
+    let host = target
+        .rsplit_once(':')
+        .map(|(host, _)| host.trim_matches(['[', ']']))
+        .unwrap_or(target);
+    let http_chunks = [
+        "GET / HTTP/1.1\r\n".to_string(),
+        format!("Host: {}\r\n", host),
+        "User-Agent: SwiftTunnel-Testbench/1.0\r\n".to_string(),
+        "Connection: close\r\n".to_string(),
+        "\r\n".to_string(),
+    ];
+
+    for idx in 0..count {
+        let payload: std::borrow::Cow<'_, str> = if addr.port() == 80 && idx < http_chunks.len() {
+            std::borrow::Cow::Borrowed(http_chunks[idx].as_str())
+        } else {
+            std::borrow::Cow::Owned(format!("SwiftTunnel TCP probe {}\r\n", idx))
+        };
+        if let Err(err) = stream.write_all(payload.as_bytes()) {
+            log::warn!("TCP probe write stopped after {} packet(s): {}", idx, err);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
     }
 
     std::thread::sleep(Duration::from_millis(500));

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -189,7 +189,7 @@ thread_local! {
     static PACKET_BUFFER: RefCell<[u8; MAX_PACKET_SIZE]> = RefCell::new([0u8; MAX_PACKET_SIZE]);
 }
 
-use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
 use windows::Win32::NetworkManagement::IpHelper::{GetAdaptersInfo, IP_ADAPTER_INFO};
 use windows::Win32::System::Threading::{
     CreateEventW, ResetEvent, SetThreadAffinityMask, WaitForSingleObject,
@@ -4596,8 +4596,60 @@ fn run_packet_reader(
         // Using 100ms timeout allows responsive stop_flag checking while
         // avoiding 1000Hz polling that wastes CPU when idle
         // (When packets arrive, event signals immediately - no added latency)
-        unsafe {
-            WaitForSingleObject(b.event, 100);
+        let wait_result = unsafe { WaitForSingleObject(b.event, 100) };
+        if wait_result == WAIT_TIMEOUT {
+            // A timeout is the normal idle path. Do not call read_packets()
+            // with an empty queue: WinpkFilter can report ERROR_INVALID_PARAMETER
+            // for that case, which is not a stale driver handle.
+            let prior = rebind.record_success();
+            if prior > 0 {
+                log::info!(
+                    "Reader: recovered after {} rebind attempt(s) - packet event wait is healthy",
+                    prior
+                );
+            }
+            continue;
+        }
+
+        if wait_result == WAIT_FAILED {
+            let e = windows::core::Error::from_win32();
+            match rebind.record_error(stop_flag.load(Ordering::Acquire)) {
+                RebindDecision::Stop => break,
+                RebindDecision::Fatal => {
+                    log::error!(
+                        "Reader: packet event wait failed ({}); rebind budget ({}) exhausted, stopping reader loop",
+                        e,
+                        READER_MAX_REBINDS
+                    );
+                    stop_flag.store(true, Ordering::Release);
+                    return Err(VpnError::SplitTunnel(format!(
+                        "packet event wait failed after {} rebinds: {}",
+                        READER_MAX_REBINDS, e
+                    )));
+                }
+                RebindDecision::Backoff(backoff) => {
+                    log::warn!(
+                        "Reader: packet event wait failed ({}); rebind attempt {}/{} after {}ms backoff",
+                        e,
+                        rebind.attempts(),
+                        READER_MAX_REBINDS,
+                        backoff.as_millis()
+                    );
+                    bindings = None;
+                    if interruptible_sleep(backoff, &stop_flag) {
+                        break;
+                    }
+                    continue;
+                }
+            }
+        }
+
+        if wait_result != WAIT_OBJECT_0 {
+            log::warn!(
+                "Reader: unexpected packet event wait result: {:?}",
+                wait_result
+            );
+            continue;
         }
 
         // Read batch of packets
@@ -4606,12 +4658,9 @@ fn run_packet_reader(
         let packets_read = match b.driver.read_packets::<BATCH_SIZE>(&mut to_read) {
             Ok(n) => {
                 // A successful read_packets IOCTL is itself the signal that
-                // the handle is healthy — `Ok(0)` (WaitForSingleObject timed
-                // out, no queued packets) is the dominant state on idle
-                // adapters, so requiring `n > 0` to reset would let the
-                // counter survive across hours of idle between transient
-                // glitches and ultimately tear down the tunnel on a single
-                // unrelated blip.
+                // the handle is healthy. `Ok(0)` is also benign here: the
+                // event can race with another reader/drain boundary, but the
+                // IOCTL still succeeded.
                 let prior = rebind.record_success();
                 if prior > 0 {
                     log::info!(

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -4612,7 +4612,7 @@ fn run_packet_reader(
         }
 
         if wait_result == WAIT_FAILED {
-            let e = windows::core::Error::from_win32();
+            let e = windows::core::Error::from_thread();
             match rebind.record_error(stop_flag.load(Ordering::Acquire)) {
                 RebindDecision::Stop => break,
                 RebindDecision::Fatal => {

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -3649,14 +3649,27 @@ impl ParallelInterceptor {
         let refresher_cache = Arc::clone(&self.process_cache);
         let refresh_now = Arc::clone(&self.refresh_now_flag);
         let refresh_condvar = Arc::clone(&self.refresh_condvar);
+        let refresher_api_tunneling = Arc::clone(&self.api_tunneling_enabled);
+        let (initial_refresh_tx, initial_refresh_rx) = crossbeam_channel::bounded::<()>(1);
         self.refresher_handle = Some(thread::spawn(move || {
             run_cache_refresher(
                 refresher_cache,
                 refresher_stop,
                 refresh_now,
                 refresh_condvar,
+                refresher_api_tunneling,
+                Some(initial_refresh_tx),
             );
         }));
+
+        if initial_refresh_rx
+            .recv_timeout(Duration::from_millis(750))
+            .is_err()
+        {
+            log::warn!(
+                "Cache refresher initial warmup did not complete before packet reader start"
+            );
+        }
 
         // Reset throughput stats on start
         self.throughput_stats.reset();
@@ -5183,6 +5196,48 @@ fn send_bypass_packet(
     }
 }
 
+/// Collect TCP source ports owned by tunnel processes for API tunneling.
+fn collect_tunnel_tcp_ports_for_api_tunneling(
+    connections: &ahash::AHashMap<ConnectionKey, u32>,
+    pid_names: &ahash::AHashMap<u32, String>,
+    tunnel_apps: &ahash::AHashSet<String>,
+) -> Vec<u16> {
+    if tunnel_apps.is_empty() {
+        return Vec::new();
+    }
+
+    let tunnel_pids: ahash::AHashSet<u32> = pid_names
+        .iter()
+        .filter_map(|(pid, name)| {
+            let name_lower = name.to_lowercase();
+            if tunnel_apps.contains(&name_lower)
+                || process_name_matches_any_tunnel_app(&name_lower, tunnel_apps)
+            {
+                Some(*pid)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if tunnel_pids.is_empty() {
+        return Vec::new();
+    }
+
+    let ports: ahash::AHashSet<u16> = connections
+        .iter()
+        .filter_map(|(key, pid)| {
+            if key.protocol == Protocol::Tcp && tunnel_pids.contains(pid) {
+                Some(key.local_port)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    ports.into_iter().collect()
+}
+
 /// Cache refresher thread - single writer
 ///
 /// OPTIMIZATION: Event-driven refresh instead of polling
@@ -5194,6 +5249,8 @@ fn run_cache_refresher(
     stop_flag: Arc<AtomicBool>,
     refresh_now: Arc<AtomicBool>,
     refresh_condvar: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+    api_tunneling_enabled: Arc<AtomicBool>,
+    mut initial_refresh_done: Option<crossbeam_channel::Sender<()>>,
 ) {
     use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
     use windows::Win32::NetworkManagement::IpHelper::*;
@@ -5462,7 +5519,17 @@ fn run_cache_refresher(
 
         // Update cache atomically. The snapshot precomputes tunnel-owned source ports
         // so readers don't need to linearly scan the connection map on a miss.
-        cache.update(connections, pid_names);
+        if api_tunneling_enabled.load(Ordering::Relaxed) {
+            let explicit_tcp_ports =
+                collect_tunnel_tcp_ports_for_api_tunneling(&connections, &pid_names, tunnel_apps);
+            cache.update_with_tcp_ports(connections, pid_names, &explicit_tcp_ports);
+        } else {
+            cache.update_with_tcp_ports(connections, pid_names, &[]);
+        }
+
+        if let Some(done) = initial_refresh_done.take() {
+            let _ = done.send(());
+        }
 
         // Log tunnel app detection periodically
         refresh_count += 1;
@@ -9108,6 +9175,60 @@ mod tests {
             true,
         ));
         assert!(cache_with_api.contains_key(&(packet_ip, src_port, Protocol::Tcp)));
+    }
+
+    #[test]
+    fn test_api_tunneling_collects_and_publishes_roblox_tcp_ports() {
+        let roblox_pid = 1111;
+        let chrome_pid = 2222;
+        let roblox_port = 53001;
+        let chrome_port = 53002;
+        let roblox_udp_port = 53003;
+
+        let mut connections = HashMap::new();
+        connections.insert(
+            ConnectionKey::new(Ipv4Addr::new(10, 0, 0, 10), roblox_port, Protocol::Tcp),
+            roblox_pid,
+        );
+        connections.insert(
+            ConnectionKey::new(Ipv4Addr::new(10, 0, 0, 11), chrome_port, Protocol::Tcp),
+            chrome_pid,
+        );
+        connections.insert(
+            ConnectionKey::new(Ipv4Addr::new(10, 0, 0, 10), roblox_udp_port, Protocol::Udp),
+            roblox_pid,
+        );
+
+        let mut pid_names = HashMap::new();
+        pid_names.insert(roblox_pid, "RobloxApp.exe".to_string());
+        pid_names.insert(chrome_pid, "chrome.exe".to_string());
+
+        let tunnel_apps: HashSet<String> =
+            ["robloxplayerbeta.exe".to_string()].into_iter().collect();
+        let mut ports =
+            collect_tunnel_tcp_ports_for_api_tunneling(&connections, &pid_names, &tunnel_apps);
+        ports.sort_unstable();
+        assert_eq!(ports, vec![roblox_port]);
+
+        let cache = LockFreeProcessCache::new(vec!["robloxplayerbeta.exe".to_string()]);
+        cache.update_with_tcp_ports(connections, pid_names, &ports);
+
+        let snapshot = cache.get_snapshot();
+        let frame = build_ipv4_frame(
+            6,
+            Ipv4Addr::new(10, 0, 0, 99),
+            Ipv4Addr::new(128, 116, 50, 100),
+            roblox_port,
+            443,
+        );
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(should_route_to_vpn_with_inline_cache(
+            &frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -264,9 +264,10 @@ impl ProcessSnapshot {
         connections: &AHashMap<ConnectionKey, u32>,
         tunnel_pids: &AHashSet<u32>,
         explicit_tunnel_udp_ports: &AHashSet<u16>,
+        explicit_tunnel_tcp_ports: &AHashSet<u16>,
     ) -> (AHashSet<u16>, AHashSet<u16>) {
         let mut tunnel_udp_ports = explicit_tunnel_udp_ports.clone();
-        let mut tunnel_tcp_ports = AHashSet::new();
+        let mut tunnel_tcp_ports = explicit_tunnel_tcp_ports.clone();
 
         for (key, pid) in connections {
             if !tunnel_pids.contains(pid) {
@@ -513,6 +514,7 @@ impl LockFreeProcessCache {
             &connections,
             &tunnel_pids,
             &explicit_tunnel_udp_ports,
+            &explicit_tunnel_tcp_ports,
         );
 
         Arc::new(ProcessSnapshot {
@@ -717,15 +719,34 @@ impl LockFreeProcessCache {
     /// Persists TCP ports across snapshot refreshes so they don't rely on
     /// stale connection-table lookups.
     pub fn register_tcp_ports(&self, ports: &[u16]) {
-        let mut guard = self.explicit_tunnel_tcp_ports.lock();
-        let new_set: AHashSet<u16> = ports.iter().copied().collect();
-        if *guard != new_set {
+        let explicit_tunnel_tcp_ports = {
+            let mut guard = self.explicit_tunnel_tcp_ports.lock();
+            let new_set: AHashSet<u16> = ports.iter().copied().collect();
+            if *guard == new_set {
+                return;
+            }
+
             log::info!(
                 "Updated TCP ports for API tunneling: {} port(s)",
                 new_set.len()
             );
             *guard = new_set;
-        }
+            guard.clone()
+        };
+
+        // Rebuild snapshot immediately so packet workers can use the new port
+        // ownership map without waiting for the next cache refresh cycle.
+        let old_snap = self.get_snapshot();
+        let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
+        let explicit_tunnel_udp_ports = self.explicit_tunnel_udp_ports.lock().clone();
+        let new_snapshot = self.snapshot_from_parts(
+            old_snap.connections.clone(),
+            old_snap.pid_names.clone(),
+            version,
+            explicit_tunnel_udp_ports,
+            explicit_tunnel_tcp_ports,
+        );
+        self.current.store(new_snapshot);
     }
 }
 
@@ -1206,5 +1227,38 @@ mod tests {
             443,
             true,
         ));
+    }
+
+    #[test]
+    fn test_register_tcp_ports_applies_immediately_and_persists() {
+        let cache = LockFreeProcessCache::new(vec!["roblox".to_string()]);
+
+        // No connection metadata yet, but API tunnel TCP ports are explicitly known.
+        cache.register_tcp_ports(&[443, 50000]);
+        let first_snapshot = cache.get_snapshot();
+        let first_version = first_snapshot.version;
+
+        assert!(first_snapshot.should_tunnel_by_port_fallback(443, Protocol::Tcp, true));
+        assert!(first_snapshot.should_tunnel_by_port_fallback(50000, Protocol::Tcp, true));
+        assert!(!first_snapshot.should_tunnel_by_port_fallback(443, Protocol::Tcp, false));
+        drop(first_snapshot);
+
+        // Calling with the same set should not force another snapshot rebuild.
+        cache.register_tcp_ports(&[443, 50000]);
+        assert_eq!(cache.get_snapshot().version, first_version);
+
+        // Regular cache updates must preserve explicitly registered TCP ports.
+        let mut connections = HashMap::new();
+        connections.insert(
+            ConnectionKey::new(Ipv4Addr::new(10, 0, 0, 20), 55000, Protocol::Udp),
+            9001,
+        );
+        let mut pid_names = HashMap::new();
+        pid_names.insert(9001, "RobloxPlayerBeta.exe".to_string());
+        cache.update(connections, pid_names);
+
+        let updated = cache.get_snapshot();
+        assert!(updated.should_tunnel_by_port_fallback(443, Protocol::Tcp, true));
+        assert!(updated.should_tunnel_by_port_fallback(50000, Protocol::Tcp, true));
     }
 }

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -483,6 +483,9 @@ pub struct LockFreeProcessCache {
     version: AtomicU64,
     /// Apps to tunnel
     tunnel_apps: AHashSet<String>,
+    /// Serializes snapshot writers so immediate registrations cannot publish
+    /// stale connection data over a fresher cache refresh.
+    snapshot_write_lock: Mutex<()>,
     /// UDP ports explicitly registered as tunnel-owned.
     explicit_tunnel_udp_ports: Mutex<AHashSet<u16>>,
     /// TCP ports explicitly registered as tunnel-owned (API tunneling).
@@ -540,6 +543,7 @@ impl LockFreeProcessCache {
             current: ArcSwap::from(initial),
             version: AtomicU64::new(0),
             tunnel_apps: apps,
+            snapshot_write_lock: Mutex::new(()),
             explicit_tunnel_udp_ports: Mutex::new(AHashSet::new()),
             explicit_tunnel_tcp_ports: Mutex::new(AHashSet::new()),
         }
@@ -574,6 +578,7 @@ impl LockFreeProcessCache {
         connections: AHashMap<ConnectionKey, u32>,
         pid_names: AHashMap<u32, String>,
     ) {
+        let _snapshot_write_guard = self.snapshot_write_lock.lock();
         let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
         let (explicit_tunnel_udp_ports, explicit_tunnel_tcp_ports) = self.clone_explicit_ports();
         let new_snapshot = self.snapshot_from_parts(
@@ -588,6 +593,32 @@ impl LockFreeProcessCache {
         self.current.store(new_snapshot);
     }
 
+    /// Update snapshot and explicit API TCP ports in a single publication.
+    ///
+    /// The cache refresher uses this when API tunneling is enabled so packet
+    /// workers never observe a new connection table without the matching
+    /// tunnel-owned TCP source ports.
+    pub fn update_with_tcp_ports(
+        &self,
+        connections: AHashMap<ConnectionKey, u32>,
+        pid_names: AHashMap<u32, String>,
+        tcp_ports: &[u16],
+    ) {
+        let _snapshot_write_guard = self.snapshot_write_lock.lock();
+        let explicit_tunnel_tcp_ports = self.replace_explicit_tcp_ports_locked(tcp_ports);
+        let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
+        let explicit_tunnel_udp_ports = self.explicit_tunnel_udp_ports.lock().clone();
+        let new_snapshot = self.snapshot_from_parts(
+            connections,
+            pid_names,
+            version,
+            explicit_tunnel_udp_ports,
+            explicit_tunnel_tcp_ports,
+        );
+
+        self.current.store(new_snapshot);
+    }
+
     /// Update tunnel apps list and immediately refresh the snapshot
     ///
     /// CRITICAL: This must create a new snapshot immediately, otherwise workers
@@ -598,6 +629,7 @@ impl LockFreeProcessCache {
             return;
         }
         self.tunnel_apps = new_apps;
+        let _snapshot_write_guard = self.snapshot_write_lock.lock();
 
         // Force immediate snapshot update so workers see the new tunnel_apps
         // Clone the current connections and pid_names from existing snapshot
@@ -647,6 +679,7 @@ impl LockFreeProcessCache {
     /// 2. We add PID → name mapping here
     /// 3. When first packet arrives, is_tunnel_pid() returns true
     pub fn register_process_immediate(&self, pid: u32, name: String) {
+        let _snapshot_write_guard = self.snapshot_write_lock.lock();
         let old_snap = self.get_snapshot();
         let name_lower = name.to_lowercase();
         if old_snap
@@ -684,6 +717,7 @@ impl LockFreeProcessCache {
     /// This is used by the Windows testbench helper so packet routing does not depend
     /// on connection-table timing races for short-lived probe processes.
     pub fn register_udp_port_immediate(&self, local_port: u16) {
+        let _snapshot_write_guard = self.snapshot_write_lock.lock();
         let explicit_tunnel_udp_ports = {
             let mut ports = self.explicit_tunnel_udp_ports.lock();
             if !ports.insert(local_port) {
@@ -719,6 +753,7 @@ impl LockFreeProcessCache {
     /// Persists TCP ports across snapshot refreshes so they don't rely on
     /// stale connection-table lookups.
     pub fn register_tcp_ports(&self, ports: &[u16]) {
+        let _snapshot_write_guard = self.snapshot_write_lock.lock();
         let explicit_tunnel_tcp_ports = {
             let mut guard = self.explicit_tunnel_tcp_ports.lock();
             let new_set: AHashSet<u16> = ports.iter().copied().collect();
@@ -747,6 +782,19 @@ impl LockFreeProcessCache {
             explicit_tunnel_tcp_ports,
         );
         self.current.store(new_snapshot);
+    }
+
+    fn replace_explicit_tcp_ports_locked(&self, ports: &[u16]) -> AHashSet<u16> {
+        let mut guard = self.explicit_tunnel_tcp_ports.lock();
+        let new_set: AHashSet<u16> = ports.iter().copied().collect();
+        if *guard != new_set {
+            log::info!(
+                "Updated TCP ports for API tunneling: {} port(s)",
+                new_set.len()
+            );
+            *guard = new_set;
+        }
+        guard.clone()
     }
 }
 
@@ -1260,5 +1308,24 @@ mod tests {
         let updated = cache.get_snapshot();
         assert!(updated.should_tunnel_by_port_fallback(443, Protocol::Tcp, true));
         assert!(updated.should_tunnel_by_port_fallback(50000, Protocol::Tcp, true));
+    }
+
+    #[test]
+    fn test_update_with_tcp_ports_publishes_connections_and_explicit_ports_together() {
+        let cache = LockFreeProcessCache::new(vec!["roblox".to_string()]);
+        let mut connections = HashMap::new();
+        connections.insert(
+            ConnectionKey::new(Ipv4Addr::new(10, 0, 0, 20), 53000, Protocol::Tcp),
+            9001,
+        );
+        let mut pid_names = HashMap::new();
+        pid_names.insert(9001, "RobloxPlayerBeta.exe".to_string());
+
+        cache.update_with_tcp_ports(connections, pid_names, &[443]);
+
+        let snap = cache.get_snapshot();
+        assert!(snap.should_tunnel(Ipv4Addr::new(10, 0, 0, 20), 53000, Protocol::Tcp));
+        assert!(snap.should_tunnel_by_port_fallback(443, Protocol::Tcp, true));
+        assert!(snap.should_tunnel_by_port_fallback(53000, Protocol::Tcp, true));
     }
 }


### PR DESCRIPTION
### Motivation
- Explicit TCP ports used for Roblox API tunneling were being stored but not merged into the snapshot's `tunnel_tcp_ports`, causing API TCP fallback ownership to be dropped after snapshot rebuilds and breaking TCP API tunneling.
- Packet workers also needed to observe TCP port ownership immediately when the set changes to avoid routing races.

### Description
- Seed `tunnel_tcp_ports` from the explicitly-registered TCP set by adding `explicit_tunnel_tcp_ports` to `ProcessSnapshot::compute_tunnel_ports` and plumbing it through `snapshot_from_parts` and callers.
- Update `register_tcp_ports` to deduplicate no-op updates and to rebuild and publish a new snapshot immediately when the TCP set changes so workers pick up the new ownership map right away.
- Add a regression test `test_register_tcp_ports_applies_immediately_and_persists` verifying immediate fallback behavior, no redundant snapshot rebuild on duplicate updates, and persistence of explicit TCP ports across later `update` calls.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded.
- Attempted `cargo test -p swifttunnel-core test_register_tcp_ports_applies_immediately_and_persists -- --nocapture` but the build aborted on this Linux CI image due to upstream `windows-future`/`windows-core` dependency compilation errors before crate tests could execute; the new unit test is present and should pass in an environment where those platform bindings compile (Windows or a compatible toolchain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5d7fa7708329be3ba4b141397b19)