### PR TITLE
Repair WinpkFilter adapter binding automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ on:
       - "Cargo.toml"
       - ".github/workflows/ci.yml"
       - ".github/workflows/release.yml"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   frontend:
@@ -101,8 +106,48 @@ jobs:
       - name: Test desktop backend
         run: cargo test -p swifttunnel-desktop -- --nocapture
 
+  split-tunnel-testbench-availability:
+    name: Split Tunnel Testbench Availability
+    runs-on: ubuntu-latest
+    outputs:
+      runner_available: ${{ steps.runner.outputs.available }}
+
+    steps:
+      - name: Check for an online testbench runner
+        id: runner
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          set +e
+          matching_runner_count="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runners" \
+              --jq '.runners[] | select(.status == "online") | select(([.labels[].name] | contains(["self-hosted", "Windows", "X64", "testbench"]))) | .id' \
+              | wc -l \
+              | tr -d ' '
+          )"
+          api_status=$?
+          set -e
+
+          if [[ "$api_status" -ne 0 ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Could not query self-hosted runners; skipping split tunnel testbench instead of queuing indefinitely."
+            exit 0
+          fi
+
+          if [[ "$matching_runner_count" -gt 0 ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Found $matching_runner_count online split tunnel testbench runner(s)."
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No online split tunnel testbench runner found; skipping split tunnel testbench instead of queuing indefinitely."
+          fi
+
   split-tunnel-testbench:
     name: Split Tunnel Testbench (Windows)
+    needs: split-tunnel-testbench-availability
+    if: needs.split-tunnel-testbench-availability.outputs.runner_available == 'true'
     runs-on: [self-hosted, Windows, X64, testbench]
     timeout-minutes: 45
 

--- a/swifttunnel-core/src/vpn/error_messages.rs
+++ b/swifttunnel-core/src/vpn/error_messages.rs
@@ -30,6 +30,10 @@ pub fn user_friendly_error(error: &VpnError) -> String {
                 "Administrator privileges required.\n\nPlease run SwiftTunnel as Administrator.".to_string()
             } else if lc.contains("no ndis adapter matched the default-route interface index") {
                 "SwiftTunnel couldn't detect your active network adapter for split tunneling.\n\nGo to Settings -> VPN -> Network Adapter, select your Wi-Fi/Ethernet adapter, then reconnect.\n\nThis can happen if another VPN, network bridge, or virtual adapter owns the default route.".to_string()
+            } else if lc.contains("winpkfilter_binding_missing")
+                || (lc.contains("nt_ndisrd") && lc.contains("not bound to adapter"))
+            {
+                "Split tunnel driver binding is missing on the active network adapter.\n\nSwiftTunnel can repair this automatically. Use Repair driver, then reconnect.".to_string()
             } else if lc.contains("internet interface") || lc.contains("no default gateway") {
                 "No internet connection detected.\n\nPlease check your network connection and try again.".to_string()
             } else {
@@ -189,6 +193,16 @@ mod tests {
         let msg = user_friendly_error(&error);
         assert!(msg.contains("Settings"));
         assert!(msg.contains("Network Adapter"));
+    }
+
+    #[test]
+    fn test_user_friendly_winpkfilter_binding_missing_is_concise() {
+        let error = VpnError::SplitTunnelSetupFailed(
+            "Failed to configure V3 split tunnel: Split tunnel driver error: winpkfilter_binding_missing: nt_ndisrd is not bound to adapter 'Ethernet'.".to_string(),
+        );
+        let msg = user_friendly_error(&error);
+        assert!(msg.contains("driver binding is missing"));
+        assert!(!msg.contains("Failed to configure V3 split tunnel"));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -250,6 +250,7 @@ enum BindingStage {
     ExactRouteMatch,
     ManualPreference,
     RememberedOverride,
+    WinpkFilterBindingMissing,
     WanFallback,
     BridgeSibling,
     RouteOwnerFallback,
@@ -264,6 +265,7 @@ impl BindingStage {
             Self::ExactRouteMatch => "exact_route_match",
             Self::ManualPreference => "manual_preference",
             Self::RememberedOverride => "remembered_override",
+            Self::WinpkFilterBindingMissing => "winpkfilter_binding_missing",
             Self::WanFallback => "wan_fallback",
             Self::BridgeSibling => "bridge_sibling",
             Self::RouteOwnerFallback => "route_owner_fallback",
@@ -2652,20 +2654,74 @@ impl ParallelInterceptor {
             BindingStage::Unrecoverable
         };
 
+        let default_route_binding_missing = default_route_binding_error
+            .as_ref()
+            .is_some_and(|err| Self::is_winpkfilter_binding_missing_failure(&err.to_string()));
+
         if selected.is_none() && physical_candidates.is_empty() {
-            self.binding_stage = BindingStage::Unrecoverable.as_str().to_string();
-            self.binding_reason =
-                "SwiftTunnel could not see any WinpkFilter-bound network adapters. Repair the split tunnel driver, then try again.".to_string();
-            self.last_validation_result = "winpkfilter_binding_missing".to_string();
+            self.binding_stage = if default_route_binding_missing {
+                BindingStage::WinpkFilterBindingMissing.as_str().to_string()
+            } else {
+                BindingStage::Unrecoverable.as_str().to_string()
+            };
+            self.binding_reason = if default_route_binding_missing {
+                "SwiftTunnel found the active network adapter, but the WinpkFilter binding is missing. Repair the split tunnel driver, then try again.".to_string()
+            } else {
+                "SwiftTunnel could not see any WinpkFilter-bound network adapters. Repair the split tunnel driver, then try again.".to_string()
+            };
+            self.last_validation_result = if default_route_binding_missing {
+                "winpkfilter_binding_missing".to_string()
+            } else {
+                "no_winpkfilter_bound_adapters".to_string()
+            };
             self.binding_candidates.clear();
             self.recommended_adapter_guid = None;
 
             let suffix = default_route_if_index
                 .map(|def| format!(" for default-route interface index {def}"))
                 .unwrap_or_default();
+            if default_route_binding_missing {
+                let adapter_label = default_route_owner
+                    .as_ref()
+                    .map(|(friendly_name, _, _, _)| friendly_name.as_str())
+                    .unwrap_or("active network adapter");
+                return Err(VpnError::SplitTunnel(
+                    Self::winpkfilter_binding_missing_message(adapter_label),
+                ));
+            }
             return Err(VpnError::SplitTunnel(format!(
                 "No WinpkFilter-bound NDIS adapters were visible{suffix}."
             )));
+        }
+
+        if strict_default_route
+            && default_route_if_index.is_some()
+            && selected.is_none()
+            && default_route_binding_missing
+        {
+            let adapter_label = default_route_owner
+                .as_ref()
+                .map(|(friendly_name, _, _, _)| friendly_name.as_str())
+                .unwrap_or("active network adapter");
+            self.binding_stage = BindingStage::WinpkFilterBindingMissing.as_str().to_string();
+            self.binding_reason =
+                "SwiftTunnel found the active network adapter, but the WinpkFilter binding is missing. Repair the split tunnel driver, then try again.".to_string();
+            self.last_validation_result = "winpkfilter_binding_missing".to_string();
+            self.binding_candidates = physical_candidates
+                .iter()
+                .map(|candidate| {
+                    Self::to_binding_candidate_info(
+                        candidate,
+                        default_route_if_index,
+                        BindingStage::SmartAuto,
+                        "Candidate available after WinpkFilter binding repair",
+                    )
+                })
+                .collect();
+            self.recommended_adapter_guid = None;
+            return Err(VpnError::SplitTunnel(
+                Self::winpkfilter_binding_missing_message(adapter_label),
+            ));
         }
 
         if strict_default_route && default_route_if_index.is_some() && selected.is_none() {
@@ -3051,6 +3107,10 @@ impl ParallelInterceptor {
             function Resolve-WinpkFilterCandidates {{
                 $candidates = [System.Collections.Generic.List[object]]::new()
 
+                if ($null -ne $adapterIfIndex) {{
+                    Add-BindingCandidate $candidates 'InterfaceIndex' ([string]$adapterIfIndex) $adapterLabel
+                }}
+
                 if (-not [string]::IsNullOrWhiteSpace($adapterHint)) {{
                     Add-BindingCandidate $candidates 'Name' $adapterHint $adapterHint
                     Add-BindingCandidate $candidates 'InterfaceDescription' $adapterHint $adapterHint
@@ -3074,6 +3134,12 @@ impl ParallelInterceptor {
             }}
 
             function Get-WinpkFilterBinding([object]$Candidate) {{
+                if ($Candidate.Selector -eq 'InterfaceIndex') {{
+                    return Get-NetAdapter -InterfaceIndex ([int]$Candidate.Value) -ErrorAction SilentlyContinue |
+                        Get-NetAdapterBinding -ComponentID 'nt_ndisrd' -ErrorAction SilentlyContinue |
+                        Select-Object -First 1
+                }}
+
                 if ($Candidate.Selector -eq 'Name') {{
                     return Get-NetAdapterBinding -Name $Candidate.Value -ComponentID 'nt_ndisrd' -ErrorAction SilentlyContinue |
                         Select-Object -First 1
@@ -3088,6 +3154,16 @@ impl ParallelInterceptor {
             }}
 
             function Enable-WinpkFilterBinding([object]$Candidate) {{
+                if ($Candidate.Selector -eq 'InterfaceIndex') {{
+                    $adapter = Get-NetAdapter -InterfaceIndex ([int]$Candidate.Value) -ErrorAction Stop |
+                        Select-Object -First 1
+                    if (-not $adapter) {{
+                        throw ('Could not resolve adapter by interface index: ' + $Candidate.Value)
+                    }}
+                    Enable-NetAdapterBinding -Name $adapter.Name -ComponentID 'nt_ndisrd' -Confirm:$false -ErrorAction Stop | Out-Null
+                    return
+                }}
+
                 if ($Candidate.Selector -eq 'Name') {{
                     Enable-NetAdapterBinding -Name $Candidate.Value -ComponentID 'nt_ndisrd' -Confirm:$false -ErrorAction Stop | Out-Null
                     return
@@ -3139,7 +3215,7 @@ impl ParallelInterceptor {
                 }}
 
                 if (-not $bindingCandidate) {{
-                    throw ('WinpkFilter binding nt_ndisrd is not installed on adapter: ' + $adapterLabel)
+                    throw ('winpkfilter_binding_missing: nt_ndisrd is not bound to adapter ''' + $adapterLabel + ''' (ifIndex=' + $adapterIfIndex + '). Repair the split tunnel driver, then try again.')
                 }}
 
                 $adapterName = if ($binding.Name) {{ [string]$binding.Name }} elseif ($bindingCandidate.DisplayName) {{ [string]$bindingCandidate.DisplayName }} else {{ $adapterLabel }}
@@ -3175,7 +3251,11 @@ impl ParallelInterceptor {
                     $errorText = 'PowerShell command failed without an exception message.'
                 }}
 
-                Write-Error ('WinpkFilter binding validation failed for adapter ' + $adapterLabel + ': ' + $errorText)
+                if ($errorText -like 'winpkfilter_binding_missing:*') {{
+                    [Console]::Error.WriteLine($errorText)
+                }} else {{
+                    [Console]::Error.WriteLine('winpkfilter_binding_validation_failed: adapter ''' + $adapterLabel + ''': ' + $errorText)
+                }}
                 exit 1
             }}
             "#,
@@ -3193,6 +3273,21 @@ impl ParallelInterceptor {
             || (details.contains("get-netadapter") && details.contains("not recognized"))
             || (details.contains("get-netadapterbinding") && details.contains("not recognized"))
             || (details.contains("enable-netadapterbinding") && details.contains("not recognized"))
+    }
+
+    fn is_winpkfilter_binding_missing_failure(details: &str) -> bool {
+        let details = details.to_ascii_lowercase();
+        details.contains("winpkfilter_binding_missing")
+            || (details.contains("nt_ndisrd")
+                && (details.contains("not installed on adapter")
+                    || details.contains("not bound to adapter")))
+    }
+
+    fn winpkfilter_binding_missing_message(adapter_label: &str) -> String {
+        format!(
+            "winpkfilter_binding_missing: nt_ndisrd is not bound to adapter '{}'. Repair the split tunnel driver, then try again.",
+            adapter_label
+        )
     }
 
     /// Ensure the WinpkFilter lightweight filter is enabled on a target adapter.
@@ -3268,11 +3363,17 @@ impl ParallelInterceptor {
                 return Ok(());
             }
 
-            // Only retry on timeouts or transient failures, not on permanent ones
-            // like "binding not installed". Check for permanent failure indicators.
-            if last_details.contains("is not installed on adapter") {
+            // Only retry on timeouts or transient failures, not on permanent
+            // binding faults. The driver repair path can re-install the LWF
+            // component and rebind it to the adapter.
+            if Self::is_winpkfilter_binding_missing_failure(&last_details) {
+                last_details = Self::winpkfilter_binding_missing_message(adapter_label);
                 break;
             }
+        }
+
+        if Self::is_winpkfilter_binding_missing_failure(&last_details) {
+            return Err(VpnError::SplitTunnel(last_details));
         }
 
         Err(VpnError::SplitTunnel(format!(
@@ -9392,7 +9493,7 @@ mod tests {
             script.contains("Add-BindingCandidate $candidates 'InterfaceDescription' $adapterHint")
         );
         assert!(script.contains("Enable-NetAdapterBinding -InterfaceDescription $Candidate.Value"));
-        assert!(script.contains("Write-Error ('WinpkFilter binding validation failed for adapter ' + $adapterLabel + ': ' + $errorText)"));
+        assert!(script.contains("winpkfilter_binding_validation_failed"));
     }
 
     #[test]
@@ -9405,6 +9506,31 @@ mod tests {
         assert!(script.contains(
             "Get-CimInstance -ClassName Win32_NetworkAdapter -Filter ('InterfaceIndex = ' + $adapterIfIndex)"
         ));
+        assert!(script.contains(
+            "Add-BindingCandidate $candidates 'InterfaceIndex' ([string]$adapterIfIndex)"
+        ));
+        assert!(script.contains("Get-NetAdapter -InterfaceIndex ([int]$Candidate.Value)"));
+        let interface_index_pos = script
+            .find("Add-BindingCandidate $candidates 'InterfaceIndex'")
+            .expect("interface-index candidate should be present");
+        let name_pos = script
+            .find("Add-BindingCandidate $candidates 'Name' $adapterHint")
+            .expect("name candidate should be present");
+        assert!(interface_index_pos < name_pos);
+    }
+
+    #[test]
+    fn test_winpkfilter_missing_binding_failure_is_structured() {
+        assert!(ParallelInterceptor::is_winpkfilter_binding_missing_failure(
+            "winpkfilter_binding_missing: nt_ndisrd is not bound to adapter 'Ethernet'"
+        ));
+        assert!(ParallelInterceptor::is_winpkfilter_binding_missing_failure(
+            "WinpkFilter binding nt_ndisrd is not installed on adapter: Ethernet"
+        ));
+        assert_eq!(
+            ParallelInterceptor::winpkfilter_binding_missing_message("Ethernet"),
+            "winpkfilter_binding_missing: nt_ndisrd is not bound to adapter 'Ethernet'. Repair the split tunnel driver, then try again."
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/winpkfilter.rs
+++ b/swifttunnel-core/src/vpn/winpkfilter.rs
@@ -181,6 +181,7 @@ pub const DRIVER_PACKAGE_WIN10_DIR: &str = "win10";
 pub const DRIVER_INF_NAME: &str = "ndisrd_lwf.inf";
 pub const DRIVER_SYS_NAME: &str = "ndisrd.sys";
 pub const DRIVER_CAT_NAME: &str = "ndisrd.cat";
+const DRIVER_COMPONENT_ID: &str = "nt_ndisrd";
 const DRIVER_INF_MIN_SIZE_BYTES: u64 = 256;
 const DRIVER_SYS_MIN_SIZE_BYTES: u64 = 4 * 1024;
 const DRIVER_CAT_MIN_SIZE_BYTES: u64 = 256;
@@ -376,6 +377,17 @@ fn pnputil_reboot_required_exit_code(code: i32) -> bool {
     code == 3010
 }
 
+fn driver_netcfg_install_command(inf_path: &str) -> (&'static str, [&str; 6]) {
+    (
+        "netcfg",
+        ["/l", inf_path, "/c", "s", "/i", DRIVER_COMPONENT_ID],
+    )
+}
+
+fn driver_pnputil_install_command(inf_path: &str) -> (&'static str, [&str; 3]) {
+    ("pnputil", ["/add-driver", inf_path, "/install"])
+}
+
 #[cfg(windows)]
 fn pnputil_output_detail(output: &std::process::Output) -> String {
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -401,30 +413,62 @@ fn pnputil_retryable_exit_code(code: i32) -> bool {
     matches!(code, 2 | 5)
 }
 
+#[cfg(windows)]
+fn netcfg_already_installed_detail(detail: &str) -> bool {
+    let detail = detail.to_ascii_lowercase();
+    detail.contains("already installed")
+        || detail.contains("already exists")
+        || detail.contains("0x800700b7")
+}
+
+#[cfg(windows)]
+fn run_netcfg_install(inf_path: &str) -> Result<(), String> {
+    let (program, args) = driver_netcfg_install_command(inf_path);
+    let output = hidden_command(program)
+        .args(args)
+        .output()
+        .map_err(|e| format!("Failed to run netcfg: {}", e))?;
+
+    let code = output.status.code().unwrap_or(-1);
+    if output.status.success() {
+        log::info!("WinpkFilter network component installed/refreshed with netcfg");
+        return Ok(());
+    }
+
+    let detail = pnputil_output_detail(&output);
+    if netcfg_already_installed_detail(&detail) {
+        log::info!(
+            "WinpkFilter network component already installed according to netcfg: {}",
+            detail
+        );
+        return Ok(());
+    }
+
+    if pnputil_reboot_required_exit_code(code) {
+        if detail.is_empty() {
+            return Err(
+                "Reboot required to finish WinpkFilter binding installation. netcfg exited with code 3010."
+                    .to_string(),
+            );
+        }
+        return Err(format!(
+            "Reboot required to finish WinpkFilter binding installation. netcfg exited with code 3010: {}",
+            detail
+        ));
+    }
+
+    if detail.is_empty() {
+        Err(format!("netcfg failed with code {}", code))
+    } else {
+        Err(format!("netcfg failed with code {}: {}", code, detail))
+    }
+}
+
 /// Maximum number of pnputil install attempts before giving up.
 const PNPUTIL_INSTALL_MAX_ATTEMPTS: u32 = 3;
 
 #[cfg(windows)]
-pub fn install_driver_from_package_dir(package_dir: &Path) -> Result<(), String> {
-    let package = validate_driver_package_dir(package_dir)?;
-    let inf_path = package.inf_path.to_string_lossy().to_string();
-
-    // Idempotency: skip install if the driver is already in the store.
-    match find_installed_driver_published_name() {
-        Ok(Some(published)) => {
-            log::info!(
-                "WinpkFilter driver already present in driver store as {}; skipping install",
-                published
-            );
-            return Ok(());
-        }
-        Ok(None) => {} // Not installed yet — proceed.
-        Err(e) => {
-            // Non-fatal: if we can't query the store, proceed with install anyway.
-            log::warn!("Could not query driver store before install: {}", e);
-        }
-    }
-
+fn run_pnputil_install(inf_path: &str) -> Result<(), String> {
     let mut last_error = String::new();
 
     for attempt in 1..=PNPUTIL_INSTALL_MAX_ATTEMPTS {
@@ -439,10 +483,8 @@ pub fn install_driver_from_package_dir(package_dir: &Path) -> Result<(), String>
             std::thread::sleep(std::time::Duration::from_millis(delay_ms as u64));
         }
 
-        let output = match hidden_command("pnputil")
-            .args(["/add-driver", &inf_path, "/install"])
-            .output()
-        {
+        let (program, args) = driver_pnputil_install_command(inf_path);
+        let output = match hidden_command(program).args(args).output() {
             Ok(output) => output,
             Err(e) => {
                 last_error = format!("Failed to run pnputil: {}", e);
@@ -518,6 +560,51 @@ pub fn install_driver_from_package_dir(package_dir: &Path) -> Result<(), String>
     }
 
     Err(last_error)
+}
+
+#[cfg(windows)]
+pub fn install_driver_from_package_dir(package_dir: &Path) -> Result<(), String> {
+    let package = validate_driver_package_dir(package_dir)?;
+    let inf_path = package.inf_path.to_string_lossy().to_string();
+
+    match find_installed_driver_published_name() {
+        Ok(Some(published)) => {
+            log::info!(
+                "WinpkFilter driver already present in driver store as {}; refreshing network component binding",
+                published
+            );
+        }
+        Ok(None) => {
+            log::info!("WinpkFilter driver package not present in driver store; installing");
+        }
+        Err(e) => {
+            // Non-fatal: if we can't query the store, proceed with install anyway.
+            log::warn!("Could not query driver store before install: {}", e);
+        }
+    }
+
+    let mut issues = Vec::new();
+
+    if let Err(e) = run_netcfg_install(&inf_path) {
+        log::warn!("WinpkFilter netcfg binding install failed: {}", e);
+        issues.push(format!("netcfg binding install failed: {}", e));
+    }
+
+    if let Err(e) = run_pnputil_install(&inf_path) {
+        log::warn!("WinpkFilter pnputil driver install failed: {}", e);
+        issues.push(format!("pnputil driver install failed: {}", e));
+    }
+
+    if issues
+        .iter()
+        .any(|issue| issue.to_ascii_lowercase().contains("reboot required"))
+    {
+        Err(issues.join("; "))
+    } else if issues.len() >= 2 {
+        Err(issues.join("; "))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(not(windows))]
@@ -823,6 +910,32 @@ Provider Name:      NDISAPI
             assert!(!pnputil_retryable_exit_code(0));
             assert!(!pnputil_retryable_exit_code(1));
             assert!(!pnputil_retryable_exit_code(3010));
+        }
+    }
+
+    #[test]
+    fn driver_rebind_commands_include_netcfg_and_pnputil_install() {
+        let inf_path = r"C:\Program Files\SwiftTunnel\drivers\ndisrd_lwf.inf";
+        let (netcfg_program, netcfg_args) = driver_netcfg_install_command(inf_path);
+        assert_eq!(netcfg_program, "netcfg");
+        assert_eq!(netcfg_args, ["/l", inf_path, "/c", "s", "/i", "nt_ndisrd"]);
+
+        let (pnputil_program, pnputil_args) = driver_pnputil_install_command(inf_path);
+        assert_eq!(pnputil_program, "pnputil");
+        assert_eq!(pnputil_args, ["/add-driver", inf_path, "/install"]);
+    }
+
+    #[test]
+    fn netcfg_already_installed_detection_is_lenient() {
+        #[cfg(windows)]
+        {
+            assert!(netcfg_already_installed_detail(
+                "The requested component is already installed."
+            ));
+            assert!(netcfg_already_installed_detail(
+                "0x800700b7 Cannot create a file when that file already exists"
+            ));
+            assert!(!netcfg_already_installed_detail("Access is denied."));
         }
     }
 

--- a/swifttunnel-core/src/vpn/winpkfilter.rs
+++ b/swifttunnel-core/src/vpn/winpkfilter.rs
@@ -562,6 +562,33 @@ fn run_pnputil_install(inf_path: &str) -> Result<(), String> {
     Err(last_error)
 }
 
+fn combine_driver_install_results(
+    netcfg_result: Result<(), String>,
+    pnputil_result: Result<(), String>,
+) -> Result<(), String> {
+    let mut issues = Vec::new();
+    let mut netcfg_failed = false;
+
+    if let Err(e) = netcfg_result {
+        netcfg_failed = true;
+        issues.push(format!("netcfg binding install failed: {}", e));
+    }
+
+    if let Err(e) = pnputil_result {
+        issues.push(format!("pnputil driver install failed: {}", e));
+    }
+
+    if netcfg_failed
+        || issues
+            .iter()
+            .any(|issue| issue.to_ascii_lowercase().contains("reboot required"))
+    {
+        Err(issues.join("; "))
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(windows)]
 pub fn install_driver_from_package_dir(package_dir: &Path) -> Result<(), String> {
     let package = validate_driver_package_dir(package_dir)?;
@@ -583,28 +610,15 @@ pub fn install_driver_from_package_dir(package_dir: &Path) -> Result<(), String>
         }
     }
 
-    let mut issues = Vec::new();
-
-    if let Err(e) = run_netcfg_install(&inf_path) {
+    let netcfg_result = run_netcfg_install(&inf_path).inspect_err(|e| {
         log::warn!("WinpkFilter netcfg binding install failed: {}", e);
-        issues.push(format!("netcfg binding install failed: {}", e));
-    }
+    });
 
-    if let Err(e) = run_pnputil_install(&inf_path) {
+    let pnputil_result = run_pnputil_install(&inf_path).inspect_err(|e| {
         log::warn!("WinpkFilter pnputil driver install failed: {}", e);
-        issues.push(format!("pnputil driver install failed: {}", e));
-    }
+    });
 
-    if issues
-        .iter()
-        .any(|issue| issue.to_ascii_lowercase().contains("reboot required"))
-    {
-        Err(issues.join("; "))
-    } else if issues.len() >= 2 {
-        Err(issues.join("; "))
-    } else {
-        Ok(())
-    }
+    combine_driver_install_results(netcfg_result, pnputil_result)
 }
 
 #[cfg(not(windows))]
@@ -923,6 +937,30 @@ Provider Name:      NDISAPI
         let (pnputil_program, pnputil_args) = driver_pnputil_install_command(inf_path);
         assert_eq!(pnputil_program, "pnputil");
         assert_eq!(pnputil_args, ["/add-driver", inf_path, "/install"]);
+    }
+
+    #[test]
+    fn driver_install_result_surfaces_netcfg_failure_even_if_pnputil_succeeds() {
+        let err = combine_driver_install_results(Err("access denied".to_string()), Ok(()))
+            .expect_err("netcfg failure must not be masked");
+        assert!(err.contains("netcfg binding install failed"));
+        assert!(err.contains("access denied"));
+    }
+
+    #[test]
+    fn driver_install_result_allows_non_reboot_pnputil_failure_after_netcfg_success() {
+        combine_driver_install_results(Ok(()), Err("pnputil failed with code 2".to_string()))
+            .expect("netcfg success is enough to refresh the LWF binding");
+    }
+
+    #[test]
+    fn driver_install_result_preserves_reboot_required_failures() {
+        let err = combine_driver_install_results(
+            Ok(()),
+            Err("Reboot required to finish driver installation.".to_string()),
+        )
+        .expect_err("reboot-required errors must stay visible");
+        assert!(err.contains("Reboot required"));
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/commands/system.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/system.rs
@@ -1267,6 +1267,12 @@ mod tests {
         fs::write(path, b"").expect("write temp file");
     }
 
+    fn assert_same_canonical_path(actual: &Path, expected: &Path) {
+        let actual = fs::canonicalize(actual).expect("canonicalize actual path");
+        let expected = fs::canonicalize(expected).expect("canonicalize expected path");
+        assert_eq!(actual, expected);
+    }
+
     #[test]
     fn driver_install_success_exit_code_accepts_expected_codes() {
         for code in [0, 1638, 1641, 3010] {
@@ -1345,7 +1351,7 @@ mod tests {
         let base = unique_temp_dir("extract_top");
         touch(&base.join("ndisrd_lwf.inf"));
         let result = find_inf_in_extract_dir(&base).expect("should find top-level inf");
-        assert_eq!(result, base);
+        assert_same_canonical_path(&result, &base);
         let _ = fs::remove_dir_all(&base);
     }
 
@@ -1356,7 +1362,7 @@ mod tests {
         fs::create_dir_all(&nested).expect("create nested dir");
         touch(&nested.join("ndisrd_lwf.inf"));
         let result = find_inf_in_extract_dir(&base).expect("should find nested inf");
-        assert_eq!(result, nested);
+        assert_same_canonical_path(&result, &nested);
         let _ = fs::remove_dir_all(&base);
     }
 
@@ -1365,7 +1371,7 @@ mod tests {
         let base = unique_temp_dir("extract_case");
         touch(&base.join("NDISRD_LWF.INF"));
         let result = find_inf_in_extract_dir(&base).expect("should find case-insensitive inf");
-        assert_eq!(result, base);
+        assert_same_canonical_path(&result, &base);
         let _ = fs::remove_dir_all(&base);
     }
 

--- a/swifttunnel-desktop/src-tauri/src/commands/system.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/system.rs
@@ -1121,9 +1121,13 @@ pub async fn system_repair_driver(app: tauri::AppHandle) -> Result<DriverCheckRe
                     .and_then(|_| swifttunnel_core::vpn::SplitTunnelDriver::self_test())
                 {
                     Ok(()) => {
-                        return Ok(DriverCheckResponse::from_health(
-                            swifttunnel_core::vpn::SplitTunnelDriver::health_check(),
-                        ));
+                        current = swifttunnel_core::vpn::SplitTunnelDriver::health_check();
+                        if !initial.ready {
+                            return Ok(DriverCheckResponse::from_health(current));
+                        }
+                        log::info!(
+                            "Driver service reset passed; continuing repair to refresh WinpkFilter adapter bindings"
+                        );
                     }
                     Err(e) => {
                         log::warn!("Driver service reset failed during repair: {}", e);
@@ -1137,7 +1141,7 @@ pub async fn system_repair_driver(app: tauri::AppHandle) -> Result<DriverCheckRe
                 );
             }
 
-            if initial.ready && current.ready && last_error.is_none() {
+            if !initial.ready && current.ready && last_error.is_none() {
                 return Ok(DriverCheckResponse::from_health(current));
             }
 
@@ -1161,7 +1165,7 @@ pub async fn system_repair_driver(app: tauri::AppHandle) -> Result<DriverCheckRe
                 initial.recommended_action,
                 DriverRecommendedAction::Install | DriverRecommendedAction::Reinstall | DriverRecommendedAction::ResetService
             ) || reset_failed
-                || (initial.ready && last_error.is_some())
+                || initial.ready
             {
                 let force_reinstall = matches!(
                     current.recommended_action,
@@ -1169,8 +1173,7 @@ pub async fn system_repair_driver(app: tauri::AppHandle) -> Result<DriverCheckRe
                 ) || matches!(
                     initial.recommended_action,
                     DriverRecommendedAction::Reinstall | DriverRecommendedAction::ResetService
-                ) || reset_failed
-                    || initial.ready;
+                ) || reset_failed;
 
                 let mut repair_errors = Vec::new();
                 if let Some(error) = &last_error {

--- a/swifttunnel-desktop/src/components/connect/connectState.test.ts
+++ b/swifttunnel-desktop/src/components/connect/connectState.test.ts
@@ -89,6 +89,20 @@ describe("connect state helpers", () => {
     });
   });
 
+  it("shows repair status while automatic binding repair runs", () => {
+    expect(
+      resolveConnectStatus({
+        driverSetupState: "repairing",
+        driverSetupError: null,
+        vpnError: null,
+        vpnState: "fetching_config",
+      }),
+    ).toEqual({
+      kind: "text",
+      text: "Repairing split tunnel driver…",
+    });
+  });
+
   it("returns reboot_required before falling back to driver_missing", () => {
     // Reboot-required must outrank driver-missing: if the install already
     // told us the system needs a restart, re-prompting for another install
@@ -249,6 +263,12 @@ describe("connect state helpers", () => {
       isConnectActionBusy({
         vpnState: "error",
         driverSetupState: "installing",
+      }),
+    ).toBe(true);
+    expect(
+      isConnectActionBusy({
+        vpnState: "error",
+        driverSetupState: "repairing",
       }),
     ).toBe(true);
     expect(

--- a/swifttunnel-desktop/src/components/connect/connectState.ts
+++ b/swifttunnel-desktop/src/components/connect/connectState.ts
@@ -75,7 +75,13 @@ export function isDriverVersionTooOld(
 
 export function isConnectActionBusy(input: {
   vpnState: string;
-  driverSetupState: "idle" | "checking" | "installing" | "installed" | "error";
+  driverSetupState:
+    | "idle"
+    | "checking"
+    | "installing"
+    | "repairing"
+    | "installed"
+    | "error";
 }): boolean {
   const isConnected = input.vpnState === "connected";
   const isIdle = input.vpnState === "disconnected" || input.vpnState === "error";
@@ -83,12 +89,19 @@ export function isConnectActionBusy(input: {
   return (
     isVpnTransitioning ||
     input.driverSetupState === "checking" ||
-    input.driverSetupState === "installing"
+    input.driverSetupState === "installing" ||
+    input.driverSetupState === "repairing"
   );
 }
 
 export function resolveConnectStatus(input: {
-  driverSetupState: "idle" | "checking" | "installing" | "installed" | "error";
+  driverSetupState:
+    | "idle"
+    | "checking"
+    | "installing"
+    | "repairing"
+    | "installed"
+    | "error";
   driverSetupError: string | null;
   driverStatus?: DriverCheckResponse | null;
   vpnError: string | null;
@@ -119,6 +132,13 @@ export function resolveConnectStatus(input: {
     return {
       kind: "text",
       text: "Installing required split tunnel driver…",
+    };
+  }
+
+  if (input.driverSetupState === "repairing") {
+    return {
+      kind: "text",
+      text: "Repairing split tunnel driver…",
     };
   }
 

--- a/swifttunnel-desktop/src/stores/vpnStore.test.ts
+++ b/swifttunnel-desktop/src/stores/vpnStore.test.ts
@@ -290,6 +290,30 @@ describe("stores/vpnStore", () => {
     expect(useVpnStore.getState().state).toBe("connected");
   });
 
+  it("does not auto-repair unrelated nt_ndisrd validation errors", async () => {
+    systemCheckDriver.mockResolvedValueOnce(driverStatus());
+    vpnPreflightBinding.mockResolvedValueOnce({
+      status: "unrecoverable",
+      reason: "nt_ndisrd adapter validation error: access denied",
+      network_signature: "source=internet_fallback;if_index=20;next_hop=1;up=",
+      route_resolution_source: "internet_fallback",
+      route_resolution_target_ip: "8.8.8.8",
+      resolved_if_index: 20,
+      recommended_guid: null,
+      cached_override_used: false,
+      binding_stage: "unrecoverable",
+      candidates: [],
+    });
+
+    const useVpnStore = await loadStore();
+    await useVpnStore.getState().connect("singapore", ["roblox"]);
+
+    expect(systemRepairDriver).not.toHaveBeenCalled();
+    expect(vpnConnect).not.toHaveBeenCalled();
+    expect(useVpnStore.getState().state).toBe("error");
+    expect(useVpnStore.getState().error).toContain("access denied");
+  });
+
   it("repairs and retries once when connect races a missing WinpkFilter binding", async () => {
     systemCheckDriver.mockResolvedValue(driverStatus());
     systemRepairDriver.mockResolvedValueOnce(driverStatus());

--- a/swifttunnel-desktop/src/stores/vpnStore.test.ts
+++ b/swifttunnel-desktop/src/stores/vpnStore.test.ts
@@ -248,6 +248,69 @@ describe("stores/vpnStore", () => {
     expect(useVpnStore.getState().state).toBe("connected");
   });
 
+  it("repairs missing WinpkFilter binding marker during preflight", async () => {
+    systemCheckDriver.mockResolvedValueOnce(driverStatus());
+    vpnPreflightBinding
+      .mockResolvedValueOnce({
+        status: "unrecoverable",
+        reason:
+          "winpkfilter_binding_missing: nt_ndisrd is not bound to adapter 'Realtek Gaming GbE Family Controller'.",
+        network_signature: "source=internet_fallback;if_index=20;next_hop=1;up=",
+        route_resolution_source: "internet_fallback",
+        route_resolution_target_ip: "8.8.8.8",
+        resolved_if_index: 20,
+        recommended_guid: null,
+        cached_override_used: false,
+        binding_stage: "winpkfilter_binding_missing",
+        candidates: [],
+      })
+      .mockResolvedValueOnce({
+        status: "ok",
+        reason: "Split tunnel adapter binding validated.",
+        network_signature:
+          "source=internet_fallback;if_index=20;next_hop=1;up=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        route_resolution_source: "internet_fallback",
+        route_resolution_target_ip: "8.8.8.8",
+        resolved_if_index: 20,
+        recommended_guid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        cached_override_used: false,
+        binding_stage: "exact_route_match",
+        candidates: [],
+      });
+    systemRepairDriver.mockResolvedValueOnce(driverStatus());
+    vpnConnect.mockResolvedValue(undefined);
+    vpnGetState.mockResolvedValue(connectedState("singapore"));
+
+    const useVpnStore = await loadStore();
+    await useVpnStore.getState().connect("singapore", ["roblox"]);
+
+    expect(systemRepairDriver).toHaveBeenCalledTimes(1);
+    expect(vpnPreflightBinding).toHaveBeenCalledTimes(2);
+    expect(vpnConnect).toHaveBeenCalledWith("singapore", ["roblox"]);
+    expect(useVpnStore.getState().state).toBe("connected");
+  });
+
+  it("repairs and retries once when connect races a missing WinpkFilter binding", async () => {
+    systemCheckDriver.mockResolvedValue(driverStatus());
+    systemRepairDriver.mockResolvedValueOnce(driverStatus());
+    vpnConnect
+      .mockRejectedValueOnce(
+        new Error(
+          "Split tunnel driver binding is missing on the active network adapter.",
+        ),
+      )
+      .mockResolvedValueOnce(undefined);
+    vpnGetState.mockResolvedValue(connectedState("singapore"));
+
+    const useVpnStore = await loadStore();
+    await useVpnStore.getState().connect("singapore", ["roblox"]);
+
+    expect(systemRepairDriver).toHaveBeenCalledTimes(1);
+    expect(vpnConnect).toHaveBeenCalledTimes(2);
+    expect(vpnPreflightBinding).toHaveBeenCalledTimes(2);
+    expect(useVpnStore.getState().state).toBe("connected");
+  });
+
   it("keeps repair action visible when binding repair does not fix preflight", async () => {
     systemCheckDriver.mockResolvedValue(driverStatus());
     const failedPreflight = {
@@ -275,10 +338,10 @@ describe("stores/vpnStore", () => {
     expect(useVpnStore.getState().state).toBe("error");
     expect(useVpnStore.getState().driverSetupState).toBe("error");
     expect(useVpnStore.getState().driverStatus?.recommended_action).toBe(
-      "reset_service",
+      "reinstall",
     );
     expect(useVpnStore.getState().driverSetupError).toContain(
-      "Automatic split tunnel driver repair did not restore adapter binding.",
+      "Automatic split tunnel driver repair did not restore the WinpkFilter adapter binding.",
     );
   });
 

--- a/swifttunnel-desktop/src/stores/vpnStore.ts
+++ b/swifttunnel-desktop/src/stores/vpnStore.ts
@@ -27,6 +27,7 @@ type DriverSetupState =
   | "idle"
   | "checking"
   | "installing"
+  | "repairing"
   | "installed"
   | "error";
 
@@ -53,8 +54,23 @@ function isRepairableBindingPreflight(preflight: BindingPreflightInfo): boolean 
   const haystack = `${preflight.reason}\n${preflight.binding_stage ?? ""}`.toLowerCase();
   return (
     preflight.status === "unrecoverable" &&
-    (haystack.includes("winpkfilter-bound network adapters") ||
+    (haystack.includes("winpkfilter_binding_missing") ||
+      haystack.includes("winpkfilter binding is missing") ||
+      haystack.includes("nt_ndisrd") ||
+      haystack.includes("winpkfilter-bound network adapters") ||
       haystack.includes("repair the split tunnel driver"))
+  );
+}
+
+function isBindingMissingMessage(message: string): boolean {
+  const haystack = message.toLowerCase();
+  return (
+    haystack.includes("winpkfilter_binding_missing") ||
+    haystack.includes("split tunnel driver binding is missing") ||
+    (haystack.includes("nt_ndisrd") &&
+      (haystack.includes("not bound") ||
+        haystack.includes("not installed on adapter") ||
+        haystack.includes("binding is missing")))
   );
 }
 
@@ -75,12 +91,12 @@ function bindingRepairFailedStatus(reason: string): DriverCheckResponse {
     installed: true,
     version: null,
     ready: false,
-    status: "binding_repair_failed",
+    status: "binding_missing",
     message:
-      "Automatic split tunnel driver repair did not restore adapter binding.\n\n" +
+      "Automatic split tunnel driver repair did not restore the WinpkFilter adapter binding.\n\n" +
       reason,
     reboot_required: false,
-    recommended_action: "reset_service",
+    recommended_action: "reinstall",
   };
 }
 
@@ -216,7 +232,7 @@ export const useVpnStore = create<VpnStore>((set, get) => ({
 
   repairDriver: async () => {
     try {
-      set({ driverSetupState: "installing", driverSetupError: null });
+      set({ driverSetupState: "repairing", driverSetupError: null });
       const repaired = await systemRepairDriver();
       set({ driverStatus: repaired });
       if (!repaired.ready) {
@@ -268,7 +284,7 @@ export const useVpnStore = create<VpnStore>((set, get) => ({
     // that this PR is trying to close. Cleared on successful connect or
     // disconnect to give the next incident a fresh attempt.
     try {
-      set({ driverSetupState: "installing", driverSetupError: null });
+      set({ driverSetupState: "repairing", driverSetupError: null });
       await systemResetDriver();
       set({
         error: null,
@@ -371,7 +387,22 @@ export const useVpnStore = create<VpnStore>((set, get) => ({
         });
         return;
       }
-      await vpnConnect(region, gamePresets);
+      try {
+        await vpnConnect(region, gamePresets);
+      } catch (e) {
+        const message = getErrorMessage(e);
+        if (
+          isBindingMissingMessage(message) &&
+          !autoRepairedBindingSignatures.has(preflight.network_signature)
+        ) {
+          autoRepairedBindingSignatures.add(preflight.network_signature);
+          await get().repairDriver();
+          if (!isCurrentConnectAttempt(attempt)) return;
+          await get().connect(region, gamePresets);
+          return;
+        }
+        throw e;
+      }
       if (!isCurrentConnectAttempt(attempt)) return;
       await get().fetchState();
       if (!isCurrentConnectAttempt(attempt)) return;

--- a/swifttunnel-desktop/src/stores/vpnStore.ts
+++ b/swifttunnel-desktop/src/stores/vpnStore.ts
@@ -56,7 +56,9 @@ function isRepairableBindingPreflight(preflight: BindingPreflightInfo): boolean 
     preflight.status === "unrecoverable" &&
     (haystack.includes("winpkfilter_binding_missing") ||
       haystack.includes("winpkfilter binding is missing") ||
-      haystack.includes("nt_ndisrd") ||
+      haystack.includes("nt_ndisrd is not bound") ||
+      haystack.includes("nt_ndisrd is not installed on adapter") ||
+      haystack.includes("binding nt_ndisrd is not installed") ||
       haystack.includes("winpkfilter-bound network adapters") ||
       haystack.includes("repair the split tunnel driver"))
   );


### PR DESCRIPTION
## Summary
- detect missing nt_ndisrd adapter bindings with a stable winpkfilter_binding_missing marker and prefer InterfaceIndex lookup before name/description fallbacks
- refresh WinpkFilter's NDIS lightweight filter binding during driver repair via netcfg plus pnputil, even when the package already exists in the driver store
- auto-repair and retry once from both preflight and connect-time binding-missing failures, with concise UI status/error text

## Tests
- npm --prefix swifttunnel-desktop test
- npm --prefix swifttunnel-desktop run build
- cargo fmt --check
- git diff --check

## Notes
- cargo test -p swifttunnel-core winpkfilter and cargo test -p swifttunnel-core winpkfilter_binding are blocked in this macOS environment before SwiftTunnel code compiles by windows-future 0.3.2 failing to find windows_core::imp::IMarshal/marshaler and windows_threading::submit.