### PR TITLE
[codex] Fix auto-routing holds and relay auth fallback

### DIFF
--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -35,11 +35,13 @@ const AUTO_ROUTING_PING_SAMPLES: usize = 5;
 const CONNECT_FAIL_HANDSHAKE_TIMEOUT: &str = "ST_CONNECT_HANDSHAKE_TIMEOUT";
 const CONNECT_FAIL_CANDIDATE_EXHAUSTED: &str = "ST_CONNECT_CANDIDATE_EXHAUSTED";
 const CONNECT_FAIL_PREFLIGHT_ENFORCED: &str = "ST_CONNECT_PREFLIGHT_ENFORCED";
+const CONNECT_FAIL_AUTH_REQUIRED: &str = "ST_CONNECT_AUTH_REQUIRED";
 const CONNECT_FAIL_REGION_UNAVAILABLE: &str = "ST_CONNECT_REGION_UNAVAILABLE";
 
 static HANDSHAKE_TIMEOUT_EVENTS: AtomicU64 = AtomicU64::new(0);
 static CANDIDATE_EXHAUSTED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static PREFLIGHT_ENFORCED_EVENTS: AtomicU64 = AtomicU64::new(0);
+static AUTH_REQUIRED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static REGION_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
@@ -47,6 +49,7 @@ struct RelayCandidateAttempt {
     region: String,
     addr: SocketAddr,
     authenticated: bool,
+    auth_required: bool,
     preflight_mode: RelayPreflightMode,
     queue_full_mode: RelayQueueFullMode,
 }
@@ -70,6 +73,10 @@ fn select_candidate_after_preflight(
     }
 
     let fallback = attempts.first().ok_or(CONNECT_FAIL_CANDIDATE_EXHAUSTED)?;
+
+    if fallback.auth_required {
+        return Err(CONNECT_FAIL_AUTH_REQUIRED);
+    }
 
     if fallback.preflight_mode == RelayPreflightMode::Enforce {
         return Err(CONNECT_FAIL_PREFLIGHT_ENFORCED);
@@ -1072,14 +1079,8 @@ impl VpnConnection {
             }
         };
 
-        let resolved_forced_server =
-            resolved_forced_server(forced_for_region.as_deref(), &relay_candidates);
-        let has_forced_server = resolved_forced_server.is_some();
-
         let mut relay_auth_mode = if custom_relay_server.is_some() {
             "custom_legacy".to_string()
-        } else if has_forced_server {
-            "forced_server_legacy".to_string()
         } else {
             "legacy_fallback".to_string()
         };
@@ -1087,11 +1088,6 @@ impl VpnConnection {
 
         if custom_relay_server.is_some() {
             log::warn!("V3: Custom relay enabled, skipping authenticated relay ticket bootstrap");
-        } else if has_forced_server {
-            log::info!(
-                "V3: Forced server '{}' selected, skipping relay ticket bootstrap for direct connection",
-                resolved_forced_server.as_deref().unwrap_or("unknown")
-            );
         } else {
             let auth_client = AuthClient::new();
             let session_id_hex = relay.session_id_hex();
@@ -1124,6 +1120,7 @@ impl VpnConnection {
                             region: candidate_region.clone(),
                             addr: *candidate_addr,
                             authenticated: false,
+                            auth_required: false,
                             preflight_mode: RelayPreflightMode::Legacy,
                             queue_full_mode: RelayQueueFullMode::Bypass,
                         });
@@ -1150,6 +1147,7 @@ impl VpnConnection {
                             region: candidate_region.clone(),
                             addr: *candidate_addr,
                             authenticated: true,
+                            auth_required: ticket.auth_required,
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1180,6 +1178,7 @@ impl VpnConnection {
                             region: candidate_region.clone(),
                             addr: *candidate_addr,
                             authenticated: false,
+                            auth_required: ticket.auth_required,
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1198,6 +1197,7 @@ impl VpnConnection {
                             region: candidate_region.clone(),
                             addr: *candidate_addr,
                             authenticated: false,
+                            auth_required: ticket.auth_required,
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1213,6 +1213,7 @@ impl VpnConnection {
                             region: candidate_region.clone(),
                             addr: *candidate_addr,
                             authenticated: false,
+                            auth_required: ticket.auth_required,
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1258,6 +1259,21 @@ impl VpnConnection {
                         let _ = driver.close();
                         return Err(VpnError::Connection(
                             "Relay preflight enforcement blocked connection (no healthy authenticated relay candidate)"
+                                .to_string(),
+                        ));
+                    }
+                    Err(CONNECT_FAIL_AUTH_REQUIRED) => {
+                        log_sampled_connect_event(
+                            &AUTH_REQUIRED_EVENTS,
+                            CONNECT_FAIL_AUTH_REQUIRED,
+                            format!(
+                                "Required relay auth rejected legacy fallback for '{}' (session {})",
+                                config.region, session_id_hex
+                            ),
+                        );
+                        let _ = driver.close();
+                        return Err(VpnError::Connection(
+                            "Relay authentication required but no relay candidate authenticated"
                                 .to_string(),
                         ));
                     }
@@ -2833,6 +2849,7 @@ mod tests {
                 region: "germany-01".to_string(),
                 addr: parse_addr("10.0.0.1:51821"),
                 authenticated: false,
+                auth_required: false,
                 preflight_mode: RelayPreflightMode::Legacy,
                 queue_full_mode: RelayQueueFullMode::Bypass,
             },
@@ -2840,6 +2857,7 @@ mod tests {
                 region: "germany-02".to_string(),
                 addr: parse_addr("10.0.0.2:51821"),
                 authenticated: true,
+                auth_required: true,
                 preflight_mode: RelayPreflightMode::Legacy,
                 queue_full_mode: RelayQueueFullMode::Drop,
             },
@@ -2847,6 +2865,7 @@ mod tests {
                 region: "germany-03".to_string(),
                 addr: parse_addr("10.0.0.3:51821"),
                 authenticated: false,
+                auth_required: true,
                 preflight_mode: RelayPreflightMode::Legacy,
                 queue_full_mode: RelayQueueFullMode::Bypass,
             },
@@ -2870,6 +2889,7 @@ mod tests {
                 region: "germany-01".to_string(),
                 addr: parse_addr("10.0.0.1:51821"),
                 authenticated: false,
+                auth_required: false,
                 preflight_mode: RelayPreflightMode::Legacy,
                 queue_full_mode: RelayQueueFullMode::Bypass,
             },
@@ -2877,6 +2897,7 @@ mod tests {
                 region: "germany-02".to_string(),
                 addr: parse_addr("10.0.0.2:51821"),
                 authenticated: false,
+                auth_required: false,
                 preflight_mode: RelayPreflightMode::Legacy,
                 queue_full_mode: RelayQueueFullMode::Drop,
             },
@@ -2899,6 +2920,7 @@ mod tests {
             region: "germany-01".to_string(),
             addr: parse_addr("10.0.0.1:51821"),
             authenticated: false,
+            auth_required: false,
             preflight_mode: RelayPreflightMode::Enforce,
             queue_full_mode: RelayQueueFullMode::Bypass,
         }];
@@ -2909,12 +2931,29 @@ mod tests {
     }
 
     #[test]
+    fn test_select_candidate_after_preflight_auth_required_rejects_legacy_fallback() {
+        let attempts = vec![RelayCandidateAttempt {
+            region: "germany-01".to_string(),
+            addr: parse_addr("10.0.0.1:51821"),
+            authenticated: false,
+            auth_required: true,
+            preflight_mode: RelayPreflightMode::Legacy,
+            queue_full_mode: RelayQueueFullMode::Bypass,
+        }];
+
+        let error = select_candidate_after_preflight(&attempts)
+            .expect_err("required auth should reject unauthenticated legacy fallback");
+        assert_eq!(error, CONNECT_FAIL_AUTH_REQUIRED);
+    }
+
+    #[test]
     fn test_select_candidate_after_preflight_fallback_uses_selected_policy() {
         let attempts = vec![
             RelayCandidateAttempt {
                 region: "germany-01".to_string(),
                 addr: parse_addr("10.0.0.1:51821"),
                 authenticated: false,
+                auth_required: false,
                 preflight_mode: RelayPreflightMode::Legacy,
                 queue_full_mode: RelayQueueFullMode::Bypass,
             },
@@ -2922,6 +2961,7 @@ mod tests {
                 region: "germany-02".to_string(),
                 addr: parse_addr("10.0.0.2:51821"),
                 authenticated: false,
+                auth_required: true,
                 preflight_mode: RelayPreflightMode::Legacy,
                 queue_full_mode: RelayQueueFullMode::Drop,
             },

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -4969,19 +4969,13 @@ fn run_packet_reader(
                     let auto_routing_bypass =
                         should_tunnel && auto_router.as_ref().map_or(false, |r| r.is_bypassed());
 
-                    if !should_tunnel || auto_routing_bypass {
-                        // When bypassing due to auto-routing whitelist, still run game server
-                        // detection + evaluation so teleports to non-whitelisted regions resume tunneling.
-                        if auto_routing_bypass {
-                            if let Some(dst_ip) = parse_ipv4_dst_ip(data) {
-                                if is_roblox_game_server_ip(dst_ip) {
-                                    if let Some(ref ar) = auto_router {
-                                        ar.evaluate_game_server(dst_ip);
-                                    }
-                                }
-                            }
-                        }
+                    if auto_routing_packet_action(data, auto_router.as_ref(), should_tunnel)
+                        == AutoRoutingPacketAction::Hold
+                    {
+                        continue;
+                    }
 
+                    if !should_tunnel || auto_routing_bypass {
                         // Batch passthrough (much cheaper than per-packet bypass reinjection).
                         let _ = passthrough_to_adapter.push(&packets[i]);
 
@@ -5036,6 +5030,20 @@ fn run_packet_reader(
                             QueueOverflowMode::from_u8(queue_overflow_mode.load(Ordering::Relaxed));
                         match queue_overflow_action(mode, data) {
                             QueueFullAction::Bypass => {
+                                if auto_routing_packet_action(data, auto_router.as_ref(), false)
+                                    == AutoRoutingPacketAction::Hold
+                                {
+                                    let event =
+                                        queue_full_events.fetch_add(1, Ordering::Relaxed) + 1;
+                                    if event <= 5 || event.is_power_of_two() {
+                                        log::warn!(
+                                            "ST_AUTO_ROUTING_HOLD_QUEUE_FULL: worker {} queue full, dropping pending auto-routing packet instead of bypassing to physical adapter (event #{})",
+                                            worker_id,
+                                            event
+                                        );
+                                    }
+                                    continue;
+                                }
                                 let _ = passthrough_to_adapter.push(&packets[i]);
                                 if let Some(stats) = worker_stats.get(worker_id) {
                                     stats.packets_bypassed.fetch_add(1, Ordering::Relaxed);
@@ -5211,16 +5219,10 @@ fn run_packet_worker(
             let auto_routing_bypass =
                 should_tunnel && auto_router.as_ref().map_or(false, |r| r.is_bypassed());
 
-            // When bypassing, still run game server detection + auto-routing evaluation
-            // so we can detect teleports to non-whitelisted regions and resume tunneling.
-            if auto_routing_bypass {
-                if let Some(dst_ip) = parse_ipv4_dst_ip(&work.data) {
-                    if is_roblox_game_server_ip(dst_ip) {
-                        if let Some(ref ar) = auto_router {
-                            ar.evaluate_game_server(dst_ip);
-                        }
-                    }
-                }
+            if auto_routing_packet_action(&work.data, auto_router.as_ref(), should_tunnel)
+                == AutoRoutingPacketAction::Hold
+            {
+                continue;
             }
 
             if should_tunnel && !auto_routing_bypass {
@@ -5261,12 +5263,7 @@ fn run_packet_worker(
                             }
                         }
 
-                        // === AUTO ROUTING ===
-                        // Notify auto-router of new game server IPs (triggers async region lookup).
-                        // The actual relay switch happens asynchronously via handle_region_lookup().
-                        if let Some(ref auto_router) = auto_router {
-                            auto_router.evaluate_game_server(dst_ip);
-                        }
+                        // Auto-routing was evaluated before any bypass path could run.
                     }
                 }
 
@@ -6133,6 +6130,12 @@ enum QueueFullAction {
     Drop,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutoRoutingPacketAction {
+    Pass,
+    Hold,
+}
+
 #[inline(always)]
 fn is_ipv4_fragment(data: &[u8]) -> bool {
     let ip_start = match parse_ipv4_header_offset(data) {
@@ -6156,6 +6159,42 @@ fn queue_overflow_action(mode: QueueOverflowMode, data: &[u8]) -> QueueFullActio
             }
         }
     }
+}
+
+/// Apply the auto-routing hold gate for packets that could otherwise escape.
+///
+/// `evaluate_new_server` should be true only after the packet has been classified as
+/// tunnel-eligible (including whitelist bypass). Pending lookups are honored for every
+/// packet to the destination, which catches fragments and queue-overflow races without
+/// starting lookups for unrelated traffic.
+#[inline(always)]
+fn auto_routing_packet_action(
+    data: &[u8],
+    auto_router: Option<&Arc<super::auto_routing::AutoRouter>>,
+    evaluate_new_server: bool,
+) -> AutoRoutingPacketAction {
+    let Some(auto_router) = auto_router else {
+        return AutoRoutingPacketAction::Pass;
+    };
+    let Some(dst_ip) = parse_ipv4_dst_ip(data) else {
+        return AutoRoutingPacketAction::Pass;
+    };
+    if !is_roblox_game_server_ip(dst_ip) {
+        return AutoRoutingPacketAction::Pass;
+    }
+
+    if auto_router.is_lookup_pending(dst_ip) {
+        return AutoRoutingPacketAction::Hold;
+    }
+
+    if evaluate_new_server {
+        auto_router.evaluate_game_server(dst_ip);
+        if auto_router.is_lookup_pending(dst_ip) {
+            return AutoRoutingPacketAction::Hold;
+        }
+    }
+
+    AutoRoutingPacketAction::Pass
 }
 
 /// Per-worker inline cache for connection lookups
@@ -9073,6 +9112,79 @@ mod tests {
             queue_overflow_action(QueueOverflowMode::Drop, &frame),
             QueueFullAction::Drop
         );
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_holds_new_game_server_packet() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+
+        let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let frame = build_ipv4_frame(17, Ipv4Addr::new(192, 168, 1, 210), dst_ip, 53020, 54020);
+
+        assert_eq!(
+            auto_routing_packet_action(&frame, Some(&router), true),
+            AutoRoutingPacketAction::Hold
+        );
+        assert!(router.is_lookup_pending(dst_ip));
+        let (queued_ip, generation) = rx.try_recv().expect("lookup should be queued");
+        assert_eq!(queued_ip, dst_ip);
+        assert_eq!(generation, 1);
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_holds_pending_tail_fragment_without_evaluating() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+
+        let src_ip = Ipv4Addr::new(192, 168, 1, 211);
+        let dst_ip = Ipv4Addr::new(128, 116, 51, 100);
+        router.evaluate_game_server(dst_ip);
+        let _ = rx.try_recv().expect("lookup should be queued");
+
+        let tail_fragment =
+            build_ipv4_udp_fragment_frame(src_ip, dst_ip, 53021, 54021, 0x5151, 1, false);
+
+        assert_eq!(
+            auto_routing_packet_action(&tail_fragment, Some(&router), false),
+            AutoRoutingPacketAction::Hold
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "tail fragment must not enqueue another lookup"
+        );
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_does_not_hold_without_lookup_channel() {
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        let dst_ip = Ipv4Addr::new(128, 116, 52, 100);
+        let frame = build_ipv4_frame(17, Ipv4Addr::new(192, 168, 1, 212), dst_ip, 53022, 54022);
+
+        assert_eq!(
+            auto_routing_packet_action(&frame, Some(&router), true),
+            AutoRoutingPacketAction::Pass
+        );
+        assert!(!router.is_lookup_pending(dst_ip));
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_ignores_similar_non_roblox_destination() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+
+        let dst_ip = Ipv4Addr::new(128, 117, 50, 100);
+        let frame = build_ipv4_frame(17, Ipv4Addr::new(192, 168, 1, 213), dst_ip, 53023, 54023);
+
+        assert_eq!(
+            auto_routing_packet_action(&frame, Some(&router), true),
+            AutoRoutingPacketAction::Pass
+        );
+        assert!(rx.try_recv().is_err());
+        assert!(!router.is_lookup_pending(dst_ip));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a shared auto-routing packet gate in the split-tunnel interceptor so packets to a Roblox game-server IP with a pending region lookup are held before any bypass path can send them out.
- Applies the gate in the reader and worker paths, including whitelist bypass, worker queue overflow fallback, and pending fragmented packets.
- Requires forced/pinned relay candidates to still complete the relay-ticket handshake instead of skipping auth, and rejects legacy fallback when the relay policy marks auth as required.
- Adds regression tests for the new auto-routing hold behavior, pending tail fragments, no lookup-channel fallback, a similar non-Roblox destination, and auth-required relay fallback rejection.

## Root Cause

Auto-routing already marked newly detected game-server IPs as pending while the async region lookup ran, but some paths could bypass that hold: whitelist bypass evaluated and then immediately sent to the physical adapter, and queue-full fallback in bypass mode could send tunnel packets to the physical adapter before a worker performed the pending lookup check. Non-initial fragments could also land in the bypass side if their first-fragment decision was unavailable.

Separately, pinned/forced server selection could skip relay-ticket bootstrap and fall back to legacy relay behavior even when the relay policy required authentication. The success condition for relay selection should be an authenticated candidate when auth is required, not merely selecting a matching relay address.

## Validation

- `cargo fmt --check`
- `git diff --cached --check` before committing `connection.rs`
- `git diff --check -- swifttunnel-core/src/vpn/parallel_interceptor.rs`
- `cargo test -p swifttunnel-core auto_routing_packet_action --lib` was attempted on macOS but failed before crate compilation in `windows-future` with missing `windows_core::imp::IMarshal` / `windows_threading::submit` symbols.
- `cargo test -p swifttunnel-core auto_routing_packet_action --lib --target x86_64-pc-windows-msvc --no-run` was attempted but this macOS image lacks the Windows C toolchain headers for `ring` (`assert.h` not found).