### PR TITLE
Treat legacy RobloxPriority QoS removal as non-fatal

### DIFF
--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -466,9 +466,17 @@ impl NetworkBooster {
             .output()?;
 
         if !output.status.success() {
-            return Err(anyhow::anyhow!(
-                "failed to remove legacy RobloxPriority QoS policy"
-            ));
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            if stderr.is_empty() {
+                warn!(
+                    "Failed to remove legacy RobloxPriority QoS policy; treating as non-fatal cleanup"
+                );
+            } else {
+                warn!(
+                    "Failed to remove legacy RobloxPriority QoS policy; treating as non-fatal cleanup: {}",
+                    stderr
+                );
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Prevent a legacy cleanup failure from surfacing as an optimization error and creating a persistent UI warning when unrelated network boosts are toggled.

### Description
- Update `remove_prioritize_game_traffic` in `swifttunnel-core/src/network_booster.rs` to log a warning (including PowerShell `stderr` when present) and continue instead of returning an error when `Remove-NetQosPolicy` fails.

### Testing
- Ran `cargo fmt` successfully.
- Attempted `cargo test -p swifttunnel-core network_booster --no-run`, which failed to compile in this environment due to an upstream `windows-future`/`windows-core` dependency mismatch unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3df3f83c8329ab9f7bffe18baaf1)