### PR TITLE
[codex] Fix connected no traffic tunnel health

### DIFF
--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -24,6 +24,20 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+/// How long an ETW/process-watcher registration remains authoritative when the
+/// Windows owner tables have not published any sockets for that PID yet.
+///
+/// This covers the launch race where Roblox is detected, then the next cache
+/// refresh sees no UDP/TCP endpoints and would otherwise erase the PID before
+/// the first game packet is classified.
+const IMMEDIATE_PROCESS_RETENTION: Duration = Duration::from_secs(45);
+
+#[derive(Clone)]
+struct ImmediateProcessRegistration {
+    name: String,
+    registered_at: Instant,
+}
+
 // ============================================================================
 // GAME SERVER IP RANGES (for V2 hybrid routing)
 // ============================================================================
@@ -487,6 +501,9 @@ pub struct LockFreeProcessCache {
     explicit_tunnel_tcp_ports: Mutex<AHashSet<u16>>,
     /// Last time each API-tunnel TCP port was observed in the owner table.
     explicit_tunnel_tcp_port_last_seen: Mutex<AHashMap<u16, Instant>>,
+    /// PIDs observed by ETW or another immediate source before owner-table
+    /// refreshes can see their sockets.
+    immediate_pid_names: Mutex<AHashMap<u32, ImmediateProcessRegistration>>,
 }
 
 impl LockFreeProcessCache {
@@ -544,7 +561,20 @@ impl LockFreeProcessCache {
             explicit_tunnel_udp_ports: Mutex::new(AHashSet::new()),
             explicit_tunnel_tcp_ports: Mutex::new(AHashSet::new()),
             explicit_tunnel_tcp_port_last_seen: Mutex::new(AHashMap::new()),
+            immediate_pid_names: Mutex::new(AHashMap::new()),
         }
+    }
+
+    fn merge_recent_immediate_processes(&self, pid_names: &mut AHashMap<u32, String>) {
+        let now = Instant::now();
+        let mut immediate = self.immediate_pid_names.lock();
+        immediate.retain(|&pid, entry| {
+            let retain = now.duration_since(entry.registered_at) <= IMMEDIATE_PROCESS_RETENTION;
+            if retain {
+                pid_names.entry(pid).or_insert_with(|| entry.name.clone());
+            }
+            retain
+        });
     }
 
     /// Get current snapshot (lock-free!)
@@ -574,9 +604,10 @@ impl LockFreeProcessCache {
     pub fn update(
         &self,
         connections: AHashMap<ConnectionKey, u32>,
-        pid_names: AHashMap<u32, String>,
+        mut pid_names: AHashMap<u32, String>,
     ) {
         let _snapshot_write_guard = self.snapshot_write_lock.lock();
+        self.merge_recent_immediate_processes(&mut pid_names);
         let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
         let (explicit_tunnel_udp_ports, explicit_tunnel_tcp_ports) = self.clone_explicit_ports();
         let new_snapshot = self.snapshot_from_parts(
@@ -599,10 +630,11 @@ impl LockFreeProcessCache {
     pub fn update_with_tcp_ports(
         &self,
         connections: AHashMap<ConnectionKey, u32>,
-        pid_names: AHashMap<u32, String>,
+        mut pid_names: AHashMap<u32, String>,
         tcp_ports: &[u16],
     ) {
         let _snapshot_write_guard = self.snapshot_write_lock.lock();
+        self.merge_recent_immediate_processes(&mut pid_names);
         let explicit_tunnel_tcp_ports = self.replace_explicit_tcp_ports_locked(tcp_ports);
         let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
         let explicit_tunnel_udp_ports = self.explicit_tunnel_udp_ports.lock().clone();
@@ -625,11 +657,12 @@ impl LockFreeProcessCache {
     pub fn update_with_recent_tcp_ports(
         &self,
         connections: AHashMap<ConnectionKey, u32>,
-        pid_names: AHashMap<u32, String>,
+        mut pid_names: AHashMap<u32, String>,
         tcp_ports: &[u16],
         retain_for: Duration,
     ) {
         let _snapshot_write_guard = self.snapshot_write_lock.lock();
+        self.merge_recent_immediate_processes(&mut pid_names);
         let explicit_tunnel_tcp_ports =
             self.retain_recent_explicit_tcp_ports_locked(tcp_ports, retain_for);
         let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
@@ -715,6 +748,13 @@ impl LockFreeProcessCache {
         {
             return;
         }
+        self.immediate_pid_names.lock().insert(
+            pid,
+            ImmediateProcessRegistration {
+                name: name_lower.clone(),
+                registered_at: Instant::now(),
+            },
+        );
         let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
 
         // Clone existing data and add the new process
@@ -736,6 +776,14 @@ impl LockFreeProcessCache {
             name,
             pid
         );
+    }
+
+    #[cfg(test)]
+    fn age_immediate_process_for_test(&self, pid: u32, age: Duration) {
+        let mut immediate = self.immediate_pid_names.lock();
+        if let Some(entry) = immediate.get_mut(&pid) {
+            entry.registered_at = Instant::now().checked_sub(age).unwrap_or_else(Instant::now);
+        }
     }
 
     /// Immediately register a UDP source port as tunnel-owned.
@@ -1117,6 +1165,44 @@ mod tests {
         );
         assert!(snap1.is_tunnel_pid_public(pid));
         assert!(snap1.tunnel_pids.contains(&pid));
+    }
+
+    #[test]
+    fn test_update_retains_recent_immediate_process_without_endpoint() {
+        let cache = LockFreeProcessCache::new(vec!["roblox".to_string()]);
+        let pid = 2233;
+
+        cache.register_process_immediate(pid, "RobloxPlayerBeta.exe".to_string());
+        cache.update(HashMap::new(), HashMap::new());
+
+        let snap = cache.get_snapshot();
+        assert_eq!(
+            snap.pid_names.get(&pid).map(|s| s.as_str()),
+            Some("robloxplayerbeta.exe")
+        );
+        assert!(
+            snap.tunnel_pids.contains(&pid),
+            "recent ETW registration must survive an empty owner-table refresh"
+        );
+    }
+
+    #[test]
+    fn test_update_drops_expired_immediate_process_without_endpoint() {
+        let cache = LockFreeProcessCache::new(vec!["roblox".to_string()]);
+        let pid = 2244;
+
+        cache.register_process_immediate(pid, "RobloxPlayerBeta.exe".to_string());
+        cache.age_immediate_process_for_test(
+            pid,
+            IMMEDIATE_PROCESS_RETENTION + Duration::from_secs(1),
+        );
+        cache.update(HashMap::new(), HashMap::new());
+
+        let snap = cache.get_snapshot();
+        assert!(
+            !snap.tunnel_pids.contains(&pid),
+            "expired immediate registrations must not tunnel unrelated PID reuse forever"
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -741,13 +741,11 @@ impl LockFreeProcessCache {
         let _snapshot_write_guard = self.snapshot_write_lock.lock();
         let old_snap = self.get_snapshot();
         let name_lower = name.to_lowercase();
-        if old_snap
-            .pid_names
-            .get(&pid)
-            .is_some_and(|existing| existing == &name_lower)
-        {
-            return;
-        }
+
+        // Always refresh the retention timestamp first. If ETW re-fires for a PID
+        // already in the snapshot, the entry might be on the verge of expiring and
+        // would be silently dropped from the next empty owner-table refresh
+        // otherwise. Re-inserting resets the 45-second window.
         self.immediate_pid_names.lock().insert(
             pid,
             ImmediateProcessRegistration {
@@ -755,6 +753,14 @@ impl LockFreeProcessCache {
                 registered_at: Instant::now(),
             },
         );
+
+        if old_snap
+            .pid_names
+            .get(&pid)
+            .is_some_and(|existing| existing == &name_lower)
+        {
+            return;
+        }
         let version = self.version.fetch_add(1, Ordering::Relaxed) + 1;
 
         // Clone existing data and add the new process
@@ -1406,6 +1412,42 @@ mod tests {
         cache.register_process_immediate(7001, "robloxplayerbeta.exe".to_string());
 
         assert_eq!(cache.get_snapshot().version, first_version);
+    }
+
+    #[test]
+    fn test_register_process_immediate_refreshes_retention_for_existing_pid() {
+        let cache = LockFreeProcessCache::new(vec!["roblox".to_string()]);
+        let pid = 7002;
+
+        cache.register_process_immediate(pid, "RobloxPlayerBeta.exe".to_string());
+        // Bring the entry close to expiry. Without the timestamp refresh below,
+        // the next aging step would push it past IMMEDIATE_PROCESS_RETENTION.
+        cache.age_immediate_process_for_test(
+            pid,
+            IMMEDIATE_PROCESS_RETENTION - Duration::from_secs(2),
+        );
+
+        // Same PID/name re-fires from ETW. The snapshot already has it, so the
+        // duplicate-snapshot-rebuild guard short-circuits — but the immediate
+        // retention timestamp must still be refreshed so the entry survives the
+        // next empty owner-table refresh.
+        cache.register_process_immediate(pid, "RobloxPlayerBeta.exe".to_string());
+
+        // Now age forward by another (retention - 2s). With the refresh, total
+        // elapsed from the latest registration is still < retention. Without
+        // the refresh, total elapsed would be ~2*(retention - 2s) > retention
+        // and the PID would be silently dropped.
+        cache.age_immediate_process_for_test(
+            pid,
+            IMMEDIATE_PROCESS_RETENTION - Duration::from_secs(2),
+        );
+        cache.update(HashMap::new(), HashMap::new());
+
+        let snap = cache.get_snapshot();
+        assert!(
+            snap.tunnel_pids.contains(&pid),
+            "ETW re-registration must refresh the immediate retention timestamp"
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/udp_relay.rs
+++ b/swifttunnel-core/src/vpn/udp_relay.rs
@@ -113,6 +113,10 @@ const INJECT_STALE_STREAK: u32 = 8;
 /// Consecutive inject failures that escalate to Dead and force the connection to tear
 /// down so the user can pick a different relay.
 const INJECT_DEAD_STREAK: u32 = 24;
+/// Consecutive structured network-unreachable send failures before the relay is
+/// declared dead. The first failures are treated as a retryable route/socket
+/// hiccup; exhausting the budget surfaces a real connection error.
+const RELAY_SEND_UNREACHABLE_DEAD_THRESHOLD: u32 = 3;
 
 /// Relay health states visible to the connection manager and UI.
 ///
@@ -165,6 +169,79 @@ impl RelaySendOutcome {
             Self::Enqueued(bytes) => bytes,
             Self::Backpressure | Self::Oversize => 0,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RelaySendFailureAction {
+    NonRepairable,
+    RetryBudgetRemaining(u32),
+    RetryBudgetExhausted(u32),
+}
+
+fn is_relay_network_unreachable_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.raw_os_error(),
+        // Windows WSAENETUNREACH, Linux ENETUNREACH, macOS ENETUNREACH.
+        Some(10051) | Some(101) | Some(51)
+    )
+}
+
+fn record_relay_send_success(send_unreachable_streak: &AtomicU32) {
+    if send_unreachable_streak.load(Ordering::Relaxed) != 0 {
+        send_unreachable_streak.store(0, Ordering::Relaxed);
+    }
+}
+
+fn record_relay_send_error(
+    send_errors: &AtomicU64,
+    relay_health: &AtomicU8,
+    send_unreachable_streak: &AtomicU32,
+    err: &std::io::Error,
+    relay_addr: SocketAddr,
+    context: &'static str,
+) -> RelaySendFailureAction {
+    let count = send_errors.fetch_add(1, Ordering::Relaxed) + 1;
+    if count <= 5 || count.is_power_of_two() {
+        log::warn!(
+            "UDP Relay: Sender thread {} send_to error #{} to {}: {}",
+            context,
+            count,
+            relay_addr,
+            err
+        );
+    }
+
+    if !is_relay_network_unreachable_error(err) {
+        send_unreachable_streak.store(0, Ordering::Relaxed);
+        return RelaySendFailureAction::NonRepairable;
+    }
+
+    let streak = send_unreachable_streak.fetch_add(1, Ordering::Relaxed) + 1;
+    if streak >= RELAY_SEND_UNREACHABLE_DEAD_THRESHOLD {
+        relay_health.store(RelayHealthState::Dead as u8, Ordering::Relaxed);
+        log::error!(
+            "UDP Relay: Health -> DEAD (relay_send_unreachable streak {} >= {}, relay {}, context {}, raw_os_error {:?})",
+            streak,
+            RELAY_SEND_UNREACHABLE_DEAD_THRESHOLD,
+            relay_addr,
+            context,
+            err.raw_os_error()
+        );
+        RelaySendFailureAction::RetryBudgetExhausted(streak)
+    } else {
+        if relay_health.load(Ordering::Relaxed) != RelayHealthState::Dead as u8 {
+            relay_health.store(RelayHealthState::Stale as u8, Ordering::Relaxed);
+        }
+        log::warn!(
+            "UDP Relay: relay_send_unreachable is retryable for now (streak {}/{}, relay {}, context {}, raw_os_error {:?})",
+            streak,
+            RELAY_SEND_UNREACHABLE_DEAD_THRESHOLD,
+            relay_addr,
+            context,
+            err.raw_os_error()
+        );
+        RelaySendFailureAction::RetryBudgetRemaining(streak)
     }
 }
 
@@ -382,6 +459,8 @@ pub struct UdpRelay {
     outbound_drops: AtomicU64,
     /// Sender thread UDP send_to() errors.
     send_errors: Arc<AtomicU64>,
+    /// Consecutive structured network-unreachable send failures.
+    send_unreachable_streak: Arc<AtomicU32>,
     /// Effective outer MTU for relay packets (<= 1500), refreshed periodically on Windows.
     relay_path_mtu: AtomicUsize,
     relay_path_context: RelayPathContext,
@@ -516,6 +595,8 @@ impl UdpRelay {
         let (outbound_tx, outbound_rx) = channel::bounded::<OutboundJob>(OUTBOUND_QUEUE_CAP);
         let ping = Arc::new(PingMetrics::new());
         let send_errors = Arc::new(AtomicU64::new(0));
+        let send_unreachable_streak = Arc::new(AtomicU32::new(0));
+        let relay_health = Arc::new(AtomicU8::new(RelayHealthState::NoTrafficYet as u8));
 
         let sender_socket = socket
             .try_clone()
@@ -524,6 +605,8 @@ impl UdpRelay {
         let sender_stop = Arc::clone(&stop_flag);
         let sender_ping = Arc::clone(&ping);
         let sender_send_errors = Arc::clone(&send_errors);
+        let sender_send_unreachable_streak = Arc::clone(&send_unreachable_streak);
+        let sender_relay_health = Arc::clone(&relay_health);
         let sender_session_id = session_id;
         let sender_panicked = Arc::new(AtomicBool::new(false));
         let sender_panicked_for_thread = Arc::clone(&sender_panicked);
@@ -559,15 +642,18 @@ impl UdpRelay {
 
                                 // Send and release buffer slot.
                                 let bytes = unsafe { sender_pool.buffer(job.buf_idx) };
-                                if let Err(e) = sender_socket.send_to(&bytes[..job.len], job.addr) {
-                                    let count =
-                                        sender_send_errors.fetch_add(1, Ordering::Relaxed) + 1;
-                                    if count <= 5 || count.is_power_of_two() {
-                                        log::warn!(
-                                            "UDP Relay: Sender thread send_to error #{} to {}: {}",
-                                            count,
+                                match sender_socket.send_to(&bytes[..job.len], job.addr) {
+                                    Ok(_) => {
+                                        record_relay_send_success(&sender_send_unreachable_streak)
+                                    }
+                                    Err(e) => {
+                                        record_relay_send_error(
+                                            &sender_send_errors,
+                                            &sender_relay_health,
+                                            &sender_send_unreachable_streak,
+                                            &e,
                                             job.addr,
-                                            e
+                                            "data",
                                         );
                                     }
                                 }
@@ -611,14 +697,18 @@ impl UdpRelay {
                         frame[SESSION_ID_LEN + 5..SESSION_ID_LEN + 13]
                             .copy_from_slice(&client_ts_mono_ms.to_be_bytes());
 
-                        if let Err(e) = sender_socket.send_to(&frame, relay_addr) {
-                            let count = sender_send_errors.fetch_add(1, Ordering::Relaxed) + 1;
-                            if count <= 5 || count.is_power_of_two() {
-                                log::warn!(
-                                    "UDP Relay: Sender thread ping send_to error #{} to {}: {}",
-                                    count,
+                        match sender_socket.send_to(&frame, relay_addr) {
+                            Ok(_) => {
+                                record_relay_send_success(&sender_send_unreachable_streak);
+                            }
+                            Err(e) => {
+                                record_relay_send_error(
+                                    &sender_send_errors,
+                                    &sender_relay_health,
+                                    &sender_send_unreachable_streak,
+                                    &e,
                                     relay_addr,
-                                    e
+                                    "ping",
                                 );
                             }
                         }
@@ -694,6 +784,7 @@ impl UdpRelay {
             oversize_drops: AtomicU64::new(0),
             outbound_drops: AtomicU64::new(0),
             send_errors,
+            send_unreachable_streak,
             relay_path_mtu: AtomicUsize::new(initial_mtu.mtu),
             relay_path_context: path_context,
             relay_path_mtu_is_fallback: AtomicBool::new(initial_mtu.is_fallback),
@@ -716,7 +807,7 @@ impl UdpRelay {
             outbound_pool,
             outbound_tx,
             ping,
-            relay_health: Arc::new(AtomicU8::new(RelayHealthState::NoTrafficYet as u8)),
+            relay_health,
             unanswered_keepalives: AtomicU32::new(0),
             inject_error_streak: AtomicU32::new(0),
             keepalive_ping_seq: AtomicU32::new(0),
@@ -793,6 +884,11 @@ impl UdpRelay {
     /// Current consecutive inject-failure streak (for tests + diagnostic logs).
     pub fn inject_error_streak(&self) -> u32 {
         self.inject_error_streak.load(Ordering::Relaxed)
+    }
+
+    /// Current consecutive structured network-unreachable send failures.
+    pub fn send_unreachable_streak(&self) -> u32 {
+        self.send_unreachable_streak.load(Ordering::Relaxed)
     }
 
     fn rollback_unanswered_keepalive(&self) {
@@ -1529,13 +1625,14 @@ impl UdpRelay {
         self.stop_flag.store(true, Ordering::Release);
         let ping = self.ping.snapshot();
         log::info!(
-            "UDP Relay: Stopped session {:016x} (sent: {}, recv: {}, oversize_drops: {}, outbound_drops: {}, send_errors: {}, pppoe_clamp_active: {}, pppoe_clamp_events: {}, health: {}, ping: {}/{} {:.1}% loss)",
+            "UDP Relay: Stopped session {:016x} (sent: {}, recv: {}, oversize_drops: {}, outbound_drops: {}, send_errors: {}, send_unreachable_streak: {}, pppoe_clamp_active: {}, pppoe_clamp_events: {}, health: {}, ping: {}/{} {:.1}% loss)",
             self.session_id_u64(),
             self.packets_sent.load(Ordering::Relaxed),
             self.packets_received.load(Ordering::Relaxed),
             self.oversize_drops.load(Ordering::Relaxed),
             self.outbound_drops.load(Ordering::Relaxed),
             self.send_errors.load(Ordering::Relaxed),
+            self.send_unreachable_streak.load(Ordering::Relaxed),
             self.point_to_point_mtu_clamp_active.load(Ordering::Acquire),
             self.point_to_point_mtu_clamp_events.load(Ordering::Relaxed),
             self.relay_health().as_str(),
@@ -1932,6 +2029,93 @@ mod tests {
             RELAY_PATH_MTU_POINT_TO_POINT_CEILING
         );
         assert_eq!(select_detected_relay_path_mtu(1492, Some(1460), true), 1460);
+    }
+
+    #[test]
+    fn test_network_unreachable_send_errors_exhaust_retry_budget() {
+        let send_errors = AtomicU64::new(0);
+        let relay_health = AtomicU8::new(RelayHealthState::Healthy as u8);
+        let streak = AtomicU32::new(0);
+        let relay_addr: SocketAddr = "127.0.0.1:51821".parse().unwrap();
+        let err = std::io::Error::from_raw_os_error(10051);
+
+        assert_eq!(
+            record_relay_send_error(
+                &send_errors,
+                &relay_health,
+                &streak,
+                &err,
+                relay_addr,
+                "data"
+            ),
+            RelaySendFailureAction::RetryBudgetRemaining(1)
+        );
+        assert_eq!(
+            RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
+            RelayHealthState::Stale
+        );
+
+        assert_eq!(
+            record_relay_send_error(
+                &send_errors,
+                &relay_health,
+                &streak,
+                &err,
+                relay_addr,
+                "data"
+            ),
+            RelaySendFailureAction::RetryBudgetRemaining(2)
+        );
+        assert_eq!(
+            record_relay_send_error(
+                &send_errors,
+                &relay_health,
+                &streak,
+                &err,
+                relay_addr,
+                "data"
+            ),
+            RelaySendFailureAction::RetryBudgetExhausted(3)
+        );
+        assert_eq!(
+            RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
+            RelayHealthState::Dead
+        );
+    }
+
+    #[test]
+    fn test_non_repairable_send_error_does_not_trigger_unreachable_recovery() {
+        let send_errors = AtomicU64::new(0);
+        let relay_health = AtomicU8::new(RelayHealthState::Healthy as u8);
+        let streak = AtomicU32::new(2);
+        let relay_addr: SocketAddr = "127.0.0.1:51821".parse().unwrap();
+        let err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "blocked");
+
+        assert_eq!(
+            record_relay_send_error(
+                &send_errors,
+                &relay_health,
+                &streak,
+                &err,
+                relay_addr,
+                "data"
+            ),
+            RelaySendFailureAction::NonRepairable
+        );
+        assert_eq!(streak.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
+            RelayHealthState::Healthy
+        );
+    }
+
+    #[test]
+    fn test_success_resets_network_unreachable_send_streak() {
+        let streak = AtomicU32::new(2);
+
+        record_relay_send_success(&streak);
+
+        assert_eq!(streak.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/udp_relay.rs
+++ b/swifttunnel-core/src/vpn/udp_relay.rs
@@ -117,6 +117,14 @@ const INJECT_DEAD_STREAK: u32 = 24;
 /// declared dead. The first failures are treated as a retryable route/socket
 /// hiccup; exhausting the budget surfaces a real connection error.
 const RELAY_SEND_UNREACHABLE_DEAD_THRESHOLD: u32 = 3;
+/// Consecutive send failures of *any* class (not just network-unreachable) that
+/// escalate the relay to Stale. This catches persistent non-repairable errors
+/// (e.g. ENOBUFS/EPERM/EACCES) that would otherwise leave health untouched
+/// while the connection silently stops moving traffic.
+const RELAY_SEND_FAILURE_STALE_THRESHOLD: u32 = 8;
+/// Consecutive send failures of any class that escalate the relay to Dead so the
+/// connection monitor tears down instead of sitting in a fake Connected state.
+const RELAY_SEND_FAILURE_DEAD_THRESHOLD: u32 = 24;
 
 /// Relay health states visible to the connection manager and UI.
 ///
@@ -187,16 +195,30 @@ fn is_relay_network_unreachable_error(err: &std::io::Error) -> bool {
     )
 }
 
-fn record_relay_send_success(send_unreachable_streak: &AtomicU32) {
+fn record_relay_send_success(send_unreachable_streak: &AtomicU32, send_failure_streak: &AtomicU32) {
     if send_unreachable_streak.load(Ordering::Relaxed) != 0 {
         send_unreachable_streak.store(0, Ordering::Relaxed);
     }
+    if send_failure_streak.load(Ordering::Relaxed) != 0 {
+        send_failure_streak.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Monotonically escalate `relay_health` to at least `target`.
+///
+/// `RelayHealthState` is laid out so worse states have larger discriminants
+/// (Healthy=0, NoTrafficYet=1, Stale=2, Dead=3). Using `fetch_max` makes the
+/// transition atomic: a concurrent writer that already moved health to Dead
+/// can never be silently downgraded to Stale by a later non-Dead update.
+fn escalate_relay_health(relay_health: &AtomicU8, target: RelayHealthState) {
+    relay_health.fetch_max(target as u8, Ordering::Relaxed);
 }
 
 fn record_relay_send_error(
     send_errors: &AtomicU64,
     relay_health: &AtomicU8,
     send_unreachable_streak: &AtomicU32,
+    send_failure_streak: &AtomicU32,
     err: &std::io::Error,
     relay_addr: SocketAddr,
     context: &'static str,
@@ -212,14 +234,42 @@ fn record_relay_send_error(
         );
     }
 
+    let total_failures = send_failure_streak.fetch_add(1, Ordering::Relaxed) + 1;
+
     if !is_relay_network_unreachable_error(err) {
         send_unreachable_streak.store(0, Ordering::Relaxed);
+
+        // Persistent non-repairable failures still need to surface as a real
+        // health degradation; otherwise the connection monitor sees Healthy
+        // forever while every send fails with EPERM/ENOBUFS/etc.
+        if total_failures >= RELAY_SEND_FAILURE_DEAD_THRESHOLD {
+            escalate_relay_health(relay_health, RelayHealthState::Dead);
+            log::error!(
+                "UDP Relay: Health -> DEAD (relay_send_failure streak {} >= {}, relay {}, context {}, raw_os_error {:?})",
+                total_failures,
+                RELAY_SEND_FAILURE_DEAD_THRESHOLD,
+                relay_addr,
+                context,
+                err.raw_os_error()
+            );
+        } else if total_failures >= RELAY_SEND_FAILURE_STALE_THRESHOLD {
+            escalate_relay_health(relay_health, RelayHealthState::Stale);
+            log::warn!(
+                "UDP Relay: Health -> STALE (relay_send_failure streak {} >= {}, relay {}, context {}, raw_os_error {:?})",
+                total_failures,
+                RELAY_SEND_FAILURE_STALE_THRESHOLD,
+                relay_addr,
+                context,
+                err.raw_os_error()
+            );
+        }
+
         return RelaySendFailureAction::NonRepairable;
     }
 
     let streak = send_unreachable_streak.fetch_add(1, Ordering::Relaxed) + 1;
     if streak >= RELAY_SEND_UNREACHABLE_DEAD_THRESHOLD {
-        relay_health.store(RelayHealthState::Dead as u8, Ordering::Relaxed);
+        escalate_relay_health(relay_health, RelayHealthState::Dead);
         log::error!(
             "UDP Relay: Health -> DEAD (relay_send_unreachable streak {} >= {}, relay {}, context {}, raw_os_error {:?})",
             streak,
@@ -230,9 +280,7 @@ fn record_relay_send_error(
         );
         RelaySendFailureAction::RetryBudgetExhausted(streak)
     } else {
-        if relay_health.load(Ordering::Relaxed) != RelayHealthState::Dead as u8 {
-            relay_health.store(RelayHealthState::Stale as u8, Ordering::Relaxed);
-        }
+        escalate_relay_health(relay_health, RelayHealthState::Stale);
         log::warn!(
             "UDP Relay: relay_send_unreachable is retryable for now (streak {}/{}, relay {}, context {}, raw_os_error {:?})",
             streak,
@@ -461,6 +509,9 @@ pub struct UdpRelay {
     send_errors: Arc<AtomicU64>,
     /// Consecutive structured network-unreachable send failures.
     send_unreachable_streak: Arc<AtomicU32>,
+    /// Consecutive send failures of any class (catches non-repairable errors
+    /// like ENOBUFS/EPERM that don't trip the unreachable retry budget).
+    send_failure_streak: Arc<AtomicU32>,
     /// Effective outer MTU for relay packets (<= 1500), refreshed periodically on Windows.
     relay_path_mtu: AtomicUsize,
     relay_path_context: RelayPathContext,
@@ -596,6 +647,7 @@ impl UdpRelay {
         let ping = Arc::new(PingMetrics::new());
         let send_errors = Arc::new(AtomicU64::new(0));
         let send_unreachable_streak = Arc::new(AtomicU32::new(0));
+        let send_failure_streak = Arc::new(AtomicU32::new(0));
         let relay_health = Arc::new(AtomicU8::new(RelayHealthState::NoTrafficYet as u8));
 
         let sender_socket = socket
@@ -606,6 +658,7 @@ impl UdpRelay {
         let sender_ping = Arc::clone(&ping);
         let sender_send_errors = Arc::clone(&send_errors);
         let sender_send_unreachable_streak = Arc::clone(&send_unreachable_streak);
+        let sender_send_failure_streak = Arc::clone(&send_failure_streak);
         let sender_relay_health = Arc::clone(&relay_health);
         let sender_session_id = session_id;
         let sender_panicked = Arc::new(AtomicBool::new(false));
@@ -643,14 +696,16 @@ impl UdpRelay {
                                 // Send and release buffer slot.
                                 let bytes = unsafe { sender_pool.buffer(job.buf_idx) };
                                 match sender_socket.send_to(&bytes[..job.len], job.addr) {
-                                    Ok(_) => {
-                                        record_relay_send_success(&sender_send_unreachable_streak)
-                                    }
+                                    Ok(_) => record_relay_send_success(
+                                        &sender_send_unreachable_streak,
+                                        &sender_send_failure_streak,
+                                    ),
                                     Err(e) => {
                                         record_relay_send_error(
                                             &sender_send_errors,
                                             &sender_relay_health,
                                             &sender_send_unreachable_streak,
+                                            &sender_send_failure_streak,
                                             &e,
                                             job.addr,
                                             "data",
@@ -699,13 +754,17 @@ impl UdpRelay {
 
                         match sender_socket.send_to(&frame, relay_addr) {
                             Ok(_) => {
-                                record_relay_send_success(&sender_send_unreachable_streak);
+                                record_relay_send_success(
+                                    &sender_send_unreachable_streak,
+                                    &sender_send_failure_streak,
+                                );
                             }
                             Err(e) => {
                                 record_relay_send_error(
                                     &sender_send_errors,
                                     &sender_relay_health,
                                     &sender_send_unreachable_streak,
+                                    &sender_send_failure_streak,
                                     &e,
                                     relay_addr,
                                     "ping",
@@ -785,6 +844,7 @@ impl UdpRelay {
             outbound_drops: AtomicU64::new(0),
             send_errors,
             send_unreachable_streak,
+            send_failure_streak,
             relay_path_mtu: AtomicUsize::new(initial_mtu.mtu),
             relay_path_context: path_context,
             relay_path_mtu_is_fallback: AtomicBool::new(initial_mtu.is_fallback),
@@ -889,6 +949,11 @@ impl UdpRelay {
     /// Current consecutive structured network-unreachable send failures.
     pub fn send_unreachable_streak(&self) -> u32 {
         self.send_unreachable_streak.load(Ordering::Relaxed)
+    }
+
+    /// Current consecutive send failures of any class.
+    pub fn send_failure_streak(&self) -> u32 {
+        self.send_failure_streak.load(Ordering::Relaxed)
     }
 
     fn rollback_unanswered_keepalive(&self) {
@@ -1523,8 +1588,7 @@ impl UdpRelay {
 
             if unanswered >= RELAY_DEAD_KEEPALIVE_THRESHOLD {
                 if current != RelayHealthState::Dead {
-                    self.relay_health
-                        .store(RelayHealthState::Dead as u8, Ordering::Relaxed);
+                    escalate_relay_health(&self.relay_health, RelayHealthState::Dead);
                     log::error!(
                         "UDP Relay: Health -> DEAD (no inbound ever, {} unanswered keepalives, {}s since first outbound, session {:016x})",
                         unanswered,
@@ -1534,8 +1598,7 @@ impl UdpRelay {
                 }
             } else if silence >= RELAY_STALE_THRESHOLD && current == RelayHealthState::NoTrafficYet
             {
-                self.relay_health
-                    .store(RelayHealthState::Stale as u8, Ordering::Relaxed);
+                escalate_relay_health(&self.relay_health, RelayHealthState::Stale);
                 log::warn!(
                     "UDP Relay: Health -> STALE (no inbound ever, {}s since first outbound, {} unanswered keepalives, session {:016x})",
                     silence.as_secs(),
@@ -1557,8 +1620,7 @@ impl UdpRelay {
 
         if unanswered >= RELAY_DEAD_KEEPALIVE_THRESHOLD {
             if current != RelayHealthState::Dead {
-                self.relay_health
-                    .store(RelayHealthState::Dead as u8, Ordering::Relaxed);
+                escalate_relay_health(&self.relay_health, RelayHealthState::Dead);
                 log::error!(
                     "UDP Relay: Health -> DEAD ({} unanswered keepalives, {}s silence, session {:016x})",
                     unanswered,
@@ -1568,8 +1630,7 @@ impl UdpRelay {
             }
         } else if silence >= RELAY_STALE_THRESHOLD {
             if current == RelayHealthState::Healthy {
-                self.relay_health
-                    .store(RelayHealthState::Stale as u8, Ordering::Relaxed);
+                escalate_relay_health(&self.relay_health, RelayHealthState::Stale);
                 log::warn!(
                     "UDP Relay: Health -> STALE ({}s since last inbound packet, {} unanswered keepalives, session {:016x})",
                     silence.as_secs(),
@@ -1586,8 +1647,7 @@ impl UdpRelay {
         let current_after = self.relay_health();
         if streak >= INJECT_DEAD_STREAK {
             if current_after != RelayHealthState::Dead {
-                self.relay_health
-                    .store(RelayHealthState::Dead as u8, Ordering::Relaxed);
+                escalate_relay_health(&self.relay_health, RelayHealthState::Dead);
                 log::error!(
                     "UDP Relay: Health -> DEAD (inject failure streak {} >= {}, session {:016x})",
                     streak,
@@ -1601,8 +1661,7 @@ impl UdpRelay {
                 RelayHealthState::Healthy | RelayHealthState::NoTrafficYet
             )
         {
-            self.relay_health
-                .store(RelayHealthState::Stale as u8, Ordering::Relaxed);
+            escalate_relay_health(&self.relay_health, RelayHealthState::Stale);
             log::warn!(
                 "UDP Relay: Health -> STALE (inject failure streak {} >= {}, session {:016x})",
                 streak,
@@ -1625,7 +1684,7 @@ impl UdpRelay {
         self.stop_flag.store(true, Ordering::Release);
         let ping = self.ping.snapshot();
         log::info!(
-            "UDP Relay: Stopped session {:016x} (sent: {}, recv: {}, oversize_drops: {}, outbound_drops: {}, send_errors: {}, send_unreachable_streak: {}, pppoe_clamp_active: {}, pppoe_clamp_events: {}, health: {}, ping: {}/{} {:.1}% loss)",
+            "UDP Relay: Stopped session {:016x} (sent: {}, recv: {}, oversize_drops: {}, outbound_drops: {}, send_errors: {}, send_unreachable_streak: {}, send_failure_streak: {}, pppoe_clamp_active: {}, pppoe_clamp_events: {}, health: {}, ping: {}/{} {:.1}% loss)",
             self.session_id_u64(),
             self.packets_sent.load(Ordering::Relaxed),
             self.packets_received.load(Ordering::Relaxed),
@@ -1633,6 +1692,7 @@ impl UdpRelay {
             self.outbound_drops.load(Ordering::Relaxed),
             self.send_errors.load(Ordering::Relaxed),
             self.send_unreachable_streak.load(Ordering::Relaxed),
+            self.send_failure_streak.load(Ordering::Relaxed),
             self.point_to_point_mtu_clamp_active.load(Ordering::Acquire),
             self.point_to_point_mtu_clamp_events.load(Ordering::Relaxed),
             self.relay_health().as_str(),
@@ -2035,7 +2095,8 @@ mod tests {
     fn test_network_unreachable_send_errors_exhaust_retry_budget() {
         let send_errors = AtomicU64::new(0);
         let relay_health = AtomicU8::new(RelayHealthState::Healthy as u8);
-        let streak = AtomicU32::new(0);
+        let unreachable = AtomicU32::new(0);
+        let failure = AtomicU32::new(0);
         let relay_addr: SocketAddr = "127.0.0.1:51821".parse().unwrap();
         let err = std::io::Error::from_raw_os_error(10051);
 
@@ -2043,7 +2104,8 @@ mod tests {
             record_relay_send_error(
                 &send_errors,
                 &relay_health,
-                &streak,
+                &unreachable,
+                &failure,
                 &err,
                 relay_addr,
                 "data"
@@ -2059,7 +2121,8 @@ mod tests {
             record_relay_send_error(
                 &send_errors,
                 &relay_health,
-                &streak,
+                &unreachable,
+                &failure,
                 &err,
                 relay_addr,
                 "data"
@@ -2070,7 +2133,8 @@ mod tests {
             record_relay_send_error(
                 &send_errors,
                 &relay_health,
-                &streak,
+                &unreachable,
+                &failure,
                 &err,
                 relay_addr,
                 "data"
@@ -2087,7 +2151,8 @@ mod tests {
     fn test_non_repairable_send_error_does_not_trigger_unreachable_recovery() {
         let send_errors = AtomicU64::new(0);
         let relay_health = AtomicU8::new(RelayHealthState::Healthy as u8);
-        let streak = AtomicU32::new(2);
+        let unreachable = AtomicU32::new(2);
+        let failure = AtomicU32::new(0);
         let relay_addr: SocketAddr = "127.0.0.1:51821".parse().unwrap();
         let err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "blocked");
 
@@ -2095,14 +2160,17 @@ mod tests {
             record_relay_send_error(
                 &send_errors,
                 &relay_health,
-                &streak,
+                &unreachable,
+                &failure,
                 &err,
                 relay_addr,
                 "data"
             ),
             RelaySendFailureAction::NonRepairable
         );
-        assert_eq!(streak.load(Ordering::Relaxed), 0);
+        // Unreachable streak resets so it can't masquerade as fast-budget exhaustion.
+        assert_eq!(unreachable.load(Ordering::Relaxed), 0);
+        // A single non-repairable failure must not yet escalate health.
         assert_eq!(
             RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
             RelayHealthState::Healthy
@@ -2110,12 +2178,103 @@ mod tests {
     }
 
     #[test]
-    fn test_success_resets_network_unreachable_send_streak() {
-        let streak = AtomicU32::new(2);
+    fn test_persistent_non_repairable_send_errors_escalate_to_dead() {
+        let send_errors = AtomicU64::new(0);
+        let relay_health = AtomicU8::new(RelayHealthState::Healthy as u8);
+        let unreachable = AtomicU32::new(0);
+        let failure = AtomicU32::new(0);
+        let relay_addr: SocketAddr = "127.0.0.1:51821".parse().unwrap();
+        let err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "blocked");
 
-        record_relay_send_success(&streak);
+        for _ in 0..(RELAY_SEND_FAILURE_STALE_THRESHOLD - 1) {
+            record_relay_send_error(
+                &send_errors,
+                &relay_health,
+                &unreachable,
+                &failure,
+                &err,
+                relay_addr,
+                "data",
+            );
+        }
+        // Still below the slow threshold — stay Healthy.
+        assert_eq!(
+            RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
+            RelayHealthState::Healthy
+        );
 
-        assert_eq!(streak.load(Ordering::Relaxed), 0);
+        // Crossing the Stale threshold escalates without ever seeing an unreachable code.
+        record_relay_send_error(
+            &send_errors,
+            &relay_health,
+            &unreachable,
+            &failure,
+            &err,
+            relay_addr,
+            "data",
+        );
+        assert_eq!(
+            RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
+            RelayHealthState::Stale
+        );
+
+        for _ in 0..(RELAY_SEND_FAILURE_DEAD_THRESHOLD - RELAY_SEND_FAILURE_STALE_THRESHOLD) {
+            record_relay_send_error(
+                &send_errors,
+                &relay_health,
+                &unreachable,
+                &failure,
+                &err,
+                relay_addr,
+                "data",
+            );
+        }
+        assert_eq!(
+            RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
+            RelayHealthState::Dead
+        );
+        // Unreachable streak must never have been touched by non-repairable errors.
+        assert_eq!(unreachable.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_concurrent_unreachable_stale_cannot_downgrade_dead() {
+        // Simulates the TOCTOU window where check_health() escalated relay_health
+        // to Dead between the sender thread observing an unreachable error and
+        // committing its Stale escalation. The monotonic fetch_max must not
+        // silently downgrade the relay back to Stale.
+        let send_errors = AtomicU64::new(0);
+        let relay_health = AtomicU8::new(RelayHealthState::Dead as u8);
+        let unreachable = AtomicU32::new(0);
+        let failure = AtomicU32::new(0);
+        let relay_addr: SocketAddr = "127.0.0.1:51821".parse().unwrap();
+        let err = std::io::Error::from_raw_os_error(10051);
+
+        record_relay_send_error(
+            &send_errors,
+            &relay_health,
+            &unreachable,
+            &failure,
+            &err,
+            relay_addr,
+            "data",
+        );
+
+        assert_eq!(
+            RelayHealthState::from_u8(relay_health.load(Ordering::Relaxed)),
+            RelayHealthState::Dead
+        );
+    }
+
+    #[test]
+    fn test_success_resets_send_streaks() {
+        let unreachable = AtomicU32::new(2);
+        let failure = AtomicU32::new(5);
+
+        record_relay_send_success(&unreachable, &failure);
+
+        assert_eq!(unreachable.load(Ordering::Relaxed), 0);
+        assert_eq!(failure.load(Ordering::Relaxed), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a v2.0.14 failure mode where SwiftTunnel can report `Connected` while Roblox traffic is not actually moving.

The user log showed two related problems:

- a just-detected Roblox process could be erased by the next empty owner-table refresh before its first sockets appeared
- repeated UDP relay `send_to` failures with Windows `WSAENETUNREACH` / `os error 10051` stayed as log noise instead of forcing the session out of the healthy connected state

## Changes

- Retain immediate ETW/process-watcher registrations for a short bounded window so launch-time Roblox PIDs survive empty owner-table refreshes.
- Expire those immediate registrations so PID reuse cannot tunnel unrelated processes forever.
- Track structured network-unreachable relay send failures separately from generic send errors.
- Mark relay health stale during the retry budget and dead after repeated unreachable sends, letting the connection monitor surface a real error and clean up instead of silently sitting connected.
- Add positive and negative tests for the immediate PID retention and relay send-failure classification.

## Validation

- `rustfmt --edition 2024 --check swifttunnel-core/src/vpn/process_cache.rs swifttunnel-core/src/vpn/udp_relay.rs`
- `git diff --check -- swifttunnel-core/src/vpn/process_cache.rs swifttunnel-core/src/vpn/udp_relay.rs`

Blocked:

- Local `cargo test -p swifttunnel-core ...` currently fails before compiling this crate because `windows-future v0.3.2` cannot find matching `windows_core::imp`/`windows_threading` symbols on this macOS checkout.
- Windows testbench SSH to `51.79.128.68:22` timed out during validation, so the focused Windows tests could not be run from this session.