### PR TITLE
Block IPv6 via firewall rule instead of unbinding ms_tcpip6

### DIFF
--- a/swifttunnel-core/src/vpn/ipv6_recovery.rs
+++ b/swifttunnel-core/src/vpn/ipv6_recovery.rs
@@ -9,6 +9,7 @@
 //! cleanly.
 
 pub const IPV6_BLOCK_RULE_NAME: &str = "SwiftTunnel-Block-IPv6-Outbound";
+pub const IPV6_BLOCK_REMOTE_IPS: &str = "2000::/3,64:ff9b::/96";
 
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -29,8 +30,8 @@ pub enum DisableMethod {
     #[default]
     BindingDisable,
     /// Current method: a Windows Firewall outbound block rule named
-    /// [`IPV6_BLOCK_RULE_NAME`] that drops traffic to `::/0`. No adapter
-    /// rebind, no WMI involvement.
+    /// [`IPV6_BLOCK_RULE_NAME`] that drops public IPv6/NAT64 traffic. No
+    /// adapter rebind, no WMI involvement.
     FirewallRule,
 }
 
@@ -67,19 +68,36 @@ impl Ipv6Marker {
         &self.method
     }
 
-    fn restore_command(&self) -> &'static str {
+    fn restore_command(&self) -> String {
         match self.method {
-            DisableMethod::FirewallRule => {
-                // Idempotent: netsh returns non-zero if the rule is missing,
-                // but we don't care — `2>&1 | Out-Null` swallows both. The
-                // outer script verifies the rule is gone afterwards.
-                "$null = & netsh.exe advfirewall firewall delete rule name=\"SwiftTunnel-Block-IPv6-Outbound\" 2>&1"
-            }
+            DisableMethod::FirewallRule => format!(
+                r#"
+        $name = "{}"
+        $deleteOutput = & netsh.exe advfirewall firewall delete rule name="$name" 2>&1
+        $deleteExit = $LASTEXITCODE
+        $showOutput = & netsh.exe advfirewall firewall show rule name="$name" 2>&1
+        $showExit = $LASTEXITCODE
+        $deleteText = ($deleteOutput | Out-String).Trim()
+        $showText = ($showOutput | Out-String).Trim()
+
+        if ($showExit -eq 0) {{
+            Write-Error ('IPv6 block firewall rule still exists after delete attempt. Delete exit=' + $deleteExit + '. Delete output: ' + $deleteText)
+            exit 1
+        }}
+
+        if ($deleteExit -ne 0 -and $showText -notmatch 'No rules match') {{
+            Write-Error ('Could not verify IPv6 block firewall rule removal. Delete exit=' + $deleteExit + '. Delete output: ' + $deleteText + '. Show output: ' + $showText)
+            exit 1
+        }}
+        "#,
+                IPV6_BLOCK_RULE_NAME
+            ),
             DisableMethod::BindingDisable => match self.originally_enabled {
                 Some(false) => {
-                    "Disable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 -Confirm:$false 2>$null"
+                    "Disable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 -Confirm:$false 2>$null".to_string()
                 }
-                _ => "Enable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 2>$null",
+                _ => "Enable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 2>$null"
+                    .to_string(),
             },
         }
     }
@@ -409,14 +427,12 @@ mod tests {
 
     #[test]
     fn test_firewall_rule_restore_command_references_block_rule_name() {
-        // restore_command returns a &'static str so we can't format the rule
-        // name in. This guards against IPV6_BLOCK_RULE_NAME being renamed
-        // without also updating the netsh delete literal — which would leave
-        // an orphaned rule on every disconnect.
         let marker = Ipv6Marker::for_firewall_rule("Ethernet".to_string());
         let cmd = marker.restore_command();
         assert!(cmd.contains(IPV6_BLOCK_RULE_NAME), "{}", cmd);
         assert!(cmd.contains("netsh.exe advfirewall firewall delete rule"));
+        assert!(cmd.contains("netsh.exe advfirewall firewall show rule"));
+        assert!(cmd.contains("exit 1"));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/ipv6_recovery.rs
+++ b/swifttunnel-core/src/vpn/ipv6_recovery.rs
@@ -1,9 +1,14 @@
-//! IPv6 binding crash recovery
+//! IPv6 leak-prevention crash recovery
 //!
-//! When SwiftTunnel disables IPv6 on the physical network adapter for split tunneling,
-//! it stores the original binding state in a marker file. If the app crashes before
-//! restoring that state, startup recovery restores the adapter to its exact prior
-//! configuration instead of blindly enabling IPv6.
+//! While connected, SwiftTunnel installs a Windows Firewall rule that blocks
+//! outbound IPv6. The marker file records that we did so (and which method we
+//! used) so a startup recovery pass can clean up after a crash without
+//! guessing at adapter state. Old installations used a different method
+//! (`Disable-NetAdapterBinding ms_tcpip6`); we keep the deserialization shape
+//! backwards-compatible so an upgrade across that boundary still recovers
+//! cleanly.
+
+pub const IPV6_BLOCK_RULE_NAME: &str = "SwiftTunnel-Block-IPv6-Outbound";
 
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -12,10 +17,29 @@ use std::path::PathBuf;
 /// Marker file name stored in %LOCALAPPDATA%/SwiftTunnel/
 const IPV6_MARKER_FILE: &str = "ipv6_disabled.marker";
 
+/// How SwiftTunnel prevented IPv6 leakage during the session this marker
+/// belongs to.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DisableMethod {
+    /// Pre-2.0.15 method: `Disable-NetAdapterBinding -ComponentId ms_tcpip6`.
+    /// Causes an NDIS rebind which physically takes the adapter offline for
+    /// 2-10s on many real-world NICs (Realtek, USB-Ethernet, Parallels VirtIO,
+    /// some Intel) — users see "my Ethernet just turned off." Default for
+    /// markers that predate the method field.
+    #[default]
+    BindingDisable,
+    /// Current method: a Windows Firewall outbound block rule named
+    /// [`IPV6_BLOCK_RULE_NAME`] that drops traffic to `::/0`. No adapter
+    /// rebind, no WMI involvement.
+    FirewallRule,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ipv6Marker {
     adapter_name: String,
     originally_enabled: Option<bool>,
+    #[serde(default)]
+    method: DisableMethod,
 }
 
 impl Ipv6Marker {
@@ -23,6 +47,15 @@ impl Ipv6Marker {
         Self {
             adapter_name,
             originally_enabled: None,
+            method: DisableMethod::BindingDisable,
+        }
+    }
+
+    pub(crate) fn for_firewall_rule(adapter_name: String) -> Self {
+        Self {
+            adapter_name,
+            originally_enabled: None,
+            method: DisableMethod::FirewallRule,
         }
     }
 
@@ -30,12 +63,24 @@ impl Ipv6Marker {
         &self.adapter_name
     }
 
+    pub fn method(&self) -> &DisableMethod {
+        &self.method
+    }
+
     fn restore_command(&self) -> &'static str {
-        match self.originally_enabled {
-            Some(false) => {
-                "Disable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 -Confirm:$false 2>$null"
+        match self.method {
+            DisableMethod::FirewallRule => {
+                // Idempotent: netsh returns non-zero if the rule is missing,
+                // but we don't care — `2>&1 | Out-Null` swallows both. The
+                // outer script verifies the rule is gone afterwards.
+                "$null = & netsh.exe advfirewall firewall delete rule name=\"SwiftTunnel-Block-IPv6-Outbound\" 2>&1"
             }
-            _ => "Enable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 2>$null",
+            DisableMethod::BindingDisable => match self.originally_enabled {
+                Some(false) => {
+                    "Disable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 -Confirm:$false 2>$null"
+                }
+                _ => "Enable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 2>$null",
+            },
         }
     }
 }
@@ -192,22 +237,39 @@ pub fn has_ipv6_binding_native(_if_index: u32) -> Option<bool> {
 
 /// Write IPv6 disabled marker with adapter name and original binding state.
 pub fn write_ipv6_marker(adapter_name: &str) {
+    let marker = Ipv6Marker {
+        adapter_name: adapter_name.trim().to_string(),
+        originally_enabled: query_ipv6_binding_enabled(adapter_name),
+        method: DisableMethod::BindingDisable,
+    };
+    write_marker(&marker);
+}
+
+/// Write a marker indicating the firewall-rule method was used to block IPv6.
+/// Used by the modern disable path so a crash-recovery pass can run
+/// `netsh advfirewall firewall delete rule` to clean up.
+pub fn write_ipv6_marker_firewall(adapter_name: &str) {
+    let marker = Ipv6Marker::for_firewall_rule(adapter_name.trim().to_string());
+    write_marker(&marker);
+}
+
+fn write_marker(marker: &Ipv6Marker) {
     if let Some(marker_path) = get_marker_path() {
         if let Some(parent) = marker_path.parent() {
             let _ = fs::create_dir_all(parent);
         }
 
-        let marker = Ipv6Marker {
-            adapter_name: adapter_name.trim().to_string(),
-            originally_enabled: query_ipv6_binding_enabled(adapter_name),
-        };
-        let payload =
-            serde_json::to_vec(&marker).unwrap_or_else(|_| adapter_name.as_bytes().to_vec());
+        let payload = serde_json::to_vec(marker)
+            .unwrap_or_else(|_| marker.adapter_name().as_bytes().to_vec());
 
         if let Err(e) = fs::write(&marker_path, payload) {
             log::warn!("Failed to write IPv6 marker file: {}", e);
         } else {
-            log::debug!("IPv6 marker written for adapter: {}", marker.adapter_name());
+            log::debug!(
+                "IPv6 marker written for adapter: {} (method: {:?})",
+                marker.adapter_name(),
+                marker.method()
+            );
         }
     }
 }
@@ -343,6 +405,30 @@ mod tests {
 
         let after_delete = read_ipv6_marker();
         assert_eq!(after_delete, None);
+    }
+
+    #[test]
+    fn test_firewall_rule_restore_command_references_block_rule_name() {
+        // restore_command returns a &'static str so we can't format the rule
+        // name in. This guards against IPV6_BLOCK_RULE_NAME being renamed
+        // without also updating the netsh delete literal — which would leave
+        // an orphaned rule on every disconnect.
+        let marker = Ipv6Marker::for_firewall_rule("Ethernet".to_string());
+        let cmd = marker.restore_command();
+        assert!(cmd.contains(IPV6_BLOCK_RULE_NAME), "{}", cmd);
+        assert!(cmd.contains("netsh.exe advfirewall firewall delete rule"));
+    }
+
+    #[test]
+    fn test_legacy_marker_round_trip_uses_binding_disable_method() {
+        // Markers written by pre-2.0.15 builds do not include the `method`
+        // field. They must deserialize as BindingDisable so the restore path
+        // runs Enable-NetAdapterBinding (matching the original behavior).
+        let legacy_payload = br#"{"adapter_name":"Ethernet","originally_enabled":true}"#;
+        let marker: Ipv6Marker = serde_json::from_slice(legacy_payload).unwrap();
+        assert_eq!(marker.method(), &DisableMethod::BindingDisable);
+        assert_eq!(marker.adapter_name(), "Ethernet");
+        assert!(marker.restore_command().contains("Enable-NetAdapterBinding"));
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -58,8 +58,7 @@ use serde::Serialize;
 use crate::process_names::process_name_matches_any_tunnel_app;
 
 use super::ipv6_recovery::{
-    delete_ipv6_marker, has_ipv6_binding_native, query_ipv6_binding_enabled,
-    restore_ipv6_from_marker, write_ipv6_marker,
+    IPV6_BLOCK_RULE_NAME, delete_ipv6_marker, restore_ipv6_from_marker, write_ipv6_marker_firewall,
 };
 use super::process_cache::{LockFreeProcessCache, ProcessSnapshot};
 use super::process_tracker::{ConnectionKey, Protocol};
@@ -3587,37 +3586,54 @@ impl ParallelInterceptor {
         self.tso_was_disabled = false;
     }
 
-    fn build_disable_ipv6_script(adapter_friendly_name: &str) -> String {
-        // Use explicit error output so failures are visible in logs for diagnostics.
+    fn build_disable_ipv6_script(_adapter_friendly_name: &str) -> String {
+        // Block outbound IPv6 via a Windows Firewall rule using `netsh advfirewall`.
+        //
+        // Why not `Disable-NetAdapterBinding -ComponentId ms_tcpip6` (the
+        // pre-2.0.15 approach):
+        //   That cmdlet rebinds the NDIS stack on the adapter, which
+        //   physically takes the link offline and back. On many real-world
+        //   NICs (Realtek, USB-Ethernet dongles, Parallels VirtIO, some Intel
+        //   variants) the relink takes 2-10 seconds and Windows reports the
+        //   connection as dropped — users see "my Ethernet just turned off
+        //   when I clicked Connect." It also routes through WMI, which hangs
+        //   15s+ on slow-WMI systems and was responsible for "Driver
+        //   initialization timed out" errors on first connect.
+        //
+        // Why netsh, not `New-NetFirewallRule`:
+        //   `New-NetFirewallRule` goes through the MSFT_NetFirewallRule WMI
+        //   provider, which has the same hang profile as the binding cmdlet.
+        //   `netsh advfirewall` is a native binary, returns in <100ms, and
+        //   doesn't touch the adapter binding.
+        //
+        // The rule blocks all outbound traffic to any IPv6 destination
+        // (`::/0`). SwiftTunnel is IPv4-only, so this is exactly the leak
+        // we're closing. The rule is removed on disconnect, and crash
+        // recovery (via the IPv6 marker file) cleans it up on next launch
+        // if the app died mid-session.
         format!(
             r#"
-            $ErrorActionPreference = 'Stop'
-            $adapter = '{}'
+            $ErrorActionPreference = 'Continue'
+            $name = '{rule}'
 
-            try {{
-                # Disable IPv6 binding on the adapter (requires elevation)
-                Disable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 -Confirm:$false | Out-Null
+            # Idempotent: drop any pre-existing rule before adding so a stale
+            # half-configured rule never persists.
+            $null = & netsh.exe advfirewall firewall delete rule name="$name" 2>&1
 
-                # Verify it was disabled
-                $binding = Get-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6
-                if (-not $binding) {{
-                    Write-Output 'IPv6 binding not present'
-                    exit 0
-                }}
+            $output = & netsh.exe advfirewall firewall add rule `
+                name="$name" `
+                dir=out action=block remoteip=::/0 profile=any 2>&1
+            $exit = $LASTEXITCODE
 
-                if (-not $binding.Enabled) {{
-                    Write-Output 'IPv6 disabled'
-                    exit 0
-                }}
-
-                Write-Error ('IPv6 binding still enabled on adapter: ' + $adapter)
-                exit 1
-            }} catch {{
-                Write-Error ('Failed to disable IPv6 on adapter ' + $adapter + ': ' + $_.Exception.Message)
+            if ($exit -ne 0) {{
+                Write-Error ('netsh add rule exited ' + $exit + ': ' + (($output | Out-String).Trim()))
                 exit 1
             }}
+
+            Write-Output 'IPv6 outbound blocked via firewall rule'
+            exit 0
             "#,
-            adapter_friendly_name.replace("'", "''")
+            rule = IPV6_BLOCK_RULE_NAME
         )
     }
 
@@ -3628,18 +3644,20 @@ impl ParallelInterceptor {
         let friendly_name = match &self.physical_adapter_friendly_name {
             Some(name) => name.clone(),
             None => {
-                log::warn!("No physical adapter friendly name available, skipping IPv6 disable");
+                log::warn!(
+                    "No physical adapter friendly name available, skipping IPv6 firewall block"
+                );
                 return Ok(());
             }
         };
 
         // IPv4-only ISP guard: SwiftTunnel needs an IPv4 default route to work.
-        // If there isn't one, disabling IPv6 would leave the user with no
+        // If there isn't one, blocking IPv6 would leave the user with no
         // network at all. Bail out early with a typed error so the UI surfaces
         // the right message instead of "tunneling failed somewhere".
         if Self::get_default_route_info_for_targets(&[]).is_none() {
             log::error!(
-                "No IPv4 default route found — refusing to disable IPv6 (likely IPv6-only network)"
+                "No IPv4 default route found — refusing to block IPv6 (likely IPv6-only network)"
             );
             return Err(VpnError::SplitTunnelSetupFailed(
                 "IPv6-only network: SwiftTunnel needs IPv4 connectivity to tunnel game traffic."
@@ -3648,69 +3666,33 @@ impl ParallelInterceptor {
         }
 
         log::info!(
-            "Disabling IPv6 on adapter: {} (SwiftTunnel is IPv4-only)",
+            "Blocking outbound IPv6 via firewall rule (adapter: {}, SwiftTunnel is IPv4-only)",
             friendly_name
         );
 
-        // Fast path: if the adapter has no IPv6 binding at all, skip the
-        // PowerShell disable entirely. `Disable-NetAdapterBinding` goes
-        // through WMI, which hangs for 20-30s on Realtek / slow-WMI systems
-        // even when there's nothing to disable (see support log from
-        // ferdi@2026-04-19). `has_ipv6_binding_native` uses the IP Helper
-        // API and returns in <1ms.
-        if let Some(if_index) = self.physical_adapter_if_index {
-            match has_ipv6_binding_native(if_index) {
-                Some(false) => {
-                    log::info!(
-                        "IPv6 already not bound on adapter {} (IP Helper fast-path); skipping disable",
-                        friendly_name
-                    );
-                    self.ipv6_was_disabled = false;
-                    delete_ipv6_marker();
-                    return Ok(());
-                }
-                Some(true) => {
-                    // IPv6 is bound — fall through to the slower check +
-                    // disable path. We don't skip the PowerShell
-                    // `query_ipv6_binding_enabled` below because it returns
-                    // the *enabled* state (bound + enabled vs. bound + force-
-                    // disabled) which the marker needs for accurate restore.
-                }
-                None => {
-                    // API error — fall through, let PowerShell handle it.
-                    log::debug!(
-                        "Native IPv6 probe failed for if_index {} — falling back to PowerShell",
-                        if_index
-                    );
-                }
-            }
-        }
-
-        if matches!(query_ipv6_binding_enabled(&friendly_name), Some(false)) {
-            log::info!(
-                "IPv6 was already disabled on adapter {} before SwiftTunnel; leaving it unchanged",
-                friendly_name
-            );
-            self.ipv6_was_disabled = false;
-            delete_ipv6_marker();
-            return Ok(());
-        }
-
-        write_ipv6_marker(&friendly_name);
+        // Write the marker BEFORE the netsh add. If we crash between add and
+        // marker write, the rule lingers across reboots and the user has no
+        // way to clean it up other than rerunning SwiftTunnel — which we
+        // accept, because the marker-then-add ordering would have the inverse
+        // race (marker exists but no rule, restore is a no-op, normal). The
+        // current ordering means recovery always over-cleans, never
+        // under-cleans.
+        write_ipv6_marker_firewall(&friendly_name);
         self.ipv6_was_disabled = true;
 
-        // Disable IPv6 binding on the adapter.
-        // This prevents Roblox/Windows from preferring IPv6 and bypassing our IPv4-only tunnel.
         let script = Self::build_disable_ipv6_script(&friendly_name);
 
-        // Give this more time than offload toggles; adapter binding changes can be slow on some systems.
-        let timeout_secs = 15;
+        // netsh.exe completes in ~50-100ms. 5s is generous slack for very
+        // loaded systems; if it actually times out at 5s, something is
+        // seriously wrong with the host's firewall service.
+        let timeout_secs = 5;
         let output = runner(&script, timeout_secs);
 
         if output.success {
             log::info!(
-                "IPv6 disabled successfully on {} - all traffic will use IPv4",
-                friendly_name
+                "IPv6 outbound blocked on {} via firewall rule '{}' — all traffic will use IPv4",
+                friendly_name,
+                IPV6_BLOCK_RULE_NAME
             );
             return Ok(());
         }
@@ -3722,7 +3704,7 @@ impl ParallelInterceptor {
             .collect();
 
         log::warn!(
-            "Failed to disable IPv6 on {} (exit={:?}, timed_out={}): stdout='{}' stderr='{}'",
+            "Failed to install IPv6 block rule on {} (exit={:?}, timed_out={}): stdout='{}' stderr='{}'",
             friendly_name,
             output.exit_code,
             output.timed_out,
@@ -3731,15 +3713,13 @@ impl ParallelInterceptor {
         );
 
         log::warn!(
-            "Refusing to continue without IPv6 disable on adapter '{}'. IPv6 traffic may bypass VPN.{}{}",
-            friendly_name,
+            "Refusing to continue without IPv6 outbound block. IPv6 traffic may bypass VPN.{}{}",
             if details.is_empty() { "" } else { " Details: " },
             details
         );
 
         Err(VpnError::SplitTunnelSetupFailed(format!(
-            "Failed to disable IPv6 on adapter '{}'. SwiftTunnel is IPv4-only; leaving IPv6 enabled could let game traffic bypass the tunnel.{}{}",
-            friendly_name,
+            "Failed to install IPv6 block firewall rule. SwiftTunnel is IPv4-only; leaving IPv6 unblocked could let game traffic bypass the tunnel.{}{}",
             if details.is_empty() { "" } else { " Details: " },
             details
         )))
@@ -3757,49 +3737,61 @@ impl ParallelInterceptor {
         self.disable_ipv6_with_runner(Self::run_powershell_with_timeout_capture)
     }
 
-    /// Re-enable IPv6 on the physical adapter
+    /// Restore IPv6 connectivity by removing the outbound block rule.
     ///
-    /// Called when the VPN disconnects to restore normal IPv6 connectivity.
+    /// Called when the VPN disconnects. The marker file records which method
+    /// was used to block IPv6 in this session (current code uses a firewall
+    /// rule; legacy markers from older installs used adapter binding). The
+    /// no-marker fallback path also targets the firewall rule because every
+    /// in-progress block this version writes uses that method.
     pub fn enable_ipv6(&mut self) {
         if !self.ipv6_was_disabled {
             return;
         }
 
-        let friendly_name = match &self.physical_adapter_friendly_name {
-            Some(name) => name.clone(),
-            None => return,
-        };
+        let friendly_name = self
+            .physical_adapter_friendly_name
+            .clone()
+            .unwrap_or_default();
 
-        log::info!("Re-enabling IPv6 on adapter: {}", friendly_name);
+        log::info!(
+            "Removing IPv6 outbound block (adapter: {})",
+            if friendly_name.is_empty() {
+                "<unknown>"
+            } else {
+                &friendly_name
+            }
+        );
 
         match restore_ipv6_from_marker() {
             Some(true) => {
-                log::info!("IPv6 restored to original state on {}", friendly_name);
+                log::info!("IPv6 restored on {}", friendly_name);
                 delete_ipv6_marker();
             }
             Some(false) => {
                 log::warn!("Failed to restore IPv6 state - will retry on next launch if needed");
             }
             None => {
+                // No marker found — likely a marker-write race or manual
+                // tampering. Best-effort: try to delete the firewall rule
+                // anyway (idempotent; silently no-ops if absent).
                 let script = format!(
                     r#"
                     $ErrorActionPreference = 'SilentlyContinue'
-                    $adapter = '{}'
-
-                    # Re-enable IPv6 binding on the adapter
-                    Enable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 2>$null
-
-                    Write-Host 'IPv6 enabled'
+                    $null = & netsh.exe advfirewall firewall delete rule name="{}" 2>&1
+                    Write-Host 'IPv6 block rule removed (best-effort)'
                     "#,
-                    friendly_name.replace("'", "''")
+                    IPV6_BLOCK_RULE_NAME
                 );
 
                 if Self::run_powershell_with_timeout(&script, 5) {
-                    log::info!("IPv6 re-enabled on {}", friendly_name);
+                    log::info!("IPv6 block rule removed on {}", friendly_name);
                     delete_ipv6_marker();
                 } else {
                     log::warn!(
-                        "Failed to re-enable IPv6 - manual re-enable may be needed via Network Settings"
+                        "Failed to remove IPv6 block rule '{}' — run `netsh advfirewall firewall delete rule name=\"{}\"` manually if connectivity is affected",
+                        IPV6_BLOCK_RULE_NAME,
+                        IPV6_BLOCK_RULE_NAME
                     );
                 }
             }
@@ -10080,9 +10072,9 @@ mod tests {
                 stdout: String::new(),
                 stderr: "Access is denied.".to_string(),
             })
-            .expect_err("IPv6 disable failure must abort connect");
+            .expect_err("IPv6 block failure must abort connect");
 
-        assert!(error.to_string().contains("Failed to disable IPv6"));
+        assert!(error.to_string().contains("IPv6 block firewall rule"));
         assert!(interceptor.ipv6_was_disabled);
         delete_ipv6_marker();
     }

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -58,7 +58,8 @@ use serde::Serialize;
 use crate::process_names::process_name_matches_any_tunnel_app;
 
 use super::ipv6_recovery::{
-    IPV6_BLOCK_RULE_NAME, delete_ipv6_marker, restore_ipv6_from_marker, write_ipv6_marker_firewall,
+    IPV6_BLOCK_REMOTE_IPS, IPV6_BLOCK_RULE_NAME, delete_ipv6_marker, restore_ipv6_from_marker,
+    write_ipv6_marker_firewall,
 };
 use super::process_cache::{LockFreeProcessCache, ProcessSnapshot};
 use super::process_tracker::{ConnectionKey, Protocol};
@@ -774,6 +775,8 @@ pub struct ParallelInterceptor {
     physical_adapter_name: Option<String>,
     /// Physical adapter friendly name (e.g., "Ethernet") for offload control
     physical_adapter_friendly_name: Option<String>,
+    /// Physical adapter kind (ethernet/wifi/ppp/tunnel/other) for firewall scoping
+    physical_adapter_kind: Option<String>,
     /// Physical adapter interface index (IfIndex) for default-route validation
     physical_adapter_if_index: Option<u32>,
     /// Whether we disabled TSO on the physical adapter (to restore on cleanup)
@@ -875,6 +878,7 @@ impl ParallelInterceptor {
             physical_adapter_idx: None,
             physical_adapter_name: None,
             physical_adapter_friendly_name: None,
+            physical_adapter_kind: None,
             physical_adapter_if_index: None,
             tso_was_disabled: false,
             ipv6_was_disabled: false,
@@ -1922,6 +1926,15 @@ impl ParallelInterceptor {
         }
     }
 
+    fn firewall_interface_type_for_adapter_kind(kind: Option<&str>) -> &'static str {
+        match kind {
+            Some("wifi") => "wireless",
+            Some("ethernet") => "lan",
+            Some("ppp") => "ras",
+            _ => "any",
+        }
+    }
+
     fn get_adapter_details_for_if_index(if_index: u32) -> Option<(String, String, String)> {
         use windows::Win32::NetworkManagement::IpHelper::{
             GAA_FLAG_INCLUDE_PREFIX, GetAdaptersAddresses, IP_ADAPTER_ADDRESSES_LH,
@@ -2892,6 +2905,7 @@ impl ParallelInterceptor {
             self.physical_adapter_idx = Some(idx);
             self.physical_adapter_name = Some(internal_name.clone());
             self.physical_adapter_friendly_name = Some(friendly_name.clone());
+            self.physical_adapter_kind = Some(selected.kind.clone());
             self.physical_adapter_if_index = if_index;
             log::info!(
                 "Selected physical adapter: {} (index {}, internal: '{}', if_index: {:?}, score: {})",
@@ -3586,7 +3600,10 @@ impl ParallelInterceptor {
         self.tso_was_disabled = false;
     }
 
-    fn build_disable_ipv6_script(_adapter_friendly_name: &str) -> String {
+    fn build_disable_ipv6_script(
+        _adapter_friendly_name: &str,
+        firewall_interface_type: &str,
+    ) -> String {
         // Block outbound IPv6 via a Windows Firewall rule using `netsh advfirewall`.
         //
         // Why not `Disable-NetAdapterBinding -ComponentId ms_tcpip6` (the
@@ -3606,15 +3623,19 @@ impl ParallelInterceptor {
         //   `netsh advfirewall` is a native binary, returns in <100ms, and
         //   doesn't touch the adapter binding.
         //
-        // The rule blocks all outbound traffic to any IPv6 destination
-        // (`::/0`). SwiftTunnel is IPv4-only, so this is exactly the leak
-        // we're closing. The rule is removed on disconnect, and crash
-        // recovery (via the IPv6 marker file) cleans it up on next launch
-        // if the app died mid-session.
+        // The rule blocks public IPv6 plus the well-known NAT64 prefix. It
+        // deliberately leaves loopback, link-local, multicast, and ULA ranges
+        // alone so local IPv6 IPC and LAN discovery are not broken while
+        // SwiftTunnel is connected. `netsh advfirewall` cannot scope by exact
+        // adapter alias, only by interface type; when we know the selected
+        // adapter kind we use that narrower type to avoid touching unrelated
+        // interface classes.
         format!(
             r#"
             $ErrorActionPreference = 'Continue'
             $name = '{rule}'
+            $remoteIps = '{remote_ips}'
+            $interfaceType = '{interface_type}'
 
             # Idempotent: drop any pre-existing rule before adding so a stale
             # half-configured rule never persists.
@@ -3622,7 +3643,7 @@ impl ParallelInterceptor {
 
             $output = & netsh.exe advfirewall firewall add rule `
                 name="$name" `
-                dir=out action=block remoteip=::/0 profile=any 2>&1
+                dir=out action=block remoteip=$remoteIps interfacetype=$interfaceType profile=any 2>&1
             $exit = $LASTEXITCODE
 
             if ($exit -ne 0) {{
@@ -3633,7 +3654,9 @@ impl ParallelInterceptor {
             Write-Output 'IPv6 outbound blocked via firewall rule'
             exit 0
             "#,
-            rule = IPV6_BLOCK_RULE_NAME
+            rule = IPV6_BLOCK_RULE_NAME,
+            remote_ips = IPV6_BLOCK_REMOTE_IPS,
+            interface_type = firewall_interface_type
         )
     }
 
@@ -3665,9 +3688,13 @@ impl ParallelInterceptor {
             ));
         }
 
+        let firewall_interface_type =
+            Self::firewall_interface_type_for_adapter_kind(self.physical_adapter_kind.as_deref());
+
         log::info!(
-            "Blocking outbound IPv6 via firewall rule (adapter: {}, SwiftTunnel is IPv4-only)",
-            friendly_name
+            "Blocking public IPv6 via firewall rule (adapter: {}, interface_type: {}, SwiftTunnel is IPv4-only)",
+            friendly_name,
+            firewall_interface_type
         );
 
         // Write the marker BEFORE the netsh add. If we crash between add and
@@ -3680,7 +3707,7 @@ impl ParallelInterceptor {
         write_ipv6_marker_firewall(&friendly_name);
         self.ipv6_was_disabled = true;
 
-        let script = Self::build_disable_ipv6_script(&friendly_name);
+        let script = Self::build_disable_ipv6_script(&friendly_name, firewall_interface_type);
 
         // netsh.exe completes in ~50-100ms. 5s is generous slack for very
         // loaded systems; if it actually times out at 5s, something is
@@ -3690,7 +3717,7 @@ impl ParallelInterceptor {
 
         if output.success {
             log::info!(
-                "IPv6 outbound blocked on {} via firewall rule '{}' — all traffic will use IPv4",
+                "Public IPv6 blocked on {} via firewall rule '{}' — game traffic will use IPv4",
                 friendly_name,
                 IPV6_BLOCK_RULE_NAME
             );
@@ -3725,11 +3752,11 @@ impl ParallelInterceptor {
         )))
     }
 
-    /// Disable IPv6 on the physical adapter
+    /// Block public IPv6 egress while the IPv4-only tunnel is active.
     ///
     /// SwiftTunnel is IPv4-only. If IPv6 is enabled, Roblox or Windows may prefer IPv6,
-    /// causing traffic to bypass our IPv4 tunnel entirely. Disabling IPv6 on the physical
-    /// adapter ensures all traffic goes through our interceptor.
+    /// causing traffic to bypass our IPv4 tunnel entirely. Blocking public IPv6/NAT64
+    /// destinations forces game traffic back to IPv4 without rebinding the adapter.
     ///
     /// This is a common cause of "detection works but tunneling fails" - the process is
     /// detected, but its IPv6 traffic bypasses the VPN.
@@ -4213,6 +4240,7 @@ impl ParallelInterceptor {
         let old_physical_adapter_idx = self.physical_adapter_idx;
         let old_physical_adapter_name = self.physical_adapter_name.clone();
         let old_physical_adapter_friendly_name = self.physical_adapter_friendly_name.clone();
+        let old_physical_adapter_kind = self.physical_adapter_kind.clone();
         let old_physical_adapter_if_index = self.physical_adapter_if_index;
         let old_default_route_if_index = prev_default_if_index;
         let old_default_route_next_hop = prev_default_next_hop;
@@ -4238,6 +4266,7 @@ impl ParallelInterceptor {
             self.physical_adapter_idx = old_physical_adapter_idx;
             self.physical_adapter_name = old_physical_adapter_name;
             self.physical_adapter_friendly_name = old_physical_adapter_friendly_name;
+            self.physical_adapter_kind = old_physical_adapter_kind;
             self.physical_adapter_if_index = old_physical_adapter_if_index;
             self.default_route_if_index = old_default_route_if_index;
             self.default_route_next_hop = old_default_route_next_hop;
@@ -10017,6 +10046,35 @@ mod tests {
             .disable_ipv6_with_runner(|_, _| panic!("runner should not be called"))
             .unwrap();
         assert!(!interceptor.ipv6_was_disabled);
+    }
+
+    #[test]
+    fn test_firewall_interface_type_maps_known_adapter_kinds() {
+        assert_eq!(
+            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("ethernet")),
+            "lan"
+        );
+        assert_eq!(
+            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("wifi")),
+            "wireless"
+        );
+        assert_eq!(
+            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("ppp")),
+            "ras"
+        );
+        assert_eq!(
+            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("other")),
+            "any"
+        );
+    }
+
+    #[test]
+    fn test_disable_ipv6_script_blocks_public_ipv6_on_interface_type() {
+        let script = ParallelInterceptor::build_disable_ipv6_script("Ethernet", "lan");
+        assert!(script.contains(IPV6_BLOCK_REMOTE_IPS), "{}", script);
+        assert!(script.contains("interfacetype=$interfaceType"), "{}", script);
+        assert!(script.contains("$interfaceType = 'lan'"), "{}", script);
+        assert!(!script.contains("remoteip=::/0"), "{}", script);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Stop the Ethernet flap on connect by replacing `Disable-NetAdapterBinding -ComponentId ms_tcpip6` with a `netsh advfirewall firewall add rule` outbound block rule.
- Scope the rule to public IPv6/NAT64 destinations (`2000::/3,64:ff9b::/96`) and the selected adapter's firewall interface type (`lan`, `wireless`, `ras`, or fallback `any`) so loopback/link-local/ULA IPv6 is not blocked while connected.
- Eliminate the 15s WMI hangs that surfaced as "Driver initialization timed out — please restart your computer" on first connect.
- Keep IPv6 marker files backwards-compatible: legacy markers (no `method` field) deserialize as `BindingDisable` and the existing `Enable-NetAdapterBinding` restore path still runs for users upgrading mid-session.
- Verify firewall-rule deletion during restore; if the rule still exists or removal cannot be verified, keep the marker so startup recovery retries instead of silently leaving IPv6 blocked.

## Why

`Disable-NetAdapterBinding` rebinds the NDIS stack on the adapter, which physically takes the link offline and back. On Realtek, USB-Ethernet dongles, Parallels VirtIO, and some Intel variants the relink takes 2-10 s and Windows reports the connection as dropped — multiple users have reported _"my Ethernet just turned off when I clicked Connect."_

The same cmdlet also routes through the `MSFT_NetAdapterBinding` WMI provider, which hangs 15 s+ on slow-WMI systems (Realtek-with-flaky-WMI hosts and Windows-on-ARM Parallels VMs are the two we have logs for). That hang surfaced to users as "Driver initialization timed out — please restart your computer" even though the driver itself was healthy.

`netsh advfirewall` is a native binary, returns in <100 ms, and does not touch the adapter binding. The new rule is named `SwiftTunnel-Block-IPv6-Outbound`; it's installed on connect and removed on disconnect. SwiftTunnel is IPv4-only, so blocking public IPv6/NAT64 destinations prevents game traffic from preferring IPv6 and bypassing the IPv4 tunnel while leaving local IPv6 IPC and LAN ranges alone.

`netsh advfirewall` cannot scope a rule to an exact adapter alias; it supports `interfacetype=wireless|lan|ras|any`. SwiftTunnel maps the selected adapter kind to that narrower firewall interface type when possible and falls back to `any` only when the adapter kind is unknown.

The pre-existing fast-path probes (`has_ipv6_binding_native`, `query_ipv6_binding_enabled`) were workarounds for the slow cmdlet and are no longer called from the hot path. They remain as `pub fn` for test coverage and any future binding-state inspection needs — removing them is out of scope for a behavior-preserving fix.

## Compatibility

- Marker file: `Ipv6Marker` gains a `method: DisableMethod` field with `#[serde(default)]`. Old markers without the field deserialize as `DisableMethod::BindingDisable`, so a user upgrading from <2.0.16 mid-session still gets their adapter binding re-enabled by the legacy path on disconnect.
- Restore path: `restore_command()` dispatches on `method`. New markers run `netsh ... delete rule`, then `netsh ... show rule`; the restore reports failure if the rule still exists or verification is inconclusive. Legacy markers run `Enable-NetAdapterBinding` as before.
- The `Disable-NetAdapterBinding -ComponentID 'nt_ndisrd'` call in `split_tunnel.rs` (WinpkFilter binding, unrelated to IPv6) is unchanged.

## Test plan

- [ ] `cargo test -p swifttunnel-core --lib vpn::ipv6_recovery` — covers firewall-rule restore command, deletion verification, and legacy marker round-trip
- [ ] `cargo test -p swifttunnel-core --lib vpn::parallel_interceptor::tests::test_disable_ipv6` — covers the runner-injected disable path
- [ ] On Windows testbench VM, connect with `RUST_LOG=info` and confirm the new log lines:
  - `Blocking public IPv6 via firewall rule (adapter: <name>, interface_type: <type>, SwiftTunnel is IPv4-only)`
  - `Public IPv6 blocked on <name> via firewall rule 'SwiftTunnel-Block-IPv6-Outbound' — game traffic will use IPv4`
  - On disconnect: `Removing IPv6 outbound block (adapter: <name>)` then `IPv6 restored on <name>`
  - `Disabling IPv6 on adapter:` and `PowerShell timed out after 15s` (for the IPv6 step) should be **absent**
- [ ] Out-of-band verify the rule appears: `netsh advfirewall firewall show rule name="SwiftTunnel-Block-IPv6-Outbound"` while connected; gone after disconnect
- [ ] Confirm local IPv6 loopback (`::1`) still works while connected
- [ ] Repro on a host that previously dropped Ethernet on connect (Realtek / Parallels VirtIO) — link should stay up
- [ ] Crash-recovery: kill the app while connected, relaunch, confirm the rule is removed via the marker recovery path
- [ ] Upgrade path: install pre-2.0.16, connect (binding-disable marker written), upgrade to this build, disconnect — `Enable-NetAdapterBinding` should run via the legacy `BindingDisable` restore branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)