### PR TITLE
Keep connect UI busy during stale disconnected polls

### DIFF
--- a/swifttunnel-desktop/src/stores/vpnStore.test.ts
+++ b/swifttunnel-desktop/src/stores/vpnStore.test.ts
@@ -539,6 +539,31 @@ describe("stores/vpnStore", () => {
     expect(useVpnStore.getState().connectAttemptInFlight).toBe(true);
   });
 
+  it("ignores stale disconnected polls while a connect attempt is pending", async () => {
+    vpnGetState.mockResolvedValue({
+      state: "disconnected",
+      region: null,
+      server_endpoint: null,
+      assigned_ip: null,
+      relay_auth_mode: null,
+      split_tunnel_active: false,
+      tunneled_processes: [],
+      error: null,
+    });
+
+    const useVpnStore = await loadStore();
+    useVpnStore.setState({
+      state: "fetching_config",
+      error: null,
+      connectAttemptInFlight: true,
+    });
+
+    await useVpnStore.getState().fetchState();
+
+    expect(useVpnStore.getState().state).toBe("fetching_config");
+    expect(useVpnStore.getState().connectAttemptInFlight).toBe(true);
+  });
+
   it("does not let stale disconnected events clear a visible connect error", async () => {
     const useVpnStore = await loadStore();
     useVpnStore.setState({

--- a/swifttunnel-desktop/src/stores/vpnStore.ts
+++ b/swifttunnel-desktop/src/stores/vpnStore.ts
@@ -240,14 +240,27 @@ export const useVpnStore = create<VpnStore>((set, get) => ({
   fetchState: async () => {
     try {
       const resp = await vpnGetState();
-      set({
-        state: resp.state,
-        region: resp.region,
-        serverEndpoint: resp.server_endpoint,
-        assignedIp: resp.assigned_ip,
-        splitTunnelActive: resp.split_tunnel_active,
-        tunneledProcesses: resp.tunneled_processes,
-        error: resp.error,
+      set((current) => {
+        const staleReadyPoll =
+          resp.state === "disconnected" &&
+          resp.error === null &&
+          current.state !== "disconnecting" &&
+          (current.connectAttemptInFlight ||
+            (current.state === "error" && current.error !== null));
+
+        if (staleReadyPoll) {
+          return {};
+        }
+
+        return {
+          state: resp.state,
+          region: resp.region,
+          serverEndpoint: resp.server_endpoint,
+          assignedIp: resp.assigned_ip,
+          splitTunnelActive: resp.split_tunnel_active,
+          tunneledProcesses: resp.tunneled_processes,
+          error: resp.error,
+        };
       });
     } catch (e) {
       set({ error: String(e) });


### PR DESCRIPTION
## Summary
- ignore stale `vpn_get_state` disconnected snapshots while a connect attempt is still in flight
- add a store regression test covering the connect-button flicker case

## Why
The backend does not enter `vpn_connect` until driver readiness and binding preflight finish. During that gap the UI has already moved to `fetching_config`, but the periodic `fetchState()` poll can still read the backend's previous `disconnected` state and make the button briefly return to Connect. The event handler already guards stale disconnected events; this applies the same guard to explicit state polling.

## Verification
- `git diff --check` passed for the changed files
- Could not run Vitest locally because this environment does not have `node` installed on PATH
