### PR TITLE
Stop connect-time NIC link bounce from killing internet

### DIFF
--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -41,10 +41,11 @@ const REFRESH_INTERVAL_MS: u64 = 500;
 const ADAPTER_WATCHDOG_WINDOW_SECS: u64 = 30;
 
 /// Number of consecutive `LocalConnectivity::Offline` ticks (each spaced
-/// `REFRESH_INTERVAL_MS` apart) before the watchdog aborts the session. With
-/// the 500ms tick this is a 3s sustained offline floor — long enough to
+/// `REFRESH_INTERVAL_MS` apart, and only counted when relay health is
+/// also non-`Healthy`) before the watchdog aborts the session. With the
+/// 500ms tick this is a 3s sustained dual-signal floor — long enough to
 /// ignore brief link flaps (Wi-Fi handover, momentary route refresh) and
-/// short enough to abort well before the relay-dead timeout fires (~5s+).
+/// short enough to abort well before the relay-dead timeout fires.
 const ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD: u32 = 6;
 
 /// Cleanup-reason marker propagated through the existing teardown path when
@@ -155,10 +156,12 @@ fn classify_relay_health(
 /// async monitor.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum WatchdogTickAction {
-    /// Window still active; observed `LocalConnectivity` did not push the
-    /// counter past threshold. The caller stores `consecutive_offline_ticks`
-    /// for the next tick. `Reachable` and `Unknown` reset to 0; `Offline`
-    /// increments.
+    /// Window still active; the dual-signal gate did not push the counter
+    /// past threshold. The caller stores `consecutive_offline_ticks` for
+    /// the next tick. The counter only increments when probe is `Offline`
+    /// AND relay health is *not* `Healthy`; any other combination resets
+    /// it to 0 — `Reachable`, `Unknown`, or relay still `Healthy` are all
+    /// "internet works" signals from the watchdog's perspective.
     Continue { consecutive_offline_ticks: u32 },
     /// Counter reached the offline-tick threshold inside the window — abort
     /// the session and run the standard teardown with this reason/message.
@@ -174,19 +177,32 @@ enum WatchdogTickAction {
 fn watchdog_tick(
     elapsed_since_connect: Duration,
     probe: LocalConnectivity,
+    relay_health: super::udp_relay::RelayHealthState,
     prior_consecutive_offline_ticks: u32,
 ) -> WatchdogTickAction {
+    use super::udp_relay::RelayHealthState;
+
     if elapsed_since_connect >= Duration::from_secs(ADAPTER_WATCHDOG_WINDOW_SECS) {
         return WatchdogTickAction::Disarmed;
     }
 
-    // `Unknown` is treated as a probe failure, NOT as offline — the existing
-    // `classify_relay_health` path uses the same "do not act on Unknown"
-    // semantic, and we mirror it here so a flaky NLM API can't abort an
-    // otherwise-healthy connect.
-    let new_count = match probe {
-        LocalConnectivity::Offline => prior_consecutive_offline_ticks.saturating_add(1),
-        LocalConnectivity::Reachable | LocalConnectivity::Unknown => 0,
+    // Two-signal gate. NLM Offline alone is a heuristic — captive/filtered
+    // networks, hidden-SSID corporate setups, and NLM bugs can produce
+    // false-positive Offline reports on machines that are actually online.
+    // Relay `Healthy` is positive ground truth: we've recently received an
+    // inbound packet through this NIC, so the user provably has working
+    // internet right now regardless of what NLM says. Only count an Offline
+    // tick if both signals agree something is wrong.
+    //
+    // `Unknown` for the probe (API failure / non-Windows / Hidden hint) and
+    // `Reachable` both reset the counter — same "do not act on Unknown"
+    // semantic that `classify_relay_health` uses.
+    let new_count = match (probe, relay_health) {
+        (
+            LocalConnectivity::Offline,
+            RelayHealthState::NoTrafficYet | RelayHealthState::Stale | RelayHealthState::Dead,
+        ) => prior_consecutive_offline_ticks.saturating_add(1),
+        _ => 0,
     };
 
     if new_count >= ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD {
@@ -2021,14 +2037,23 @@ impl VpnConnection {
                         // touching adapter properties — `LocalConnectivity::probe`
                         // goes Offline (`No internet access` in NLM terms) when
                         // the IPv4 default route disappears. Firing here
-                        // surfaces a clear retry message in ~3s instead of the
-                        // ~22s the user otherwise waits for the relay-dead
+                        // surfaces a clear retry message in seconds instead of
+                        // the ~22s the user otherwise waits for the relay-dead
                         // path to declare the same outcome.
+                        //
+                        // Two-signal gate: the offline counter only increments
+                        // when relay health is non-Healthy as well. A Healthy
+                        // relay means we've recently received an inbound
+                        // packet through this NIC, which overrides any NLM
+                        // false-positive (captive portals, virtual adapters,
+                        // hidden-SSID corp networks). See `watchdog_tick`.
                         if watchdog_armed {
                             let probe = super::local_connectivity::probe();
+                            let relay_health_now = relay_health_monitor.relay_health();
                             match watchdog_tick(
                                 connect_started_at.elapsed(),
                                 probe,
+                                relay_health_now,
                                 watchdog_offline_ticks,
                             ) {
                                 WatchdogTickAction::Continue { consecutive_offline_ticks } => {
@@ -2072,6 +2097,15 @@ impl VpnConnection {
                                             guard.cleanup_all(cleanup_reason);
                                         }
                                         break;
+                                    } else {
+                                        // State already left Connected — a concurrent
+                                        // path (user-initiated disconnect, the relay-
+                                        // health monitor beating us to the transition)
+                                        // owns teardown. Disarm so the next tick doesn't
+                                        // re-enter Abort with the same prior counter and
+                                        // spam log::error every 500ms until stop_flag.
+                                        watchdog_armed = false;
+                                        watchdog_offline_ticks = 0;
                                     }
                                 }
                             }
@@ -2785,12 +2819,24 @@ mod tests {
         assert_eq!(action, RelayHealthAction::Continue { relay_status: None });
     }
 
+    /// Default relay health for tests where the relay-health gate isn't
+    /// the variable under test. `NoTrafficYet` is what the relay reports
+    /// during the early connect window before the first inbound packet,
+    /// which matches the realistic scenario the watchdog is designed for.
+    const TEST_RELAY_NOT_HEALTHY: super::super::udp_relay::RelayHealthState =
+        super::super::udp_relay::RelayHealthState::NoTrafficYet;
+
     #[test]
     fn test_watchdog_continues_on_first_offline_tick() {
         // One offline tick alone must not fire — we only abort on a sustained
         // outage. The counter should bump from 0 to 1 and the caller should
         // store it for next tick.
-        let action = watchdog_tick(Duration::from_secs(1), LocalConnectivity::Offline, 0);
+        let action = watchdog_tick(
+            Duration::from_secs(1),
+            LocalConnectivity::Offline,
+            TEST_RELAY_NOT_HEALTHY,
+            0,
+        );
 
         assert_eq!(
             action,
@@ -2805,7 +2851,12 @@ mod tests {
         // A brief Offline → Reachable sequence must NOT push the watchdog past
         // its threshold. This covers Wi-Fi handover, momentary route refresh,
         // sleep/resume settle: all transient and should be ignored.
-        let after_offline_1 = watchdog_tick(Duration::from_secs(1), LocalConnectivity::Offline, 0);
+        let after_offline_1 = watchdog_tick(
+            Duration::from_secs(1),
+            LocalConnectivity::Offline,
+            TEST_RELAY_NOT_HEALTHY,
+            0,
+        );
         let count_after_offline = match after_offline_1 {
             WatchdogTickAction::Continue {
                 consecutive_offline_ticks,
@@ -2816,6 +2867,7 @@ mod tests {
         let after_offline_2 = watchdog_tick(
             Duration::from_secs(2),
             LocalConnectivity::Offline,
+            TEST_RELAY_NOT_HEALTHY,
             count_after_offline,
         );
         let count_after_offline_2 = match after_offline_2 {
@@ -2829,6 +2881,7 @@ mod tests {
         let after_reachable = watchdog_tick(
             Duration::from_secs(3),
             LocalConnectivity::Reachable,
+            TEST_RELAY_NOT_HEALTHY,
             count_after_offline_2,
         );
         assert_eq!(
@@ -2850,7 +2903,12 @@ mod tests {
         let mut count = 0u32;
         for tick in 1..ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD {
             let elapsed = Duration::from_millis(500 * tick as u64);
-            match watchdog_tick(elapsed, LocalConnectivity::Offline, count) {
+            match watchdog_tick(
+                elapsed,
+                LocalConnectivity::Offline,
+                TEST_RELAY_NOT_HEALTHY,
+                count,
+            ) {
                 WatchdogTickAction::Continue {
                     consecutive_offline_ticks,
                 } => count = consecutive_offline_ticks,
@@ -2863,7 +2921,12 @@ mod tests {
 
         let final_elapsed =
             Duration::from_millis(500 * ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD as u64);
-        let action = watchdog_tick(final_elapsed, LocalConnectivity::Offline, count);
+        let action = watchdog_tick(
+            final_elapsed,
+            LocalConnectivity::Offline,
+            TEST_RELAY_NOT_HEALTHY,
+            count,
+        );
 
         match action {
             WatchdogTickAction::Abort {
@@ -2890,13 +2953,19 @@ mod tests {
     #[test]
     fn test_watchdog_does_not_fire_on_unknown_probe() {
         // `Unknown` is treated as a probe failure (NLM API hung,
-        // non-Windows build, hint=Unknown), NOT as offline. Mirrors the
-        // existing semantic in `classify_relay_health` — a flaky NLM API
-        // must not be allowed to abort an otherwise-healthy connect.
+        // non-Windows build, hint=Unknown, hint=Hidden), NOT as offline.
+        // Mirrors the existing semantic in `classify_relay_health` — a
+        // flaky NLM API must not be allowed to abort an otherwise-healthy
+        // connect.
         let mut count = 0u32;
         for tick in 1..(ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD * 4) {
             let elapsed = Duration::from_millis(500 * tick as u64);
-            match watchdog_tick(elapsed, LocalConnectivity::Unknown, count) {
+            match watchdog_tick(
+                elapsed,
+                LocalConnectivity::Unknown,
+                TEST_RELAY_NOT_HEALTHY,
+                count,
+            ) {
                 WatchdogTickAction::Continue {
                     consecutive_offline_ticks,
                 } => {
@@ -2930,6 +2999,7 @@ mod tests {
         let action = watchdog_tick(
             elapsed,
             LocalConnectivity::Offline,
+            TEST_RELAY_NOT_HEALTHY,
             ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD + 100,
         );
 
@@ -2948,7 +3018,12 @@ mod tests {
         // offlines mid-session are a different problem (handled by the
         // existing relay-health classifier).
         let elapsed = Duration::from_secs(600);
-        let action = watchdog_tick(elapsed, LocalConnectivity::Offline, 0);
+        let action = watchdog_tick(
+            elapsed,
+            LocalConnectivity::Offline,
+            TEST_RELAY_NOT_HEALTHY,
+            0,
+        );
 
         assert_eq!(
             action,
@@ -2965,6 +3040,7 @@ mod tests {
         let action = watchdog_tick(
             Duration::from_secs(2),
             LocalConnectivity::Reachable,
+            TEST_RELAY_NOT_HEALTHY,
             ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD - 1,
         );
 
@@ -2973,6 +3049,68 @@ mod tests {
             WatchdogTickAction::Continue {
                 consecutive_offline_ticks: 0,
             }
+        );
+    }
+
+    #[test]
+    fn test_watchdog_does_not_fire_when_relay_is_healthy() {
+        // Relay-health gate (Codex P1): NLM Offline alone is a heuristic
+        // and can be wrong on captive/filtered networks, virtual-adapter
+        // configs, and certain Wi-Fi drivers. `RelayHealthState::Healthy`
+        // means we've recently received an inbound packet from the relay
+        // — positive ground truth that internet is working through this
+        // NIC right now. In that case, even a sustained Offline NLM
+        // signal must NOT push the watchdog past threshold.
+        use super::super::udp_relay::RelayHealthState;
+        let mut count = 0u32;
+        for tick in 1..(ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD * 4) {
+            let elapsed = Duration::from_millis(500 * tick as u64);
+            match watchdog_tick(
+                elapsed,
+                LocalConnectivity::Offline,
+                RelayHealthState::Healthy,
+                count,
+            ) {
+                WatchdogTickAction::Continue {
+                    consecutive_offline_ticks,
+                } => {
+                    assert_eq!(
+                        consecutive_offline_ticks, 0,
+                        "relay Healthy must keep the counter at 0 even when probe is Offline (tick {}, count {})",
+                        tick, consecutive_offline_ticks
+                    );
+                    count = consecutive_offline_ticks;
+                }
+                WatchdogTickAction::Disarmed => return,
+                WatchdogTickAction::Abort { .. } => panic!(
+                    "watchdog must not fire when relay is Healthy (tick {})",
+                    tick
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_watchdog_resets_on_relay_recovery_to_healthy() {
+        // Counter sits one short of threshold (relay was Stale, NLM Offline,
+        // counter has been climbing). Then the relay flips back to Healthy
+        // — internet has recovered through some other path before NLM
+        // caught up — the next tick must reset the counter to 0 and not
+        // fire. Guards against stale state racing the recovery.
+        use super::super::udp_relay::RelayHealthState;
+        let action = watchdog_tick(
+            Duration::from_secs(2),
+            LocalConnectivity::Offline,
+            RelayHealthState::Healthy,
+            ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD - 1,
+        );
+
+        assert_eq!(
+            action,
+            WatchdogTickAction::Continue {
+                consecutive_offline_ticks: 0,
+            },
+            "relay flipping back to Healthy must reset the offline-tick counter"
         );
     }
 

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -6,6 +6,7 @@
 //! - UDP relay for game traffic forwarding
 //! - Connection state tracking
 
+use super::local_connectivity::LocalConnectivity;
 use super::parallel_interceptor::{
     AdapterBindingPreference, QueueOverflowMode, ThroughputStats,
     is_point_to_point_default_route_context,
@@ -28,6 +29,35 @@ use tokio::sync::{Mutex, watch};
 /// Lower = faster detection of new processes, slightly higher CPU
 /// 500ms balances detection speed with CPU usage
 const REFRESH_INTERVAL_MS: u64 = 500;
+
+/// How long after a successful connect we keep the local-connectivity watchdog
+/// armed. The point of the watchdog is specifically to catch *adapter-reset
+/// rollback* — `Set-NetAdapterAdvancedProperty` calls during interceptor start
+/// can briefly bounce the NIC on some hardware (Realtek, Killer, USB-Ethernet)
+/// and we want to fail fast with a clear retry message instead of letting the
+/// user sit through the relay-dead timeout. After this window passes we
+/// disarm; mid-session connectivity loss is handled by the existing
+/// `classify_relay_health` path which also consults `LocalConnectivity`.
+const ADAPTER_WATCHDOG_WINDOW_SECS: u64 = 30;
+
+/// Number of consecutive `LocalConnectivity::Offline` ticks (each spaced
+/// `REFRESH_INTERVAL_MS` apart) before the watchdog aborts the session. With
+/// the 500ms tick this is a 3s sustained offline floor — long enough to
+/// ignore brief link flaps (Wi-Fi handover, momentary route refresh) and
+/// short enough to abort well before the relay-dead timeout fires (~5s+).
+const ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD: u32 = 6;
+
+/// Cleanup-reason marker propagated through the existing teardown path when
+/// the watchdog fires. Distinct from `relay_dead_recovery` /
+/// `internet_lost_recovery` so process-performance and telemetry can
+/// distinguish "we aborted during the connect window because the adapter
+/// reset took the route with it" from mid-session relay loss.
+const ADAPTER_RESET_ROLLBACK_REASON: &str = "adapter_reset_rollback";
+
+/// Error string surfaced to the UI on watchdog rollback. Wording deliberately
+/// asks the user to retry — the path is recoverable on next connect.
+const ADAPTER_RESET_ROLLBACK_MESSAGE: &str =
+    "SwiftTunnel rolled back the connection because your network adapter went offline during setup. This usually clears up on its own — please try connecting again.";
 const ETW_CONNECTION_READY_TIMEOUT_MS: u64 = 150;
 const ETW_CONNECTION_READY_POLL_MS: u64 = 5;
 /// Number of ICMP samples to collect per relay candidate when probing.
@@ -78,10 +108,24 @@ enum RelayHealthAction {
 fn classify_relay_health(
     health: super::udp_relay::RelayHealthState,
     sender_panicked: bool,
+    local_connectivity: LocalConnectivity,
 ) -> RelayHealthAction {
     use super::udp_relay::RelayHealthState;
 
     if health == RelayHealthState::Dead {
+        // The relay-dead heuristic also fires when the user's own machine
+        // loses internet (Wi-Fi blip, sleep/resume, ISP outage): keepalives
+        // appear "unanswered" purely because nothing leaves the NIC. Asking
+        // Windows whether it currently has internet lets us pick a message
+        // the user can act on instead of telling them to choose a different
+        // relay when no relay is reachable.
+        if local_connectivity == LocalConnectivity::Offline {
+            return RelayHealthAction::Fatal {
+                error_message: "Internet connection lost - SwiftTunnel stopped the session because your device went offline. Reconnect to your network and try again."
+                    .to_string(),
+                cleanup_reason: "internet_lost_recovery",
+            };
+        }
         return RelayHealthAction::Fatal {
             error_message: "Relay connection failed - SwiftTunnel stopped the session because the relay stopped returning traffic. Please reconnect or choose another relay."
                 .to_string(),
@@ -103,6 +147,58 @@ fn classify_relay_health(
             RelayHealthAction::Continue { relay_status: None }
         }
         RelayHealthState::Dead => unreachable!("handled above"),
+    }
+}
+
+/// Decision returned by the post-connect adapter-reset watchdog on each
+/// refresh tick. Pulled out as a pure function so the threshold and
+/// window semantics can be unit-tested without spinning up the full
+/// async monitor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WatchdogTickAction {
+    /// Window still active; observed `LocalConnectivity` did not push the
+    /// counter past threshold. The caller stores `consecutive_offline_ticks`
+    /// for the next tick. `Reachable` and `Unknown` reset to 0; `Offline`
+    /// increments.
+    Continue { consecutive_offline_ticks: u32 },
+    /// Counter reached the offline-tick threshold inside the window — abort
+    /// the session and run the standard teardown with this reason/message.
+    Abort {
+        error_message: String,
+        cleanup_reason: &'static str,
+    },
+    /// 30s window has elapsed without firing. Watchdog disarms for the rest
+    /// of this session; relay-health monitoring takes over from here.
+    Disarmed,
+}
+
+fn watchdog_tick(
+    elapsed_since_connect: Duration,
+    probe: LocalConnectivity,
+    prior_consecutive_offline_ticks: u32,
+) -> WatchdogTickAction {
+    if elapsed_since_connect >= Duration::from_secs(ADAPTER_WATCHDOG_WINDOW_SECS) {
+        return WatchdogTickAction::Disarmed;
+    }
+
+    // `Unknown` is treated as a probe failure, NOT as offline — the existing
+    // `classify_relay_health` path uses the same "do not act on Unknown"
+    // semantic, and we mirror it here so a flaky NLM API can't abort an
+    // otherwise-healthy connect.
+    let new_count = match probe {
+        LocalConnectivity::Offline => prior_consecutive_offline_ticks.saturating_add(1),
+        LocalConnectivity::Reachable | LocalConnectivity::Unknown => 0,
+    };
+
+    if new_count >= ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD {
+        WatchdogTickAction::Abort {
+            error_message: ADAPTER_RESET_ROLLBACK_MESSAGE.to_string(),
+            cleanup_reason: ADAPTER_RESET_ROLLBACK_REASON,
+        }
+    } else {
+        WatchdogTickAction::Continue {
+            consecutive_offline_ticks: new_count,
+        }
     }
 }
 
@@ -1767,6 +1863,20 @@ impl VpnConnection {
             let mut stop_tick = tokio::time::interval(Duration::from_millis(100));
             let mut etw_rx = etw_tokio_rx;
 
+            // Adapter-reset watchdog. Armed for the first
+            // ADAPTER_WATCHDOG_WINDOW_SECS after this monitor task spawns
+            // (~immediately after `driver.configure()` returns); fires if
+            // `LocalConnectivity::probe()` reports `Offline` for
+            // ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD consecutive 500ms
+            // ticks (~3s sustained). Catches the case where
+            // `Set-NetAdapterAdvancedProperty` calls during interceptor
+            // start bounced the NIC and dropped the IPv4 default route,
+            // turning what looks like a successful connect into a stuck
+            // tunnel for 22+s before the relay-dead path notices.
+            let connect_started_at = Instant::now();
+            let mut watchdog_offline_ticks: u32 = 0;
+            let mut watchdog_armed: bool = true;
+
             loop {
                 if stop_flag.load(Ordering::SeqCst) {
                     break;
@@ -1906,6 +2016,68 @@ impl VpnConnection {
 
                     // Periodic refresh path
                     _ = refresh_tick.tick() => {
+                        // Adapter-reset watchdog: only armed for the first
+                        // ADAPTER_WATCHDOG_WINDOW_SECS after connect. Catches
+                        // the NIC link-bounce caused by interceptor startup
+                        // touching adapter properties — `LocalConnectivity::probe`
+                        // goes Offline (`No internet access` in NLM terms) when
+                        // the IPv4 default route disappears. Firing here
+                        // surfaces a clear retry message in ~3s instead of the
+                        // ~22s the user otherwise waits for the relay-dead
+                        // path to declare the same outcome.
+                        if watchdog_armed {
+                            let probe = super::local_connectivity::probe();
+                            match watchdog_tick(
+                                connect_started_at.elapsed(),
+                                probe,
+                                watchdog_offline_ticks,
+                            ) {
+                                WatchdogTickAction::Continue { consecutive_offline_ticks } => {
+                                    watchdog_offline_ticks = consecutive_offline_ticks;
+                                }
+                                WatchdogTickAction::Disarmed => {
+                                    watchdog_armed = false;
+                                }
+                                WatchdogTickAction::Abort { error_message, cleanup_reason } => {
+                                    let observed_ticks = watchdog_offline_ticks + 1;
+                                    let transitioned = state_handle.send_if_modified(|state| {
+                                        if matches!(*state, ConnectionState::Connected { .. }) {
+                                            log::error!(
+                                                "V3: adapter-reset watchdog fired ({} consecutive offline ticks within {}s of connect) — transitioning Connected → Error",
+                                                observed_ticks,
+                                                ADAPTER_WATCHDOG_WINDOW_SECS
+                                            );
+                                            *state = ConnectionState::Error(error_message.clone());
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    });
+
+                                    if transitioned {
+                                        {
+                                            let mut driver_guard = driver.lock().await;
+                                            if let Err(e) = driver_guard.close() {
+                                                log::warn!(
+                                                    "V3: watchdog rollback cleanup — driver.close() returned {}",
+                                                    e
+                                                );
+                                            }
+                                        }
+                                        super::wfp_block::cleanup();
+                                        if let Some(ref auto_router) = auto_router_for_monitor {
+                                            auto_router.reset();
+                                        }
+                                        if let Some(ref manager) = process_performance_for_monitor {
+                                            let mut guard = manager.lock().await;
+                                            guard.cleanup_all(cleanup_reason);
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
                         let mut driver_guard = driver.lock().await;
                         match driver_guard.maybe_rebind_on_default_route_change() {
                             Ok(true) => log::info!("V3: Split tunnel adapter re-bound to active interface"),
@@ -2036,7 +2208,15 @@ impl VpnConnection {
                             }
 
                             let sender_panicked = relay_health_monitor.sender_panicked();
-                            match classify_relay_health(health, sender_panicked) {
+                            let local_connectivity = if health
+                                == super::udp_relay::RelayHealthState::Dead
+                            {
+                                super::local_connectivity::probe()
+                            } else {
+                                LocalConnectivity::Unknown
+                            };
+                            match classify_relay_health(health, sender_panicked, local_connectivity)
+                            {
                                 RelayHealthAction::Fatal {
                                     error_message,
                                     cleanup_reason,
@@ -2486,7 +2666,11 @@ mod tests {
 
     #[test]
     fn test_dead_relay_health_is_fatal() {
-        let action = classify_relay_health(super::super::udp_relay::RelayHealthState::Dead, false);
+        let action = classify_relay_health(
+            super::super::udp_relay::RelayHealthState::Dead,
+            false,
+            LocalConnectivity::Unknown,
+        );
 
         match action {
             RelayHealthAction::Fatal {
@@ -2501,8 +2685,87 @@ mod tests {
     }
 
     #[test]
+    fn test_dead_relay_with_internet_offline_blames_local_network() {
+        let action = classify_relay_health(
+            super::super::udp_relay::RelayHealthState::Dead,
+            false,
+            LocalConnectivity::Offline,
+        );
+
+        match action {
+            RelayHealthAction::Fatal {
+                error_message,
+                cleanup_reason,
+            } => {
+                assert!(
+                    error_message.contains("Internet connection lost"),
+                    "expected offline message, got: {error_message}"
+                );
+                assert!(
+                    !error_message.contains("choose another relay"),
+                    "must not advise picking another relay when device is offline"
+                );
+                assert_eq!(cleanup_reason, "internet_lost_recovery");
+            }
+            RelayHealthAction::Continue { .. } => {
+                panic!("dead relay must not remain connected even when offline")
+            }
+        }
+    }
+
+    #[test]
+    fn test_dead_relay_with_internet_reachable_still_blames_relay() {
+        // Negative test for the offline-detection branch: when the OS
+        // confirms the device is online, a dead relay must still be
+        // surfaced as a relay failure (the user really should pick another
+        // relay). This guards against the offline path masking real relay
+        // outages.
+        let action = classify_relay_health(
+            super::super::udp_relay::RelayHealthState::Dead,
+            false,
+            LocalConnectivity::Reachable,
+        );
+
+        match action {
+            RelayHealthAction::Fatal {
+                error_message,
+                cleanup_reason,
+            } => {
+                assert!(error_message.contains("relay stopped returning traffic"));
+                assert!(error_message.contains("choose another relay"));
+                assert_eq!(cleanup_reason, "relay_dead_recovery");
+            }
+            RelayHealthAction::Continue { .. } => panic!("dead relay must not remain connected"),
+        }
+    }
+
+    #[test]
     fn test_stale_relay_health_remains_connected_status() {
-        let action = classify_relay_health(super::super::udp_relay::RelayHealthState::Stale, false);
+        let action = classify_relay_health(
+            super::super::udp_relay::RelayHealthState::Stale,
+            false,
+            LocalConnectivity::Unknown,
+        );
+
+        assert_eq!(
+            action,
+            RelayHealthAction::Continue {
+                relay_status: Some("stale".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_stale_relay_health_ignores_offline_hint() {
+        // A stale relay must not be escalated to a fatal "internet lost"
+        // teardown just because the OS hint happens to read Offline at the
+        // probe instant. Only Dead transitions consult the connectivity
+        // hint; Stale stays a continue.
+        let action = classify_relay_health(
+            super::super::udp_relay::RelayHealthState::Stale,
+            false,
+            LocalConnectivity::Offline,
+        );
 
         assert_eq!(
             action,
@@ -2517,9 +2780,201 @@ mod tests {
         let action = classify_relay_health(
             super::super::udp_relay::RelayHealthState::NoTrafficYet,
             false,
+            LocalConnectivity::Unknown,
         );
 
         assert_eq!(action, RelayHealthAction::Continue { relay_status: None });
+    }
+
+    #[test]
+    fn test_watchdog_continues_on_first_offline_tick() {
+        // One offline tick alone must not fire — we only abort on a sustained
+        // outage. The counter should bump from 0 to 1 and the caller should
+        // store it for next tick.
+        let action = watchdog_tick(Duration::from_secs(1), LocalConnectivity::Offline, 0);
+
+        assert_eq!(
+            action,
+            WatchdogTickAction::Continue {
+                consecutive_offline_ticks: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn test_watchdog_does_not_fire_on_brief_link_flap() {
+        // A brief Offline → Reachable sequence must NOT push the watchdog past
+        // its threshold. This covers Wi-Fi handover, momentary route refresh,
+        // sleep/resume settle: all transient and should be ignored.
+        let after_offline_1 = watchdog_tick(Duration::from_secs(1), LocalConnectivity::Offline, 0);
+        let count_after_offline = match after_offline_1 {
+            WatchdogTickAction::Continue {
+                consecutive_offline_ticks,
+            } => consecutive_offline_ticks,
+            other => panic!("expected Continue on first offline tick, got {:?}", other),
+        };
+
+        let after_offline_2 = watchdog_tick(
+            Duration::from_secs(2),
+            LocalConnectivity::Offline,
+            count_after_offline,
+        );
+        let count_after_offline_2 = match after_offline_2 {
+            WatchdogTickAction::Continue {
+                consecutive_offline_ticks,
+            } => consecutive_offline_ticks,
+            other => panic!("expected Continue on second offline tick, got {:?}", other),
+        };
+
+        // Reachable must reset the counter to zero, not merely continue.
+        let after_reachable = watchdog_tick(
+            Duration::from_secs(3),
+            LocalConnectivity::Reachable,
+            count_after_offline_2,
+        );
+        assert_eq!(
+            after_reachable,
+            WatchdogTickAction::Continue {
+                consecutive_offline_ticks: 0,
+            },
+            "Reachable must reset the consecutive-offline counter to zero (got {:?})",
+            after_reachable
+        );
+    }
+
+    #[test]
+    fn test_watchdog_fires_on_sustained_offline() {
+        // Hit the threshold exactly. The threshold is the number of
+        // consecutive Offline ticks required; with the 500ms refresh tick
+        // that's 3s sustained — a structured marker that the IPv4 default
+        // route really has gone away, not just a flap.
+        let mut count = 0u32;
+        for tick in 1..ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD {
+            let elapsed = Duration::from_millis(500 * tick as u64);
+            match watchdog_tick(elapsed, LocalConnectivity::Offline, count) {
+                WatchdogTickAction::Continue {
+                    consecutive_offline_ticks,
+                } => count = consecutive_offline_ticks,
+                other => panic!(
+                    "expected Continue at tick {} (count {}), got {:?}",
+                    tick, count, other
+                ),
+            }
+        }
+
+        let final_elapsed =
+            Duration::from_millis(500 * ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD as u64);
+        let action = watchdog_tick(final_elapsed, LocalConnectivity::Offline, count);
+
+        match action {
+            WatchdogTickAction::Abort {
+                error_message,
+                cleanup_reason,
+            } => {
+                assert_eq!(cleanup_reason, ADAPTER_RESET_ROLLBACK_REASON);
+                assert!(
+                    error_message.contains("rolled back"),
+                    "expected user-facing 'rolled back' wording, got: {error_message}"
+                );
+                assert!(
+                    error_message.contains("try connecting again"),
+                    "expected retry hint, got: {error_message}"
+                );
+            }
+            other => panic!(
+                "expected Abort at threshold (count was about to become {}), got {:?}",
+                ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD, other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_watchdog_does_not_fire_on_unknown_probe() {
+        // `Unknown` is treated as a probe failure (NLM API hung,
+        // non-Windows build, hint=Unknown), NOT as offline. Mirrors the
+        // existing semantic in `classify_relay_health` — a flaky NLM API
+        // must not be allowed to abort an otherwise-healthy connect.
+        let mut count = 0u32;
+        for tick in 1..(ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD * 4) {
+            let elapsed = Duration::from_millis(500 * tick as u64);
+            match watchdog_tick(elapsed, LocalConnectivity::Unknown, count) {
+                WatchdogTickAction::Continue {
+                    consecutive_offline_ticks,
+                } => {
+                    assert_eq!(
+                        consecutive_offline_ticks, 0,
+                        "Unknown probe must keep the counter at 0, got {} at tick {}",
+                        consecutive_offline_ticks, tick
+                    );
+                    count = consecutive_offline_ticks;
+                }
+                WatchdogTickAction::Disarmed => {
+                    // Eventually the window will pass (at 30s) — that's fine,
+                    // it just means we ran the loop long enough. The key
+                    // assertion is "no Abort variant ever surfaced".
+                    return;
+                }
+                WatchdogTickAction::Abort { .. } => panic!(
+                    "Unknown probe must never abort the watchdog (tick {})",
+                    tick
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_watchdog_disarms_after_window_passes() {
+        // Even with the counter pre-loaded above threshold, once the window
+        // has elapsed the watchdog must return Disarmed and stop firing —
+        // mid-session relay-health monitoring takes over.
+        let elapsed = Duration::from_secs(ADAPTER_WATCHDOG_WINDOW_SECS);
+        let action = watchdog_tick(
+            elapsed,
+            LocalConnectivity::Offline,
+            ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD + 100,
+        );
+
+        assert_eq!(
+            action,
+            WatchdogTickAction::Disarmed,
+            "watchdog must disarm at exactly the window boundary, even if probe is Offline"
+        );
+    }
+
+    #[test]
+    fn test_watchdog_disarms_well_after_window_for_offline_probe() {
+        // Negative test paired with the previous one: an Offline probe ten
+        // minutes into the session must NOT cause the watchdog to abort.
+        // Adapter-reset rollback is a connect-window concept; sustained
+        // offlines mid-session are a different problem (handled by the
+        // existing relay-health classifier).
+        let elapsed = Duration::from_secs(600);
+        let action = watchdog_tick(elapsed, LocalConnectivity::Offline, 0);
+
+        assert_eq!(
+            action,
+            WatchdogTickAction::Disarmed,
+            "watchdog must stay disarmed long after the connect window — sustained offline is a different code path"
+        );
+    }
+
+    #[test]
+    fn test_watchdog_reachable_inside_window_resets_counter() {
+        // Even if we're 5 ticks into a 6-tick threshold, a single Reachable
+        // probe must clear the counter — that's the whole point of
+        // requiring *consecutive* offline ticks, not cumulative ones.
+        let action = watchdog_tick(
+            Duration::from_secs(2),
+            LocalConnectivity::Reachable,
+            ADAPTER_WATCHDOG_OFFLINE_TICK_THRESHOLD - 1,
+        );
+
+        assert_eq!(
+            action,
+            WatchdogTickAction::Continue {
+                consecutive_offline_ticks: 0,
+            }
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -56,8 +56,7 @@ const ADAPTER_RESET_ROLLBACK_REASON: &str = "adapter_reset_rollback";
 
 /// Error string surfaced to the UI on watchdog rollback. Wording deliberately
 /// asks the user to retry — the path is recoverable on next connect.
-const ADAPTER_RESET_ROLLBACK_MESSAGE: &str =
-    "SwiftTunnel rolled back the connection because your network adapter went offline during setup. This usually clears up on its own — please try connecting again.";
+const ADAPTER_RESET_ROLLBACK_MESSAGE: &str = "SwiftTunnel rolled back the connection because your network adapter went offline during setup. This usually clears up on its own — please try connecting again.";
 const ETW_CONNECTION_READY_TIMEOUT_MS: u64 = 150;
 const ETW_CONNECTION_READY_POLL_MS: u64 = 5;
 /// Number of ICMP samples to collect per relay candidate when probing.

--- a/swifttunnel-core/src/vpn/local_connectivity.rs
+++ b/swifttunnel-core/src/vpn/local_connectivity.rs
@@ -1,0 +1,52 @@
+//! Local internet reachability hint.
+//!
+//! Used to disambiguate "the relay went away" from "the user's machine lost
+//! internet" when the relay-health monitor is about to declare a session dead.
+//! On Windows we ask `GetNetworkConnectivityHint` — the same NLM signal that
+//! drives the "No internet access" badge in the system tray.
+
+/// Authoritative-enough verdict on whether this device can currently reach
+/// the public internet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalConnectivity {
+    /// OS reports internet (or constrained internet) is available.
+    Reachable,
+    /// OS reports no public internet — local-network-only or fully offline.
+    Offline,
+    /// We could not get a verdict (API failed, hint=Unknown, non-Windows
+    /// build). Treat as "do not override the existing relay-failure path."
+    Unknown,
+}
+
+#[cfg(windows)]
+pub fn probe() -> LocalConnectivity {
+    use windows::Win32::NetworkManagement::IpHelper::GetNetworkConnectivityHint;
+    use windows::Win32::Networking::WinSock::{
+        NL_NETWORK_CONNECTIVITY_HINT, NetworkConnectivityLevelHintConstrainedInternetAccess,
+        NetworkConnectivityLevelHintHidden, NetworkConnectivityLevelHintInternetAccess,
+        NetworkConnectivityLevelHintLocalAccess, NetworkConnectivityLevelHintNone,
+        NetworkConnectivityLevelHintUnknown,
+    };
+
+    let mut hint = NL_NETWORK_CONNECTIVITY_HINT::default();
+    // SAFETY: out-pointer write into a stack-allocated, properly-sized struct.
+    let status = unsafe { GetNetworkConnectivityHint(&mut hint) };
+    if status.is_err() {
+        return LocalConnectivity::Unknown;
+    }
+
+    match hint.ConnectivityLevel {
+        NetworkConnectivityLevelHintInternetAccess
+        | NetworkConnectivityLevelHintConstrainedInternetAccess => LocalConnectivity::Reachable,
+        NetworkConnectivityLevelHintLocalAccess
+        | NetworkConnectivityLevelHintNone
+        | NetworkConnectivityLevelHintHidden => LocalConnectivity::Offline,
+        NetworkConnectivityLevelHintUnknown => LocalConnectivity::Unknown,
+        _ => LocalConnectivity::Unknown,
+    }
+}
+
+#[cfg(not(windows))]
+pub fn probe() -> LocalConnectivity {
+    LocalConnectivity::Unknown
+}

--- a/swifttunnel-core/src/vpn/local_connectivity.rs
+++ b/swifttunnel-core/src/vpn/local_connectivity.rs
@@ -4,6 +4,11 @@
 //! internet" when the relay-health monitor is about to declare a session dead.
 //! On Windows we ask `GetNetworkConnectivityHint` — the same NLM signal that
 //! drives the "No internet access" badge in the system tray.
+//!
+//! Minimum supported Windows: 10 build 17763 (1809). The `windows` crate
+//! late-binds these symbols, so older builds return a non-success status
+//! through `status.is_err()` and we degrade gracefully to `Unknown` rather
+//! than failing to load.
 
 /// Authoritative-enough verdict on whether this device can currently reach
 /// the public internet.
@@ -38,10 +43,19 @@ pub fn probe() -> LocalConnectivity {
     match hint.ConnectivityLevel {
         NetworkConnectivityLevelHintInternetAccess
         | NetworkConnectivityLevelHintConstrainedInternetAccess => LocalConnectivity::Reachable,
-        NetworkConnectivityLevelHintLocalAccess
-        | NetworkConnectivityLevelHintNone
-        | NetworkConnectivityLevelHintHidden => LocalConnectivity::Offline,
-        NetworkConnectivityLevelHintUnknown => LocalConnectivity::Unknown,
+        NetworkConnectivityLevelHintLocalAccess | NetworkConnectivityLevelHintNone => {
+            LocalConnectivity::Offline
+        }
+        // `Hidden` means NLM couldn't determine the interface's connectivity
+        // properties — typical on VPN-managed virtual adapters, hidden-SSID
+        // corporate networks, and some Wi-Fi drivers. It is *not* a reliable
+        // "offline" signal and treating it as one would cause the post-connect
+        // watchdog to fire spurious adapter-reset rollbacks on those configs.
+        // Mapped to `Unknown` so the existing "do not override the relay
+        // failure path" semantic carries through.
+        NetworkConnectivityLevelHintHidden | NetworkConnectivityLevelHintUnknown => {
+            LocalConnectivity::Unknown
+        }
         _ => LocalConnectivity::Unknown,
     }
 }

--- a/swifttunnel-core/src/vpn/mod.rs
+++ b/swifttunnel-core/src/vpn/mod.rs
@@ -22,6 +22,7 @@ pub mod auto_routing;
 pub mod connection;
 pub mod error_messages;
 pub mod ipv6_recovery;
+pub mod local_connectivity;
 pub mod parallel_interceptor;
 pub mod process_cache;
 pub mod process_performance;

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -3439,8 +3439,27 @@ impl ParallelInterceptor {
 
         log::info!("Disabling TSO/LSO on adapter: {}", friendly_name);
 
-        // Disable Large Send Offload v2 for IPv4 and IPv6
-        // These are the standard registry keywords for TSO/LSO
+        // Disable Large Send Offload v2 for IPv4 and IPv6.
+        //
+        // We deliberately do NOT touch *TCPChecksumOffload* / *UDPChecksumOffload*
+        // here, even though the pre-2026-04 builds did. Each
+        // `Set-NetAdapterAdvancedProperty` call notifies the NDIS stack via WMI
+        // and on many real-world NICs (Realtek, Killer, USB-Ethernet, some
+        // Intel) each property change triggers a transient adapter reset to
+        // apply the new value — the same family of failure mode documented for
+        // `Disable-NetAdapterBinding ms_tcpip6` further down. Six sequential
+        // resets in a few seconds was thrashing the NIC enough to drop the
+        // IPv4 default route mid-connect (tushi report, 2026-04 stlog: route
+        // disappeared 4s after a successful relay handshake while this
+        // background script was still landing changes). Cutting the script
+        // from 6 properties to 2 cuts that thrash by ~67%.
+        //
+        // Tunneled correctness does not depend on disabling NIC checksum
+        // offload — `fix_packet_checksums` (this file, ~7350) zeros and
+        // recomputes IP/TCP/UDP checksums in software on every forwarded
+        // packet (callers at ~4605 outbound and ~5443 inbound). Bypassed
+        // (non-tunneled) traffic is unaffected: the NIC stamps checksums on
+        // the way out exactly like it does on a non-SwiftTunnel system.
         let script = format!(
             r#"
             $ErrorActionPreference = 'SilentlyContinue'
@@ -3451,13 +3470,6 @@ impl ParallelInterceptor {
 
             # Disable LSO v2 IPv6
             Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv6' -RegistryValue 0 2>$null
-
-            # Also disable TCP/UDP checksum offload to ensure we handle all checksums
-            # (Some NICs have separate settings for Tx and Rx)
-            Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv4' -RegistryValue 0 2>$null
-            Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv4' -RegistryValue 0 2>$null
-            Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv6' -RegistryValue 0 2>$null
-            Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv6' -RegistryValue 0 2>$null
 
             Write-Host 'Offload disabled'
             "#,
@@ -3578,6 +3590,12 @@ impl ParallelInterceptor {
                 log::warn!("Failed to restore TSO - will retry on next launch");
             }
             None => {
+                // Fallback restore (no marker file). Mirrors the disable
+                // script: only LSO is re-enabled because that's all we
+                // disable. The marker-driven path (`restore_tso_from_marker`)
+                // still emits checksum-offload restore commands for legacy
+                // markers from pre-2026-04 builds, so users who upgrade
+                // mid-session don't end up with checksum offload stuck off.
                 let script = format!(
                     r#"
                     $ErrorActionPreference = 'SilentlyContinue'
@@ -3586,12 +3604,6 @@ impl ParallelInterceptor {
                     # Re-enable LSO v2
                     Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv4' -RegistryValue 1 2>$null
                     Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv6' -RegistryValue 1 2>$null
-
-                    # Re-enable checksum offload
-                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv4' -RegistryValue 3 2>$null
-                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv4' -RegistryValue 3 2>$null
-                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv6' -RegistryValue 3 2>$null
-                    Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv6' -RegistryValue 3 2>$null
 
                     Write-Host 'Offload enabled'
                     "#,

--- a/swifttunnel-core/src/vpn/tso_recovery.rs
+++ b/swifttunnel-core/src/vpn/tso_recovery.rs
@@ -59,13 +59,14 @@ impl TsoMarker {
             return captured_commands;
         }
 
+        // Legacy / no-captured-values fallback. Only re-enable LSO — checksum
+        // offload is no longer something we touch on connect, so we must not
+        // forcibly re-enable it here either (a user who manually disabled
+        // checksum offload for their own reasons would otherwise have it
+        // silently restored on next disconnect).
         vec![
             "Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv4' -RegistryValue 1 2>$null".to_string(),
             "Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*LsoV2IPv6' -RegistryValue 1 2>$null".to_string(),
-            "Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv4' -RegistryValue 3 2>$null".to_string(),
-            "Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv4' -RegistryValue 3 2>$null".to_string(),
-            "Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*TCPChecksumOffloadIPv6' -RegistryValue 3 2>$null".to_string(),
-            "Set-NetAdapterAdvancedProperty -Name $adapter -RegistryKeyword '*UDPChecksumOffloadIPv6' -RegistryValue 3 2>$null".to_string(),
         ]
     }
 }
@@ -151,26 +152,24 @@ fn query_adapter_offload_value(adapter_name: &str, keyword: &str) -> Option<u32>
 }
 
 fn capture_tso_marker(adapter_name: &str) -> TsoMarker {
+    // We only capture/restore LSO. Checksum-offload toggles are no longer
+    // performed on connect (they triggered repeated NIC resets that dropped
+    // the default route mid-connect), so capturing them would only cost
+    // 4 extra Get-NetAdapterAdvancedProperty calls — each up to
+    // ADAPTER_QUERY_TIMEOUT_SECS — for values we'll never use on restore.
+    //
+    // The struct still has the fields so on-disk markers from older builds
+    // still deserialize cleanly; their restore commands still run via
+    // `TsoMarker::restore_commands` so users upgrading mid-session don't end
+    // up with checksum offload stuck disabled.
     TsoMarker {
         adapter_name: adapter_name.trim().to_string(),
         lso_v2_ipv4: query_adapter_offload_value(adapter_name, "*LsoV2IPv4"),
         lso_v2_ipv6: query_adapter_offload_value(adapter_name, "*LsoV2IPv6"),
-        tcp_checksum_offload_ipv4: query_adapter_offload_value(
-            adapter_name,
-            "*TCPChecksumOffloadIPv4",
-        ),
-        udp_checksum_offload_ipv4: query_adapter_offload_value(
-            adapter_name,
-            "*UDPChecksumOffloadIPv4",
-        ),
-        tcp_checksum_offload_ipv6: query_adapter_offload_value(
-            adapter_name,
-            "*TCPChecksumOffloadIPv6",
-        ),
-        udp_checksum_offload_ipv6: query_adapter_offload_value(
-            adapter_name,
-            "*UDPChecksumOffloadIPv6",
-        ),
+        tcp_checksum_offload_ipv4: None,
+        udp_checksum_offload_ipv4: None,
+        tcp_checksum_offload_ipv6: None,
+        udp_checksum_offload_ipv6: None,
     }
 }
 

--- a/swifttunnel-core/src/vpn/tso_recovery.rs
+++ b/swifttunnel-core/src/vpn/tso_recovery.rs
@@ -78,11 +78,13 @@ fn get_marker_path() -> Option<PathBuf> {
 
 /// Per-query timeout for adapter offload probes.
 ///
-/// 6 queries × 2s = 12s absolute worst case for a full marker capture. A hung
-/// WMI provider on a flaky NIC (Realtek RTL8821CE in the 2026-04-19 incident)
-/// can otherwise block `.output()` for 30–60s, freezing whichever thread
-/// called us. Every call site now runs this off the connect path, but the
-/// bound is still the right belt-and-braces.
+/// 2 queries × 2s = 4s absolute worst case for a full marker capture (LSO v2
+/// IPv4 + IPv6; checksum-offload values are no longer captured because we
+/// don't toggle them on connect any more). A hung WMI provider on a flaky
+/// NIC (Realtek RTL8821CE in the 2026-04-19 incident) can otherwise block
+/// `.output()` for 30–60s, freezing whichever thread called us. Every call
+/// site now runs this off the connect path, but the bound is still the right
+/// belt-and-braces.
 const ADAPTER_QUERY_TIMEOUT_SECS: u64 = 2;
 
 fn query_adapter_offload_value(adapter_name: &str, keyword: &str) -> Option<u32> {


### PR DESCRIPTION
## Summary

Connect was reliably killing some users' internet. Logs from `tushi` (2026-04 stlog):

| Time | Event |
|---|---|
| 09:10:12 | Connect succeeds, packets flow through germany-03 relay (V3 inbound #1–#9). |
| 09:10:16 | **Network goes unreachable** — `os error 10051 (WSAENETUNREACH)`, `No default route found in GetIpForwardTable`. |
| 09:10:17 | Relay marked Dead, teardown begins. |
| 09:10:18 | `Failed to disable TSO on Ethernet (non-fatal): … or WMI is unresponsive` — the *background* TSO-disable thread (started at connect time) timed out at 3s while the route was disappearing. |
| 09:10:38 | Internet back, ~22s after it dropped. |

**Root cause:** `disable_adapter_offload()` runs **6 sequential `Set-NetAdapterAdvancedProperty` calls** (LSO×2 + checksum offload×4) on every connect. Each call notifies NDIS via WMI; on Realtek / Killer / USB-Ethernet / some Intel NICs each property change triggers a transient adapter reset. Six-in-a-row was thrashing the NIC enough to drop the IPv4 default route mid-connect — exactly the failure mode already documented for `Disable-NetAdapterBinding ms_tcpip6` further down in the same file.

## Two changes

**1. Drop the four checksum-offload disables.** They're redundant: `fix_packet_checksums` (parallel_interceptor.rs:7350) already recomputes IP/TCP/UDP checksums in software on every forwarded packet (callers at ~4605 outbound, ~5443 inbound). Bypassed traffic is unaffected — NIC stamps as normal. Cuts adapter-property thrash 6→2. Legacy on-disk markers still restore checksum offload values for users upgrading mid-session.

**2. Post-connect adapter-reset watchdog (`connection.rs`).** Polls `LocalConnectivity::probe` every 500ms for the first 30s after `driver.configure()` returns. If NLM reports `Offline` for 6 consecutive ticks (~3s sustained), abort with `cleanup_reason=adapter_reset_rollback` and a clear retry message. `Unknown` does **not** count as offline (matches the existing `classify_relay_health` semantic — a flaky NLM API can't preempt a healthy connect). Disarms after the window; mid-session connectivity loss stays on the existing path.

Result: users get a clear "please try again" in ~3s instead of sitting through 22+s of broken internet before the relay-dead path declares the same outcome.

## Test plan

Unit tests added (all in `connection.rs`):

- [x] `test_watchdog_continues_on_first_offline_tick` — single offline doesn't fire.
- [x] `test_watchdog_does_not_fire_on_brief_link_flap` — Offline → Reachable resets the counter.
- [x] `test_watchdog_fires_on_sustained_offline` — threshold reached → `Abort` with correct reason/message.
- [x] `test_watchdog_does_not_fire_on_unknown_probe` — Unknown for the entire window never aborts. Negative test guarding against NLM API flakiness.
- [x] `test_watchdog_disarms_after_window_passes` — `elapsed >= 30s` returns `Disarmed` even if probe is Offline.
- [x] `test_watchdog_disarms_well_after_window_for_offline_probe` — offline mid-session does not abort. Negative test that the connect-window scope doesn't bleed into long-lived sessions.
- [x] `test_watchdog_reachable_inside_window_resets_counter` — Reachable clears the counter; consecutive-not-cumulative semantic preserved.

Existing `classify_relay_health` tests cover the post-mortem path that already shipped on this branch.

**Windows testbench (per project rule — macOS local `cargo check` blocked by pre-existing `windows-future v0.3.2` ↔ `windows_core v0.62.2` API drift, unrelated to this PR):**

- [ ] Sync to testbench, `cd swifttunnel-desktop && npm install && npm run tauri build`.
- [ ] Run `while ($true) { (route print -4 | Select-String '^\s+0\.0\.0\.0').Line; Start-Sleep -Seconds 1 }` in a side console.
- [ ] Connect 5 times consecutively on Ethernet; confirm no >2s gap in the default route during any connect window, and `adapter_reset_rollback` does not fire on healthy NICs.
- [ ] Launch Roblox during one connect; confirm `Worker N: V3 relay forward OK` in stlog and the game actually plays — validates that dropping the checksum-offload disables didn't break tunneling.
- [ ] Disconnect and verify TSO is restored: `Get-NetAdapterAdvancedProperty -Name <NIC> -RegistryKeyword '*LsoV2IPv4'` returns the original value. Also confirm `*TCPChecksumOffloadIPv4` is **unchanged from baseline** (we never touched it).
- [ ] Watchdog positive path: connect, then within the 30s window manually run `Disable-NetAdapter -Name <NIC>` for ~5s and re-enable. Confirm the watchdog fires with `adapter_reset_rollback` and surfaces the retry message.
- [ ] If a Wi-Fi NIC is available, repeat the steady-state checks on Wi-Fi.

If after this fix the testbench still shows route loss, the next escalation is to move the LSO disable out of the connect path entirely (deferred — see plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)