### PR TITLE
[codex] Stabilize IPinfo auto routing

### DIFF
--- a/swifttunnel-core/src/geolocation.rs
+++ b/swifttunnel-core/src/geolocation.rs
@@ -152,8 +152,12 @@ fn format_api_location(location: &GameServerRegionLocation) -> Option<String> {
 pub fn is_roblox_game_server_ip(ip: Ipv4Addr) -> bool {
     let ip_u32 = u32::from(ip);
 
-    // Roblox IP ranges (network, mask)
-    // Note: 128.116.0.0/17 covers ALL regional game servers
+    // Roblox regional game-server IP ranges (network, mask).
+    //
+    // Keep this list scoped to game-server ranges only. Roblox-owned API,
+    // matchmaking, and infrastructure CIDRs also resolve through IPinfo, but
+    // they are not valid auto-routing signals and can pull an in-game session
+    // toward San Mateo/US West when contacted mid-session.
     const ROBLOX_RANGES: &[(u32, u32)] = &[
         // Primary game servers (all regions)
         (0x80740000, 0xFFFF8000), // 128.116.0.0/17
@@ -163,14 +167,6 @@ pub fn is_roblox_game_server_ip(ip: Ipv4Addr) -> bool {
         (0x678C1C00, 0xFFFFFE00), // 103.140.28.0/23
         // China (Luobu)
         (0x678EDC00, 0xFFFFFE00), // 103.142.220.0/23
-        // API/Matchmaking
-        (0x17ADC000, 0xFFFFFF00), // 23.173.192.0/24
-        (0x8DC10300, 0xFFFFFF00), // 141.193.3.0/24
-        (0xCDC93E00, 0xFFFFFF00), // 205.201.62.0/24
-        // Infrastructure
-        (0xCC09B800, 0xFFFFFF00), // 204.9.184.0/24
-        (0xCC0DA800, 0xFFFFFC00), // 204.13.168.0/22
-        (0xCC0DAC00, 0xFFFFFE00), // 204.13.172.0/23
     ];
 
     for &(network, mask) in ROBLOX_RANGES {
@@ -570,10 +566,13 @@ mod tests {
         // Should match - in Roblox range
         assert!(is_roblox_game_server_ip(Ipv4Addr::new(128, 116, 50, 100)));
         assert!(is_roblox_game_server_ip(Ipv4Addr::new(209, 206, 42, 10)));
+        assert!(is_roblox_game_server_ip(Ipv4Addr::new(103, 140, 28, 10)));
 
-        // Should not match - outside ranges
+        // Should not match - outside game-server ranges
         assert!(!is_roblox_game_server_ip(Ipv4Addr::new(1, 1, 1, 1)));
         assert!(!is_roblox_game_server_ip(Ipv4Addr::new(8, 8, 8, 8)));
+        assert!(!is_roblox_game_server_ip(Ipv4Addr::new(23, 173, 192, 10)));
+        assert!(!is_roblox_game_server_ip(Ipv4Addr::new(204, 9, 184, 10)));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/auto_routing.rs
+++ b/swifttunnel-core/src/vpn/auto_routing.rs
@@ -388,7 +388,19 @@ impl AutoRouter {
     /// Pin the first structured game-server lookup accepted for this session.
     /// Returns false when another IP already owns the active session.
     pub fn pin_active_game_server(&self, ip: Ipv4Addr) -> bool {
+        let session_epoch = self.lookup_session_epoch.load(Ordering::Acquire);
+        self.pin_active_game_server_for_session(ip, session_epoch)
+    }
+
+    /// Pin only if the lookup belongs to the currently active session.
+    ///
+    /// The session check happens while holding the active-IP lock so reset()
+    /// cannot clear the pin between a stale lookup's session check and pin.
+    pub fn pin_active_game_server_for_session(&self, ip: Ipv4Addr, session_epoch: u64) -> bool {
         let mut active = self.active_game_server_ip.write();
+        if !self.is_current_lookup_session(session_epoch) {
+            return false;
+        }
         match *active {
             Some(active_ip) => active_ip == ip,
             None => {
@@ -626,10 +638,10 @@ impl AutoRouter {
         *self.current_game_region.write() = None;
         *self.current_relay_addr.write() = None;
         self.seen_game_servers.write().clear();
+        self.lookup_session_epoch.fetch_add(1, Ordering::AcqRel);
         *self.active_game_server_ip.write() = None;
         self.pending_lookups.write().clear();
         self.latest_lookup_generation.store(0, Ordering::Release);
-        self.lookup_session_epoch.fetch_add(1, Ordering::AcqRel);
         self.pending_any.store(false, Ordering::Release);
         self.auto_routing_bypassed.store(false, Ordering::Release);
         self.clear_lookup_channel();
@@ -867,6 +879,10 @@ mod tests {
 
         router.reset();
         assert!(!router.is_current_lookup_session(session_epoch));
+        assert!(
+            !router
+                .pin_active_game_server_for_session(Ipv4Addr::new(128, 116, 50, 1), session_epoch)
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/auto_routing.rs
+++ b/swifttunnel-core/src/vpn/auto_routing.rs
@@ -56,9 +56,12 @@ pub struct AutoRouter {
     /// Log of auto-routing events for UI display
     event_log: RwLock<VecDeque<AutoRoutingEvent>>,
     /// Channel to send game server IPs for async geolocation lookup
-    lookup_sender: RwLock<Option<tokio::sync::mpsc::UnboundedSender<(Ipv4Addr, u64)>>>,
+    lookup_sender: RwLock<Option<tokio::sync::mpsc::UnboundedSender<(Ipv4Addr, u64, u64)>>>,
     /// Monotonic generation assigned to newly detected game-server lookups.
     latest_lookup_generation: AtomicU64,
+    /// Session epoch copied into lookup messages so post-reset results cannot
+    /// mutate a freshly reset router.
+    lookup_session_epoch: AtomicU64,
     /// IPs currently being looked up — packets to these are held (dropped) until
     /// the lookup completes, preventing the game server from seeing a relay IP change.
     pending_lookups: RwLock<HashSet<Ipv4Addr>>,
@@ -115,6 +118,7 @@ impl AutoRouter {
             event_log: RwLock::new(VecDeque::new()),
             lookup_sender: RwLock::new(None),
             latest_lookup_generation: AtomicU64::new(0),
+            lookup_session_epoch: AtomicU64::new(1),
             pending_lookups: RwLock::new(HashSet::new()),
             pending_any: AtomicBool::new(false),
             whitelisted_regions: RwLock::new(HashSet::new()),
@@ -124,7 +128,10 @@ impl AutoRouter {
     }
 
     /// Set the channel for sending game server IPs to the background lookup task
-    pub fn set_lookup_channel(&self, sender: tokio::sync::mpsc::UnboundedSender<(Ipv4Addr, u64)>) {
+    pub fn set_lookup_channel(
+        &self,
+        sender: tokio::sync::mpsc::UnboundedSender<(Ipv4Addr, u64, u64)>,
+    ) {
         *self.lookup_sender.write() = Some(sender);
     }
 
@@ -310,8 +317,12 @@ impl AutoRouter {
         }
 
         let generation = self.latest_lookup_generation.fetch_add(1, Ordering::AcqRel) + 1;
+        let session_epoch = self.lookup_session_epoch.load(Ordering::Acquire);
 
-        if sender.send((game_server_ip, generation)).is_err() {
+        if sender
+            .send((game_server_ip, generation, session_epoch))
+            .is_err()
+        {
             log::warn!(
                 "Auto-routing: Lookup channel closed — releasing packets for {} and disabling holding behavior",
                 game_server_ip
@@ -356,6 +367,10 @@ impl AutoRouter {
     /// Check whether a lookup result is still allowed to change relay state.
     pub fn is_current_lookup_generation(&self, generation: u64) -> bool {
         self.latest_lookup_generation.load(Ordering::Acquire) == generation
+    }
+
+    pub fn is_current_lookup_session(&self, session_epoch: u64) -> bool {
+        self.lookup_session_epoch.load(Ordering::Acquire) == session_epoch
     }
 
     /// Whether a completed lookup result is allowed to affect routing.
@@ -614,6 +629,7 @@ impl AutoRouter {
         *self.active_game_server_ip.write() = None;
         self.pending_lookups.write().clear();
         self.latest_lookup_generation.store(0, Ordering::Release);
+        self.lookup_session_epoch.fetch_add(1, Ordering::AcqRel);
         self.pending_any.store(false, Ordering::Release);
         self.auto_routing_bypassed.store(false, Ordering::Release);
         self.clear_lookup_channel();
@@ -809,9 +825,11 @@ mod tests {
 
         // First call sends to channel
         router.evaluate_game_server(ip);
-        let (received_ip, generation) = rx.try_recv().expect("first lookup should be sent");
+        let (received_ip, generation, session_epoch) =
+            rx.try_recv().expect("first lookup should be sent");
         assert_eq!(received_ip, ip);
         assert_eq!(generation, 1);
+        assert!(router.is_current_lookup_session(session_epoch));
 
         // Second call with same IP should NOT send again
         router.evaluate_game_server(ip);
@@ -825,13 +843,30 @@ mod tests {
         router.set_lookup_channel(tx);
 
         router.evaluate_game_server(Ipv4Addr::new(128, 116, 50, 1));
-        let (_, first_generation) = rx.try_recv().expect("first lookup");
+        let (_, first_generation, first_session_epoch) = rx.try_recv().expect("first lookup");
         assert!(router.is_current_lookup_generation(first_generation));
+        assert!(router.is_current_lookup_session(first_session_epoch));
 
         router.evaluate_game_server(Ipv4Addr::new(128, 116, 55, 1));
-        let (_, second_generation) = rx.try_recv().expect("second lookup");
+        let (_, second_generation, second_session_epoch) = rx.try_recv().expect("second lookup");
         assert!(!router.is_current_lookup_generation(first_generation));
         assert!(router.is_current_lookup_generation(second_generation));
+        assert_eq!(first_session_epoch, second_session_epoch);
+        assert!(router.is_current_lookup_session(second_session_epoch));
+    }
+
+    #[test]
+    fn test_reset_invalidates_inflight_lookup_session() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = AutoRouter::new(true, "singapore");
+        router.set_lookup_channel(tx);
+
+        router.evaluate_game_server(Ipv4Addr::new(128, 116, 50, 1));
+        let (_, _generation, session_epoch) = rx.try_recv().expect("lookup");
+        assert!(router.is_current_lookup_session(session_epoch));
+
+        router.reset();
+        assert!(!router.is_current_lookup_session(session_epoch));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/auto_routing.rs
+++ b/swifttunnel-core/src/vpn/auto_routing.rs
@@ -1,7 +1,8 @@
 //! Auto Routing - Automatic relay server switching based on game server region
 //!
-//! Detects when a Roblox player gets teleported to a game server in a different
-//! region and automatically switches the relay server for optimal latency.
+//! Detects the first structured Roblox game-server region for a VPN session and
+//! switches the relay server for optimal latency. Once a game server is pinned,
+//! later Roblox-owned endpoints cannot change the route until disconnect.
 //!
 //! Similar to GearUp's AIR (Adaptive Intelligent Routing) and ExitLag's
 //! automatic region detection.
@@ -42,8 +43,14 @@ pub struct AutoRouter {
     last_switch_time: RwLock<Instant>,
     /// Number of switches in the current minute window
     switches_this_minute: RwLock<(u32, Instant)>,
-    /// Game server IPs we've already routed (to detect new teleports)
+    /// Game server IPs we've already evaluated this session
     seen_game_servers: RwLock<HashSet<Ipv4Addr>>,
+    /// First structured game-server IP accepted for this VPN session.
+    ///
+    /// Roblox can contact several Roblox-owned endpoints while a user is already
+    /// playing. Once a real game-server lookup succeeds, later candidate IPs
+    /// must not override that route until disconnect resets the session.
+    active_game_server_ip: RwLock<Option<Ipv4Addr>>,
     /// Callback: list of (region_id, relay_addr, cached_latency_ms) for available servers
     available_servers: RwLock<Vec<(String, SocketAddr, Option<u32>)>>,
     /// Log of auto-routing events for UI display
@@ -103,6 +110,7 @@ impl AutoRouter {
             ),
             switches_this_minute: RwLock::new((0, Instant::now())),
             seen_game_servers: RwLock::new(HashSet::new()),
+            active_game_server_ip: RwLock::new(None),
             available_servers: RwLock::new(Vec::new()),
             event_log: RwLock::new(VecDeque::new()),
             lookup_sender: RwLock::new(None),
@@ -350,6 +358,38 @@ impl AutoRouter {
         self.latest_lookup_generation.load(Ordering::Acquire) == generation
     }
 
+    /// Whether a completed lookup result is allowed to affect routing.
+    ///
+    /// Before the first structured lookup succeeds, candidates may resolve in
+    /// channel order. After one IP is accepted, superficially similar Roblox
+    /// traffic cannot flip the relay mid-game.
+    pub fn should_process_lookup_result(&self, ip: Ipv4Addr) -> bool {
+        match *self.active_game_server_ip.read() {
+            Some(active_ip) => active_ip == ip,
+            None => true,
+        }
+    }
+
+    /// Pin the first structured game-server lookup accepted for this session.
+    /// Returns false when another IP already owns the active session.
+    pub fn pin_active_game_server(&self, ip: Ipv4Addr) -> bool {
+        let mut active = self.active_game_server_ip.write();
+        match *active {
+            Some(active_ip) => active_ip == ip,
+            None => {
+                *active = Some(ip);
+                log::info!("Auto-routing: Active game server pinned to {}", ip);
+                true
+            }
+        }
+    }
+
+    pub fn is_active_game_server(&self, ip: Ipv4Addr) -> bool {
+        self.active_game_server_ip
+            .read()
+            .is_some_and(|active_ip| active_ip == ip)
+    }
+
     /// Resolve the best relay server for a game region.
     ///
     /// Returns `None` if:
@@ -571,6 +611,7 @@ impl AutoRouter {
         *self.current_game_region.write() = None;
         *self.current_relay_addr.write() = None;
         self.seen_game_servers.write().clear();
+        *self.active_game_server_ip.write() = None;
         self.pending_lookups.write().clear();
         self.latest_lookup_generation.store(0, Ordering::Release);
         self.pending_any.store(false, Ordering::Release);
@@ -794,6 +835,35 @@ mod tests {
     }
 
     #[test]
+    fn test_active_game_server_pins_first_successful_lookup() {
+        let router = AutoRouter::new(true, "singapore");
+        let first_ip = Ipv4Addr::new(128, 116, 50, 1);
+        let later_ip = Ipv4Addr::new(128, 116, 55, 1);
+
+        assert!(router.should_process_lookup_result(first_ip));
+        assert!(router.should_process_lookup_result(later_ip));
+        assert!(router.pin_active_game_server(first_ip));
+
+        assert!(router.should_process_lookup_result(first_ip));
+        assert!(!router.should_process_lookup_result(later_ip));
+        assert!(router.is_active_game_server(first_ip));
+        assert!(!router.pin_active_game_server(later_ip));
+    }
+
+    #[test]
+    fn test_active_game_server_allows_retry_until_lookup_succeeds() {
+        let router = AutoRouter::new(true, "singapore");
+        let failed_ip = Ipv4Addr::new(128, 116, 50, 1);
+        let retry_ip = Ipv4Addr::new(128, 116, 55, 1);
+
+        assert!(router.should_process_lookup_result(failed_ip));
+        assert!(router.should_process_lookup_result(retry_ip));
+
+        assert!(router.pin_active_game_server(retry_ip));
+        assert!(!router.should_process_lookup_result(failed_ip));
+    }
+
+    #[test]
     fn test_pending_lookup_marked_and_cleared() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let router = AutoRouter::new(true, "singapore");
@@ -875,9 +945,11 @@ mod tests {
 
         router.get_best_server_for_region(&RobloxRegion::UsEast);
         assert!(router.is_bypassed());
+        assert!(router.pin_active_game_server(Ipv4Addr::new(128, 116, 50, 1)));
 
         router.reset();
         assert!(!router.is_bypassed());
+        assert!(router.should_process_lookup_result(Ipv4Addr::new(128, 116, 55, 1)));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -1527,15 +1527,25 @@ impl VpnConnection {
         // Spawn background task for async ipinfo.io region lookups
         if auto_routing_enabled {
             let (lookup_tx, mut lookup_rx) =
-                tokio::sync::mpsc::unbounded_channel::<(std::net::Ipv4Addr, u64)>();
+                tokio::sync::mpsc::unbounded_channel::<(std::net::Ipv4Addr, u64, u64)>();
             auto_router.set_lookup_channel(lookup_tx);
 
             let router_for_lookup = Arc::clone(&auto_router);
             let state_for_lookup = Arc::clone(&self.state);
             let lookup_handle = tokio::spawn(async move {
-                while let Some((ip, generation)) = lookup_rx.recv().await {
+                while let Some((ip, generation, session_epoch)) = lookup_rx.recv().await {
                     match crate::geolocation::lookup_game_server_region(ip).await {
                         Some((region, location)) => {
+                            if !router_for_lookup.is_current_lookup_session(session_epoch) {
+                                log::info!(
+                                    "Auto-routing: Ignoring stale lookup for {} (generation {}, session {}) after router reset",
+                                    ip,
+                                    generation,
+                                    session_epoch
+                                );
+                                router_for_lookup.clear_pending_lookup(ip);
+                                continue;
+                            }
                             if !router_for_lookup.should_process_lookup_result(ip) {
                                 log::info!(
                                     "Auto-routing: Ignoring lookup for {} (generation {}) because another game server is active",
@@ -1662,9 +1672,11 @@ impl VpnConnection {
                                     )
                                     .await;
 
-                                    if !router_for_lookup.is_active_game_server(ip) {
+                                    if !router_for_lookup.is_current_lookup_session(session_epoch)
+                                        || !router_for_lookup.is_active_game_server(ip)
+                                    {
                                         log::info!(
-                                            "Auto-routing: Ignoring probe refinement for {} (generation {}) because it is no longer active",
+                                            "Auto-routing: Ignoring probe refinement for {} (generation {}) because it is stale or no longer active",
                                             ip,
                                             generation
                                         );

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -1555,7 +1555,9 @@ impl VpnConnection {
                                 router_for_lookup.clear_pending_lookup(ip);
                                 continue;
                             }
-                            if !router_for_lookup.pin_active_game_server(ip) {
+                            if !router_for_lookup
+                                .pin_active_game_server_for_session(ip, session_epoch)
+                            {
                                 log::info!(
                                     "Auto-routing: Ignoring lookup for {} (generation {}) after active game server changed",
                                     ip,

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -1536,9 +1536,18 @@ impl VpnConnection {
                 while let Some((ip, generation)) = lookup_rx.recv().await {
                     match crate::geolocation::lookup_game_server_region(ip).await {
                         Some((region, location)) => {
-                            if !router_for_lookup.is_current_lookup_generation(generation) {
+                            if !router_for_lookup.should_process_lookup_result(ip) {
                                 log::info!(
-                                    "Auto-routing: Ignoring stale lookup for {} (generation {})",
+                                    "Auto-routing: Ignoring lookup for {} (generation {}) because another game server is active",
+                                    ip,
+                                    generation
+                                );
+                                router_for_lookup.clear_pending_lookup(ip);
+                                continue;
+                            }
+                            if !router_for_lookup.pin_active_game_server(ip) {
+                                log::info!(
+                                    "Auto-routing: Ignoring lookup for {} (generation {}) after active game server changed",
                                     ip,
                                     generation
                                 );
@@ -1653,9 +1662,9 @@ impl VpnConnection {
                                     )
                                     .await;
 
-                                    if !router_for_lookup.is_current_lookup_generation(generation) {
+                                    if !router_for_lookup.is_active_game_server(ip) {
                                         log::info!(
-                                            "Auto-routing: Ignoring stale probe refinement for {} (generation {})",
+                                            "Auto-routing: Ignoring probe refinement for {} (generation {}) because it is no longer active",
                                             ip,
                                             generation
                                         );
@@ -1726,7 +1735,7 @@ impl VpnConnection {
                         }
                         None => {
                             log::warn!(
-                                "Auto-routing: ipinfo.io lookup failed for {}, releasing packets on current relay",
+                                "Auto-routing: SwiftTunnel resolver lookup failed for {}, releasing packets on current relay",
                                 ip
                             );
                             // Release packets even on failure — better to route through

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -4638,6 +4638,14 @@ fn forward_tunneled_packet_from_reader(
     if ip_packet.len() >= 20 {
         let dst_ip = Ipv4Addr::new(ip_packet[16], ip_packet[17], ip_packet[18], ip_packet[19]);
         if is_roblox_game_server_ip(dst_ip) {
+            if let Some(auto_router) = auto_router {
+                if auto_router.is_lookup_pending(dst_ip) {
+                    return ReaderTunnelAction::Consumed;
+                }
+            }
+        }
+
+        if auto_routing_candidate_dst_ip(data) == Some(dst_ip) {
             if let Some(mut servers) = detected_game_servers.try_write() {
                 if servers.len() < MAX_DETECTED_GAME_SERVERS || servers.contains(&dst_ip) {
                     if servers.insert(dst_ip) {
@@ -6452,6 +6460,8 @@ enum AutoRoutingPacketAction {
     Hold,
 }
 
+const ROBLOX_GAME_SERVER_PORT_START: u16 = 49152;
+
 #[inline(always)]
 fn is_ipv4_fragment(data: &[u8]) -> bool {
     let ip_start = match parse_ipv4_header_offset(data) {
@@ -6475,6 +6485,46 @@ fn queue_overflow_action(mode: QueueOverflowMode, data: &[u8]) -> QueueFullActio
             }
         }
     }
+}
+
+#[inline(always)]
+fn auto_routing_candidate_dst_ip(data: &[u8]) -> Option<Ipv4Addr> {
+    let ip_start = parse_ipv4_header_offset(data)?;
+    let ihl = ((data[ip_start] & 0x0F) as usize) * 4;
+    if ihl < 20 {
+        return None;
+    }
+
+    let dst_ip = Ipv4Addr::new(
+        data[ip_start + 16],
+        data[ip_start + 17],
+        data[ip_start + 18],
+        data[ip_start + 19],
+    );
+    if !is_roblox_game_server_ip(dst_ip) {
+        return None;
+    }
+
+    let fragment_bits = u16::from_be_bytes([data[ip_start + 6], data[ip_start + 7]]);
+    if (fragment_bits & 0x1FFF) != 0 {
+        return None;
+    }
+
+    if data[ip_start + 9] != 17 {
+        return None;
+    }
+
+    let transport_start = ip_start + ihl;
+    if data.len() < transport_start + 4 {
+        return None;
+    }
+
+    let dst_port = u16::from_be_bytes([data[transport_start + 2], data[transport_start + 3]]);
+    if dst_port < ROBLOX_GAME_SERVER_PORT_START {
+        return None;
+    }
+
+    Some(dst_ip)
 }
 
 /// Apply the auto-routing hold gate for packets that could otherwise escape.
@@ -6503,7 +6553,7 @@ fn auto_routing_packet_action(
         return AutoRoutingPacketAction::Hold;
     }
 
-    if evaluate_new_server {
+    if evaluate_new_server && auto_routing_candidate_dst_ip(data) == Some(dst_ip) {
         auto_router.evaluate_game_server(dst_ip);
         if auto_router.is_lookup_pending(dst_ip) {
             return AutoRoutingPacketAction::Hold;
@@ -9725,6 +9775,40 @@ mod tests {
     }
 
     #[test]
+    fn test_auto_routing_packet_action_ignores_roblox_tcp_api_packet() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+
+        let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let frame = build_ipv4_frame(6, Ipv4Addr::new(192, 168, 1, 210), dst_ip, 53020, 443);
+
+        assert_eq!(
+            auto_routing_packet_action(&frame, Some(&router), true),
+            AutoRoutingPacketAction::Pass
+        );
+        assert!(rx.try_recv().is_err());
+        assert!(!router.is_lookup_pending(dst_ip));
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_ignores_low_port_udp_to_roblox_range() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+
+        let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let frame = build_ipv4_frame(17, Ipv4Addr::new(192, 168, 1, 210), dst_ip, 53020, 3478);
+
+        assert_eq!(
+            auto_routing_packet_action(&frame, Some(&router), true),
+            AutoRoutingPacketAction::Pass
+        );
+        assert!(rx.try_recv().is_err());
+        assert!(!router.is_lookup_pending(dst_ip));
+    }
+
+    #[test]
     fn test_auto_routing_packet_action_holds_pending_tail_fragment_without_evaluating() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
@@ -9769,6 +9853,23 @@ mod tests {
 
         let dst_ip = Ipv4Addr::new(128, 117, 50, 100);
         let frame = build_ipv4_frame(17, Ipv4Addr::new(192, 168, 1, 213), dst_ip, 53023, 54023);
+
+        assert_eq!(
+            auto_routing_packet_action(&frame, Some(&router), true),
+            AutoRoutingPacketAction::Pass
+        );
+        assert!(rx.try_recv().is_err());
+        assert!(!router.is_lookup_pending(dst_ip));
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_ignores_roblox_infrastructure_destination() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+
+        let dst_ip = Ipv4Addr::new(23, 173, 192, 10);
+        let frame = build_ipv4_frame(17, Ipv4Addr::new(192, 168, 1, 214), dst_ip, 53024, 55000);
 
         assert_eq!(
             auto_routing_packet_action(&frame, Some(&router), true),

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -9769,7 +9769,8 @@ mod tests {
             AutoRoutingPacketAction::Hold
         );
         assert!(router.is_lookup_pending(dst_ip));
-        let (queued_ip, generation) = rx.try_recv().expect("lookup should be queued");
+        let (queued_ip, generation, _session_epoch) =
+            rx.try_recv().expect("lookup should be queued");
         assert_eq!(queued_ip, dst_ip);
         assert_eq!(generation, 1);
     }


### PR DESCRIPTION
## What changed

- Scoped auto-routing candidates to regional Roblox game-server CIDRs and removed API/matchmaking/infrastructure CIDRs from the game-server predicate.
- Started auto-routing lookups only for first-fragment UDP traffic on the Roblox high game-server port range.
- Pinned the first successful structured resolver lookup for the VPN session so later Roblox-owned endpoints cannot swap the relay mid-game.
- Kept resolver-only routing: failures or missing structured IDs release held packets and keep the current relay instead of falling back locally.

## Root cause

The app was using IPinfo-backed resolver results correctly, but it was asking the resolver about too broad a set of Roblox-owned destinations. API/infrastructure IPs resolve to valid locations too, often San Mateo/US West, so a later in-game endpoint could become the latest lookup and move the relay away from the actual game server.

## Validation

- cargo fmt --check
- git diff --check
- Live resolver spot checks confirmed Roblox API/infrastructure samples such as 23.173.192.10 and 204.9.184.10 return valid IPinfo US West results, proving they must not be auto-routing triggers.
- cargo test -p swifttunnel-core geolocation --lib, cargo test -p swifttunnel-core auto_routing --lib, and cargo test -p swifttunnel-core test_auto_routing_packet_action --lib are blocked in this macOS checkout before project code compiles by the existing windows-future/windows_core mismatch: missing windows_core::imp::IMarshal/marshaler and windows_threading::submit.