### PR TITLE
[codex] Fix saved network boost activation

### DIFF
--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -116,10 +116,13 @@ impl NetworkBooster {
     ) -> NetworkApplyOutcome {
         info!("Reconciling network optimizations");
 
-        let mut applied_config = config.clone();
+        let mut requested_config = config.clone();
+        requested_config.normalize_legacy_master_boost();
+
+        let mut applied_config = requested_config.clone();
         let mut warnings = Vec::new();
 
-        if config.prioritize_roblox_traffic {
+        if requested_config.prioritize_roblox_traffic {
             if let Err(e) = self.prioritize_game_traffic() {
                 applied_config.prioritize_roblox_traffic = false;
                 warnings.push(format!("Prioritize Roblox traffic: {}", e));
@@ -129,7 +132,7 @@ impl NetworkBooster {
         }
 
         // Tier 1 (Safe) Network Boosts
-        if config.disable_nagle {
+        if requested_config.disable_nagle {
             if let Err(e) = self.disable_nagle_algorithm() {
                 applied_config.disable_nagle = false;
                 warnings.push(format!("Disable Nagle's algorithm: {}", e));
@@ -138,7 +141,7 @@ impl NetworkBooster {
             warnings.push(format!("Restore Nagle's algorithm defaults: {}", e));
         }
 
-        if config.disable_network_throttling {
+        if requested_config.disable_network_throttling {
             if let Err(e) = self.disable_network_throttling() {
                 applied_config.disable_network_throttling = false;
                 warnings.push(format!("Disable network throttling: {}", e));
@@ -147,7 +150,7 @@ impl NetworkBooster {
             warnings.push(format!("Restore network throttling defaults: {}", e));
         }
 
-        if config.gaming_qos {
+        if requested_config.gaming_qos {
             if let Err(e) = self.enable_gaming_qos() {
                 applied_config.gaming_qos = false;
                 warnings.push(format!("Enable gaming QoS: {}", e));
@@ -156,7 +159,7 @@ impl NetworkBooster {
             warnings.push(format!("Disable gaming QoS: {}", e));
         }
 
-        if config.firewall_fix {
+        if requested_config.firewall_fix {
             if let Err(e) = self.firewall_fixer.apply() {
                 applied_config.firewall_fix = false;
                 warnings.push(format!("Apply Roblox firewall fix: {}", e));
@@ -166,8 +169,10 @@ impl NetworkBooster {
         }
 
         self.persist_snapshot();
+        applied_config.normalize_legacy_master_boost();
 
-        let effective_config = self.effective_network_config(&applied_config);
+        let mut effective_config = self.effective_network_config(&applied_config);
+        effective_config.normalize_legacy_master_boost();
         if applied_config.disable_nagle && !effective_config.disable_nagle {
             warnings.push("Disable Nagle's algorithm did not verify after apply".to_string());
         }
@@ -306,8 +311,10 @@ impl NetworkBooster {
 
     pub fn effective_network_config(&self, desired: &NetworkConfig) -> NetworkConfig {
         let mut effective = desired.clone();
+        effective.normalize_legacy_master_boost();
+        let requested = effective.clone();
 
-        if desired.disable_nagle {
+        if requested.disable_nagle {
             let adapter_guids = self.list_adapter_guids();
             effective.disable_nagle = !adapter_guids.is_empty()
                 && adapter_guids.iter().all(|guid| {
@@ -320,7 +327,7 @@ impl NetworkBooster {
                 });
         }
 
-        if desired.disable_network_throttling {
+        if requested.disable_network_throttling {
             effective.disable_network_throttling = Self::query_registry_dword(
                 NETWORK_SYSTEM_PROFILE_KEY,
                 REG_VALUE_NETWORK_THROTTLING_INDEX,
@@ -331,7 +338,7 @@ impl NetworkBooster {
                 ) == Some(0);
         }
 
-        if desired.gaming_qos {
+        if requested.gaming_qos {
             let dscp_enabled = Self::query_registry_dword(
                 r"HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\QoS",
                 "Do not use NLA",
@@ -348,11 +355,12 @@ impl NetworkBooster {
                 dscp_enabled && roblox_policies_present && relay_policies_present;
         }
 
-        if desired.prioritize_roblox_traffic {
+        if requested.prioritize_roblox_traffic {
             effective.prioritize_roblox_traffic =
                 Self::qos_policy_exists(LEGACY_ROBLOX_PRIORITY_POLICY);
         }
 
+        effective.normalize_legacy_master_boost();
         effective
     }
 

--- a/swifttunnel-core/src/settings.rs
+++ b/swifttunnel-core/src/settings.rs
@@ -288,6 +288,7 @@ impl AppSettings {
                 normalize_guid_ascii_lowercase(&guid).map(|normalized| (signature, normalized))
             })
             .collect();
+        self.config.network_settings.normalize_legacy_master_boost();
         self.selected_game_presets = default_game_presets();
         // Older releases serialized false as the default even though the app has
         // no user-facing toggle. Keep app-close safe for shared/cafe PCs.
@@ -500,6 +501,51 @@ mod tests {
         let json = r#"{"theme": "dark", "config": {}, "optimizations_active": false}"#;
         let loaded: AppSettings = serde_json::from_str(json).unwrap();
         assert!(!loaded.auto_routing_enabled);
+    }
+
+    #[test]
+    fn test_settings_sanitize_migrates_legacy_network_boost_master() {
+        let mut settings: AppSettings = serde_json::from_str(
+            r#"{
+              "theme": "dark",
+              "config": {
+                "network_settings": {
+                  "enable_network_boost": true
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        settings.sanitize_in_place();
+
+        assert!(settings.config.network_settings.enable_network_boost);
+        assert!(settings.config.network_settings.disable_nagle);
+        assert!(settings.config.network_settings.disable_network_throttling);
+        assert!(settings.config.network_settings.gaming_qos);
+        assert!(!settings.config.network_settings.firewall_fix);
+    }
+
+    #[test]
+    fn test_settings_sanitize_preserves_all_off_network_boosts() {
+        let mut settings: AppSettings = serde_json::from_str(
+            r#"{
+              "theme": "dark",
+              "config": {
+                "network_settings": {
+                  "enable_network_boost": false
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        settings.sanitize_in_place();
+
+        assert!(!settings.config.network_settings.enable_network_boost);
+        assert!(!settings.config.network_settings.disable_nagle);
+        assert!(!settings.config.network_settings.disable_network_throttling);
+        assert!(!settings.config.network_settings.gaming_qos);
     }
 
     #[test]

--- a/swifttunnel-core/src/structs.rs
+++ b/swifttunnel-core/src/structs.rs
@@ -183,7 +183,7 @@ impl GraphicsQuality {
 }
 
 /// Network optimization settings
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct NetworkConfig {
     pub enable_network_boost: bool,
     pub prioritize_roblox_traffic: bool,
@@ -211,6 +211,66 @@ impl Default for NetworkConfig {
             gaming_qos: false,
             firewall_fix: false, // Off by default, one-click fix for Roblox launch crashes
         }
+    }
+}
+
+impl NetworkConfig {
+    fn any_specific_boost_enabled(&self) -> bool {
+        self.prioritize_roblox_traffic
+            || self.disable_nagle
+            || self.disable_network_throttling
+            || self.gaming_qos
+            || self.firewall_fix
+    }
+
+    pub fn has_enabled_boosts(&self) -> bool {
+        self.any_specific_boost_enabled()
+    }
+
+    pub fn normalize_legacy_master_boost(&mut self) {
+        self.enable_network_boost = self.any_specific_boost_enabled();
+    }
+}
+
+impl<'de> Deserialize<'de> for NetworkConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Default, Deserialize)]
+        struct NetworkConfigWire {
+            enable_network_boost: Option<bool>,
+            prioritize_roblox_traffic: Option<bool>,
+            disable_nagle: Option<bool>,
+            disable_network_throttling: Option<bool>,
+            gaming_qos: Option<bool>,
+            firewall_fix: Option<bool>,
+        }
+
+        let wire = NetworkConfigWire::deserialize(deserializer)?;
+        let has_any_specific_field = wire.prioritize_roblox_traffic.is_some()
+            || wire.disable_nagle.is_some()
+            || wire.disable_network_throttling.is_some()
+            || wire.gaming_qos.is_some()
+            || wire.firewall_fix.is_some();
+
+        let mut config = NetworkConfig {
+            enable_network_boost: wire.enable_network_boost.unwrap_or(false),
+            prioritize_roblox_traffic: wire.prioritize_roblox_traffic.unwrap_or(false),
+            disable_nagle: wire.disable_nagle.unwrap_or(false),
+            disable_network_throttling: wire.disable_network_throttling.unwrap_or(false),
+            gaming_qos: wire.gaming_qos.unwrap_or(false),
+            firewall_fix: wire.firewall_fix.unwrap_or(false),
+        };
+
+        if config.enable_network_boost && !has_any_specific_field {
+            config.disable_nagle = true;
+            config.disable_network_throttling = true;
+            config.gaming_qos = true;
+        }
+
+        config.normalize_legacy_master_boost();
+        Ok(config)
     }
 }
 
@@ -499,6 +559,51 @@ mod tests {
         assert!(!cfg.disable_network_throttling);
         assert!(!cfg.gaming_qos);
         assert!(!cfg.firewall_fix);
+    }
+
+    #[test]
+    fn test_network_config_deserializes_legacy_master_boost_to_real_toggles() {
+        let cfg: NetworkConfig = serde_json::from_str(r#"{"enable_network_boost": true}"#).unwrap();
+
+        assert!(cfg.enable_network_boost);
+        assert!(cfg.disable_nagle);
+        assert!(cfg.disable_network_throttling);
+        assert!(cfg.gaming_qos);
+        assert!(!cfg.prioritize_roblox_traffic);
+        assert!(!cfg.firewall_fix);
+    }
+
+    #[test]
+    fn test_network_config_does_not_invent_boosts_when_master_is_explicitly_stale() {
+        let cfg: NetworkConfig = serde_json::from_str(
+            r#"{
+              "enable_network_boost": true,
+              "prioritize_roblox_traffic": false,
+              "disable_nagle": false,
+              "disable_network_throttling": false,
+              "gaming_qos": false,
+              "firewall_fix": false
+            }"#,
+        )
+        .unwrap();
+
+        assert!(!cfg.enable_network_boost);
+        assert!(!cfg.has_enabled_boosts());
+    }
+
+    #[test]
+    fn test_network_config_master_tracks_specific_boosts() {
+        let mut cfg = NetworkConfig {
+            disable_network_throttling: true,
+            ..Default::default()
+        };
+
+        cfg.normalize_legacy_master_boost();
+
+        assert!(cfg.enable_network_boost);
+        assert!(!cfg.disable_nagle);
+        assert!(cfg.disable_network_throttling);
+        assert!(!cfg.gaming_qos);
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -157,8 +157,9 @@ pub async fn boost_update_config(
     state: State<'_, AppState>,
     config_json: String,
 ) -> Result<BoostUpdateResult, String> {
-    let config: swifttunnel_core::structs::Config =
+    let mut config: swifttunnel_core::structs::Config =
         serde_json::from_str(&config_json).map_err(|e| format!("Invalid config: {}", e))?;
+    config.network_settings.normalize_legacy_master_boost();
 
     let settings = state.settings.clone();
     let performance_monitor = state.performance_monitor.clone();
@@ -242,10 +243,13 @@ pub async fn boost_sync_effective_config(
     let network_booster = state.network_booster.clone();
 
     tauri::async_runtime::spawn_blocking(move || {
-        let current_config = {
+        let mut current_config = {
             let s = settings.lock();
             s.config.clone()
         };
+        current_config
+            .network_settings
+            .normalize_legacy_master_boost();
 
         let effective_network_config = {
             let nb = network_booster.lock();

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -204,6 +204,59 @@ fn disconnect_vpn_on_exit(app: &tauri::AppHandle) {
     }
 }
 
+#[cfg(windows)]
+fn reapply_saved_network_boosts(state: &AppState) {
+    let (requested_config, normalized_config_changed) = {
+        let mut settings = state.settings.lock();
+        let original = settings.config.network_settings.clone();
+        settings
+            .config
+            .network_settings
+            .normalize_legacy_master_boost();
+        (
+            settings.config.network_settings.clone(),
+            settings.config.network_settings != original,
+        )
+    };
+
+    if !requested_config.has_enabled_boosts() {
+        if normalized_config_changed {
+            let snapshot = state.settings.lock().clone();
+            if let Err(e) = swifttunnel_core::settings::save_settings(&snapshot) {
+                warn!("Failed to persist normalized network boost state: {}", e);
+            }
+        }
+        return;
+    }
+
+    info!("Reapplying saved network boost settings on startup");
+    let outcome = state
+        .network_booster
+        .lock()
+        .reconcile_optimizations_checked(&requested_config);
+
+    if !outcome.warnings.is_empty() {
+        warn!(
+            "Saved network boosts reapplied with warnings: {}",
+            outcome.warnings.join("; ")
+        );
+    }
+
+    if outcome.applied_config != requested_config || normalized_config_changed {
+        let snapshot = {
+            let mut settings = state.settings.lock();
+            settings.config.network_settings = outcome.applied_config;
+            settings.clone()
+        };
+        if let Err(e) = swifttunnel_core::settings::save_settings(&snapshot) {
+            warn!("Failed to persist reapplied network boost state: {}", e);
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn reapply_saved_network_boosts(_state: &AppState) {}
+
 pub fn run() {
     logging::init();
     let launched_from_startup = autostart::launched_from_startup_flag();
@@ -295,6 +348,7 @@ pub fn run() {
 
             // Recover network booster state from persisted snapshot (crash recovery)
             app_state.network_booster.lock().recover_from_snapshot();
+            reapply_saved_network_boosts(&app_state);
 
             let run_on_startup_enabled = app_state.settings.lock().run_on_startup;
             let vpn_state_rx = app_state.vpn_state_handle.clone();

--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -4,6 +4,7 @@ import { useSettingsStore } from "../../stores/settingsStore";
 import { useBoostStore } from "../../stores/boostStore";
 import { useToastStore } from "../../stores/toastStore";
 import { systemRestartAsAdmin } from "../../lib/commands";
+import { normalizeNetworkBoostConfig } from "../../lib/settings";
 import { notify } from "../../lib/notifications";
 import {
   Toggle,
@@ -56,7 +57,9 @@ export function BoostTab() {
   const [restartAdminState, setRestartAdminState] = useState<
     "idle" | "restarting" | "error"
   >("idle");
-  const [restartAdminError, setRestartAdminError] = useState<string | null>(null);
+  const [restartAdminError, setRestartAdminError] = useState<string | null>(
+    null,
+  );
   const [networkApplying, setNetworkApplying] = useState(false);
 
   const savedConfig = settings.config;
@@ -67,7 +70,8 @@ export function BoostTab() {
   }, [savedConfig]);
 
   const savedGPP = settings.game_process_performance;
-  const [draftGPP, setDraftGPP] = useState<GameProcessPerformanceSettings>(savedGPP);
+  const [draftGPP, setDraftGPP] =
+    useState<GameProcessPerformanceSettings>(savedGPP);
 
   useEffect(() => {
     setDraftGPP(savedGPP);
@@ -77,7 +81,12 @@ export function BoostTab() {
     let canceled = false;
     void boost.syncEffectiveConfig().then((appliedConfig) => {
       if (canceled || !appliedConfig) return;
-      if (!configsEqual(appliedConfig, useSettingsStore.getState().settings.config)) {
+      if (
+        !configsEqual(
+          appliedConfig,
+          useSettingsStore.getState().settings.config,
+        )
+      ) {
         updateSettings({ config: appliedConfig });
         void useSettingsStore.getState().save();
       }
@@ -215,11 +224,16 @@ export function BoostTab() {
       const nextDraft = {
         ...draft,
         profile: "Custom" as const,
-        network_settings: { ...draft.network_settings, ...p },
+        network_settings: normalizeNetworkBoostConfig({
+          ...draft.network_settings,
+          ...p,
+        }),
       };
       setNetworkApplying(true);
       try {
-        const appliedConfig = await boost.updateConfig(JSON.stringify(nextDraft));
+        const appliedConfig = await boost.updateConfig(
+          JSON.stringify(nextDraft),
+        );
         updateSettings({
           config: appliedConfig,
           game_process_performance: draftGPP,
@@ -229,7 +243,10 @@ export function BoostTab() {
 
         const currentWarning = useBoostStore.getState().warning;
         if (currentWarning) {
-          addToast({ type: "warning", message: "Network boost could not fully apply" });
+          addToast({
+            type: "warning",
+            message: "Network boost could not fully apply",
+          });
         } else {
           addToast({ type: "success", message: "Network boost updated" });
         }
@@ -276,9 +293,7 @@ export function BoostTab() {
 
   return (
     <div className="flex w-full flex-col gap-5 pb-24">
-      {boost.error && (
-        <ErrorBanner tone="error">{boost.error}</ErrorBanner>
-      )}
+      {boost.error && <ErrorBanner tone="error">{boost.error}</ErrorBanner>}
 
       {boost.warning && (
         <ErrorBanner tone="warning">{boost.warning}</ErrorBanner>
@@ -343,10 +358,7 @@ export function BoostTab() {
       </section>
 
       {/* ── Roblox ── */}
-      <Section
-        title="Roblox"
-        tag={`${rblxCount} / 3 on`}
-      >
+      <Section title="Roblox" tag={`${rblxCount} / 3 on`}>
         <SettingRow
           title="Unlock FPS"
           desc="Remove 60 FPS cap"
@@ -370,12 +382,18 @@ export function BoostTab() {
           height={draft.roblox_settings.window_height}
           onWidthChange={(w) =>
             updateRblxOpt({
-              window_width: parseWindowDimensionInput(String(w), MIN_WINDOW_WIDTH),
+              window_width: parseWindowDimensionInput(
+                String(w),
+                MIN_WINDOW_WIDTH,
+              ),
             })
           }
           onHeightChange={(h) =>
             updateRblxOpt({
-              window_height: parseWindowDimensionInput(String(h), MIN_WINDOW_HEIGHT),
+              window_height: parseWindowDimensionInput(
+                String(h),
+                MIN_WINDOW_HEIGHT,
+              ),
             })
           }
           error={windowValidationError}
@@ -433,7 +451,9 @@ export function BoostTab() {
             desc="Full bandwidth while gaming"
             tooltip="Windows throttles network I/O when multimedia is playing. Disabling prevents sudden bandwidth drops."
             enabled={draft.network_settings.disable_network_throttling}
-            onChange={(v) => void applyNetworkOpt({ disable_network_throttling: v })}
+            onChange={(v) =>
+              void applyNetworkOpt({ disable_network_throttling: v })
+            }
             disabled={networkApplying}
           />
           <SettingRow
@@ -755,7 +775,9 @@ function ResolutionRow({
             step={2}
             value={width}
             onChange={(e) =>
-              onWidthChange(parseWindowDimensionInput(e.target.value, MIN_WINDOW_WIDTH))
+              onWidthChange(
+                parseWindowDimensionInput(e.target.value, MIN_WINDOW_WIDTH),
+              )
             }
             className="boost-input rounded-[4px] px-3 py-1.5 font-mono text-[13px] outline-none transition-colors"
             style={{
@@ -777,7 +799,9 @@ function ResolutionRow({
             step={2}
             value={height}
             onChange={(e) =>
-              onHeightChange(parseWindowDimensionInput(e.target.value, MIN_WINDOW_HEIGHT))
+              onHeightChange(
+                parseWindowDimensionInput(e.target.value, MIN_WINDOW_HEIGHT),
+              )
             }
             className="boost-input rounded-[4px] px-3 py-1.5 font-mono text-[13px] outline-none transition-colors"
             style={{
@@ -940,84 +964,90 @@ function RamCleanerCard({
           )}
         </div>
 
-      {showBottom && (
-        <div
-          className="space-y-2 border-t px-4 py-3"
-          style={{ borderColor: "var(--color-border-subtle)" }}
-        >
-          {isCleaning && (
-            <div className="flex items-center gap-2 text-[11.5px] text-text-muted">
-              <Spinner size={10} color="var(--color-accent-primary)" />
-              <span>
-                {stage === "flushing_modified"
-                  ? "Flushing modified pages…"
-                  : stage === "standby_purge"
-                    ? "Purging standby list…"
-                    : stage
-                      ? stage
-                      : "Cleaning…"}
-                {trimmedCount > 0 ? ` · Trimmed: ${trimmedCount}` : ""}
-                {currentProcess ? ` · ${currentProcess}` : ""}
-              </span>
-            </div>
-          )}
-          {!isAdmin && (
-            <div className="text-[11.5px] text-text-muted">
-              Deep clean requires Administrator.{" "}
-              <button
-                type="button"
-                onClick={onRestartAsAdmin}
-                disabled={restartState === "restarting"}
-                className="font-semibold text-accent-secondary hover:underline disabled:opacity-60"
-              >
-                {restartState === "restarting"
-                  ? "Restarting…"
-                  : "Restart as Admin"}
-              </button>
-              {restartState === "error" && restartError && (
-                <div className="mt-1 text-[11px] text-status-error">
-                  {restartError}
-                </div>
-              )}
-            </div>
-          )}
-          {result && (
-            <div
-              className="rounded-[5px] px-3 py-2 text-[11px] text-text-muted"
-              style={{ backgroundColor: "var(--color-bg-elevated)" }}
-            >
-              <div className="flex flex-wrap gap-x-5 gap-y-1">
-                <ResultPill label="Freed" value={formatDeltaMb(result.freed_mb)} />
-                {result.standby_freed_mb != null && (
-                  <ResultPill
-                    label="Standby"
-                    value={formatDeltaMb(result.standby_freed_mb)}
-                  />
-                )}
-                {result.modified_freed_mb != null && (
-                  <ResultPill
-                    label="Modified"
-                    value={formatDeltaMb(result.modified_freed_mb)}
-                  />
-                )}
-                <ResultPill label="Trimmed" value={String(result.trimmed_count)} />
-                <ResultPill
-                  label="Deep clean"
-                  value={deepCleanLabel(result.standby_purge)}
-                />
+        {showBottom && (
+          <div
+            className="space-y-2 border-t px-4 py-3"
+            style={{ borderColor: "var(--color-border-subtle)" }}
+          >
+            {isCleaning && (
+              <div className="flex items-center gap-2 text-[11.5px] text-text-muted">
+                <Spinner size={10} color="var(--color-accent-primary)" />
+                <span>
+                  {stage === "flushing_modified"
+                    ? "Flushing modified pages…"
+                    : stage === "standby_purge"
+                      ? "Purging standby list…"
+                      : stage
+                        ? stage
+                        : "Cleaning…"}
+                  {trimmedCount > 0 ? ` · Trimmed: ${trimmedCount}` : ""}
+                  {currentProcess ? ` · ${currentProcess}` : ""}
+                </span>
               </div>
-              {result.warnings.length > 0 && (
-                <div className="mt-1.5 text-[10.5px] text-status-warning">
-                  <Chip tone="warning" size="xs">
-                    {result.warnings.length} warning
-                    {result.warnings.length !== 1 ? "s" : ""}
-                  </Chip>
+            )}
+            {!isAdmin && (
+              <div className="text-[11.5px] text-text-muted">
+                Deep clean requires Administrator.{" "}
+                <button
+                  type="button"
+                  onClick={onRestartAsAdmin}
+                  disabled={restartState === "restarting"}
+                  className="font-semibold text-accent-secondary hover:underline disabled:opacity-60"
+                >
+                  {restartState === "restarting"
+                    ? "Restarting…"
+                    : "Restart as Admin"}
+                </button>
+                {restartState === "error" && restartError && (
+                  <div className="mt-1 text-[11px] text-status-error">
+                    {restartError}
+                  </div>
+                )}
+              </div>
+            )}
+            {result && (
+              <div
+                className="rounded-[5px] px-3 py-2 text-[11px] text-text-muted"
+                style={{ backgroundColor: "var(--color-bg-elevated)" }}
+              >
+                <div className="flex flex-wrap gap-x-5 gap-y-1">
+                  <ResultPill
+                    label="Freed"
+                    value={formatDeltaMb(result.freed_mb)}
+                  />
+                  {result.standby_freed_mb != null && (
+                    <ResultPill
+                      label="Standby"
+                      value={formatDeltaMb(result.standby_freed_mb)}
+                    />
+                  )}
+                  {result.modified_freed_mb != null && (
+                    <ResultPill
+                      label="Modified"
+                      value={formatDeltaMb(result.modified_freed_mb)}
+                    />
+                  )}
+                  <ResultPill
+                    label="Trimmed"
+                    value={String(result.trimmed_count)}
+                  />
+                  <ResultPill
+                    label="Deep clean"
+                    value={deepCleanLabel(result.standby_purge)}
+                  />
                 </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+                {result.warnings.length > 0 && (
+                  <div className="mt-1.5 text-[10.5px] text-status-warning">
+                    <Chip tone="warning" size="xs">
+                      {result.warnings.length} warning
+                      {result.warnings.length !== 1 ? "s" : ""}
+                    </Chip>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/swifttunnel-desktop/src/components/boost/boostConfig.test.ts
+++ b/swifttunnel-desktop/src/components/boost/boostConfig.test.ts
@@ -13,6 +13,9 @@ describe("boost config helpers", () => {
     expect(result.profile).toBe("LowEnd");
     expect(result.system_optimization.power_plan).toBe("Ultimate");
     expect(result.roblox_settings.graphics_quality).toBe("Level1");
+    expect(result.network_settings.enable_network_boost).toBe(true);
+    expect(result.network_settings.disable_nagle).toBe(true);
+    expect(result.network_settings.disable_network_throttling).toBe(true);
     expect(result.network_settings.gaming_qos).toBe(true);
     expect(result.auto_start_with_roblox).toBe(false);
   });

--- a/swifttunnel-desktop/src/components/boost/boostConfig.ts
+++ b/swifttunnel-desktop/src/components/boost/boostConfig.ts
@@ -3,6 +3,7 @@ import type {
   OptimizationProfile,
   StandbyPurgeResult,
 } from "../../lib/types";
+import { normalizeNetworkBoostConfig } from "../../lib/settings";
 
 export const PROFILES: {
   id: OptimizationProfile;
@@ -60,12 +61,12 @@ export function getPresetConfig(
           target_fps: 360,
           ultraboost: true,
         },
-        network_settings: {
+        network_settings: normalizeNetworkBoostConfig({
           ...current.network_settings,
           disable_nagle: true,
           disable_network_throttling: true,
           gaming_qos: true,
-        },
+        }),
       };
     case "Balanced":
       return {
@@ -88,12 +89,12 @@ export function getPresetConfig(
           target_fps: 144,
           ultraboost: false,
         },
-        network_settings: {
+        network_settings: normalizeNetworkBoostConfig({
           ...current.network_settings,
           disable_nagle: true,
           disable_network_throttling: true,
           gaming_qos: true,
-        },
+        }),
       };
     case "HighEnd":
       return {
@@ -116,12 +117,12 @@ export function getPresetConfig(
           target_fps: 60,
           ultraboost: false,
         },
-        network_settings: {
+        network_settings: normalizeNetworkBoostConfig({
           ...current.network_settings,
           disable_nagle: true,
           disable_network_throttling: true,
           gaming_qos: true,
-        },
+        }),
       };
     default:
       return base;
@@ -133,7 +134,9 @@ export function configsEqual(a: Config, b: Config): boolean {
 }
 
 export function robloxSettingsChanged(a: Config, b: Config): boolean {
-  return JSON.stringify(a.roblox_settings) !== JSON.stringify(b.roblox_settings);
+  return (
+    JSON.stringify(a.roblox_settings) !== JSON.stringify(b.roblox_settings)
+  );
 }
 
 export function validateWindowDimension(

--- a/swifttunnel-desktop/src/lib/settings.ts
+++ b/swifttunnel-desktop/src/lib/settings.ts
@@ -1,4 +1,4 @@
-import type { AppSettings } from "./types";
+import type { AppSettings, NetworkConfig } from "./types";
 
 export const DEFAULT_SETTINGS: AppSettings = {
   theme: "dark",
@@ -71,9 +71,55 @@ export const DEFAULT_SETTINGS: AppSettings = {
   enable_api_tunneling: false,
 };
 
+function isLegacyMasterOnlyNetworkConfig(
+  raw: Partial<NetworkConfig> | undefined,
+): boolean {
+  return Boolean(
+    raw?.enable_network_boost &&
+    raw.prioritize_roblox_traffic === undefined &&
+    raw.disable_nagle === undefined &&
+    raw.disable_network_throttling === undefined &&
+    raw.gaming_qos === undefined &&
+    raw.firewall_fix === undefined,
+  );
+}
+
+export function normalizeNetworkBoostConfig(
+  config: NetworkConfig,
+  options: { legacyMasterOnly?: boolean } = {},
+): NetworkConfig {
+  const next = { ...config };
+  const hasSpecificBoost =
+    next.prioritize_roblox_traffic ||
+    next.disable_nagle ||
+    next.disable_network_throttling ||
+    next.gaming_qos ||
+    next.firewall_fix;
+
+  if (
+    options.legacyMasterOnly &&
+    next.enable_network_boost &&
+    !hasSpecificBoost
+  ) {
+    next.disable_nagle = true;
+    next.disable_network_throttling = true;
+    next.gaming_qos = true;
+  }
+
+  next.enable_network_boost =
+    next.prioritize_roblox_traffic ||
+    next.disable_nagle ||
+    next.disable_network_throttling ||
+    next.gaming_qos ||
+    next.firewall_fix;
+
+  return next;
+}
+
 export function mergeAppSettings(
   raw: Partial<AppSettings> | undefined,
 ): AppSettings {
+  const rawNetworkSettings = raw?.config?.network_settings;
   const settings = {
     ...DEFAULT_SETTINGS,
     ...raw,
@@ -93,8 +139,16 @@ export function mergeAppSettings(
         ...raw?.config?.roblox_settings,
       },
       network_settings: {
-        ...DEFAULT_SETTINGS.config.network_settings,
-        ...raw?.config?.network_settings,
+        ...normalizeNetworkBoostConfig(
+          {
+            ...DEFAULT_SETTINGS.config.network_settings,
+            ...rawNetworkSettings,
+          },
+          {
+            legacyMasterOnly:
+              isLegacyMasterOnlyNetworkConfig(rawNetworkSettings),
+          },
+        ),
       },
     },
     window_state: {

--- a/swifttunnel-desktop/src/stores/settingsStore.test.ts
+++ b/swifttunnel-desktop/src/stores/settingsStore.test.ts
@@ -55,11 +55,86 @@ describe("stores/settingsStore", () => {
       useSettingsStore.getState().settings.config.roblox_settings.window_width,
     ).toBe(1280);
     expect(
-      useSettingsStore.getState().settings.config.roblox_settings.graphics_quality,
+      useSettingsStore.getState().settings.config.roblox_settings
+        .graphics_quality,
     ).toBe("Automatic");
     expect(
       useSettingsStore.getState().settings.config.roblox_settings.unlock_fps,
     ).toBe(false);
+  });
+
+  it("migrates legacy master network boost into current per-toggle boosts", async () => {
+    settingsLoad.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      config: {
+        ...DEFAULT_SETTINGS.config,
+        network_settings: {
+          enable_network_boost: true,
+        },
+      },
+    });
+
+    const useSettingsStore = await loadStore();
+    await useSettingsStore.getState().load();
+
+    const network =
+      useSettingsStore.getState().settings.config.network_settings;
+    expect(network.enable_network_boost).toBe(true);
+    expect(network.disable_nagle).toBe(true);
+    expect(network.disable_network_throttling).toBe(true);
+    expect(network.gaming_qos).toBe(true);
+    expect(network.firewall_fix).toBe(false);
+  });
+
+  it("preserves explicit all-off network boosts even with a stale master flag", async () => {
+    settingsLoad.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      config: {
+        ...DEFAULT_SETTINGS.config,
+        network_settings: {
+          ...DEFAULT_SETTINGS.config.network_settings,
+          enable_network_boost: true,
+          disable_nagle: false,
+          disable_network_throttling: false,
+          gaming_qos: false,
+          prioritize_roblox_traffic: false,
+          firewall_fix: false,
+        },
+      },
+    });
+
+    const useSettingsStore = await loadStore();
+    await useSettingsStore.getState().load();
+
+    const network =
+      useSettingsStore.getState().settings.config.network_settings;
+    expect(network.enable_network_boost).toBe(false);
+    expect(network.disable_nagle).toBe(false);
+    expect(network.disable_network_throttling).toBe(false);
+    expect(network.gaming_qos).toBe(false);
+  });
+
+  it("does not enable network boosts when legacy master is off", async () => {
+    settingsLoad.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      config: {
+        ...DEFAULT_SETTINGS.config,
+        network_settings: {
+          ...DEFAULT_SETTINGS.config.network_settings,
+          enable_network_boost: false,
+        },
+      },
+    });
+
+    const useSettingsStore = await loadStore();
+    await useSettingsStore.getState().load();
+
+    const network =
+      useSettingsStore.getState().settings.config.network_settings;
+    expect(network.enable_network_boost).toBe(false);
+    expect(network.disable_nagle).toBe(false);
+    expect(network.disable_network_throttling).toBe(false);
+    expect(network.gaming_qos).toBe(false);
   });
 
   it("defaults minimize_to_tray to true when load fails", async () => {
@@ -72,10 +147,12 @@ describe("stores/settingsStore", () => {
     expect(useSettingsStore.getState().settings.minimize_to_tray).toBe(true);
     expect(useSettingsStore.getState().settings.run_on_startup).toBe(false);
     expect(useSettingsStore.getState().settings.auto_reconnect).toBe(false);
-    expect(useSettingsStore.getState().settings.resume_vpn_on_startup).toBe(false);
-    expect(useSettingsStore.getState().settings.preferred_physical_adapter_guid).toBe(
-      null,
+    expect(useSettingsStore.getState().settings.resume_vpn_on_startup).toBe(
+      false,
     );
+    expect(
+      useSettingsStore.getState().settings.preferred_physical_adapter_guid,
+    ).toBe(null);
     expect(useSettingsStore.getState().settings.adapter_binding_mode).toBe(
       "smart_auto",
     );
@@ -90,20 +167,22 @@ describe("stores/settingsStore", () => {
     expect(
       useSettingsStore.getState().settings.game_process_performance.unbind_cpu0,
     ).toBe(false);
-    expect(useSettingsStore.getState().settings.config.roblox_settings.window_width).toBe(
-      1280,
-    );
     expect(
-      useSettingsStore.getState().settings.config.roblox_settings.graphics_quality,
+      useSettingsStore.getState().settings.config.roblox_settings.window_width,
+    ).toBe(1280);
+    expect(
+      useSettingsStore.getState().settings.config.roblox_settings
+        .graphics_quality,
     ).toBe("Automatic");
     expect(
       useSettingsStore.getState().settings.config.roblox_settings.unlock_fps,
     ).toBe(false);
-    expect(useSettingsStore.getState().settings.config.roblox_settings.window_height).toBe(
-      720,
-    );
     expect(
-      useSettingsStore.getState().settings.config.roblox_settings.window_fullscreen,
+      useSettingsStore.getState().settings.config.roblox_settings.window_height,
+    ).toBe(720);
+    expect(
+      useSettingsStore.getState().settings.config.roblox_settings
+        .window_fullscreen,
     ).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- migrate legacy `enable_network_boost` configs into the current per-toggle network boosts
- normalize the network boost master flag everywhere configs are loaded/applied so saved state matches real boost toggles
- reapply saved network boosts on Windows startup after crash-recovery restore, so boosts work before the user opens the Boost tab

## Root cause
Older installs can still have the removed master `enable_network_boost` flag set while the current per-toggle settings are all false. The app also restores network registry/QoS state on exit/startup but did not reapply saved network boosts during startup, so persisted boost intent could become inactive or get synced back as off.

## Validation
- `npm test` in `swifttunnel-desktop` passed: 17 files, 114 tests
- `npm run build` in `swifttunnel-desktop` passed
- `cargo fmt --all -- --check` passed
- `git diff --check` passed

Blocked locally:
- `cargo test -p swifttunnel-core ...` is blocked on this macOS host before app code compiles by the known `windows-future` / `windows-core` mismatch (`IMarshal`, `windows_threading::submit`). Windows CI is the Rust compile/test gate for this change.
