### PR TITLE
[codex] Reduce WebView2 renderer background work

### DIFF
--- a/swifttunnel-desktop/src-tauri/src/events.rs
+++ b/swifttunnel-desktop/src-tauri/src/events.rs
@@ -7,6 +7,7 @@ pub const SERVER_LIST_UPDATED: &str = "server-list-updated";
 pub const THROUGHPUT_UPDATE: &str = "throughput-update";
 pub const PERFORMANCE_METRICS_UPDATE: &str = "performance-metrics-update";
 pub const RAM_CLEAN_PROGRESS: &str = "ram-clean-progress";
+pub const WINDOW_VISIBILITY_CHANGED: &str = "window-visibility-changed";
 
 /// VPN state change event payload
 #[derive(Clone, Serialize)]

--- a/swifttunnel-desktop/src-tauri/src/window_restore.rs
+++ b/swifttunnel-desktop/src-tauri/src/window_restore.rs
@@ -1,4 +1,4 @@
-use tauri::WebviewWindow;
+use tauri::{Emitter, WebviewWindow};
 
 trait WindowOps {
     fn unminimize(&self) -> Result<(), String>;
@@ -28,6 +28,7 @@ fn restore_window<W: WindowOps>(window: &W) {
 
 pub fn restore_main_window(window: &WebviewWindow) {
     restore_window(window);
+    let _ = window.emit(crate::events::WINDOW_VISIBILITY_CHANGED, true);
 }
 
 #[cfg(test)]

--- a/swifttunnel-desktop/src/App.tsx
+++ b/swifttunnel-desktop/src/App.tsx
@@ -21,6 +21,10 @@ import { cleanupEventListeners, initEventListeners } from "./lib/events";
 import { createCloseToTrayHandler } from "./lib/closeToTray";
 import { runAppBootstrap } from "./lib/appBootstrap";
 import { reportError } from "./lib/errors";
+import {
+  installRendererActivityListeners,
+  useRendererActivityStore,
+} from "./lib/rendererActivity";
 import { systemLaunchedFromStartup } from "./lib/commands";
 import {
   ensureWindowStateVisible,
@@ -58,6 +62,16 @@ function App() {
   const fetchVpnState = useVpnStore((s) => s.fetchState);
   const connectVpn = useVpnStore((s) => s.connect);
   const checkForUpdates = useUpdaterStore((s) => s.checkForUpdates);
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
+  const setWindowVisible = useRendererActivityStore((s) => s.setWindowVisible);
+
+  useEffect(() => installRendererActivityListeners(), []);
+
+  useEffect(() => {
+    document.documentElement.dataset.rendererActive = rendererActive
+      ? "true"
+      : "false";
+  }, [rendererActive]);
 
   useEffect(() => {
     let disposed = false;
@@ -82,10 +96,12 @@ function App() {
           const fromStartup = await systemLaunchedFromStartup();
           if (!fromStartup && !disposed) {
             await getCurrentWindow().show();
+            setWindowVisible(true);
           }
         } catch {
           if (!disposed) {
             await getCurrentWindow().show();
+            setWindowVisible(true);
           }
         }
       }
@@ -109,6 +125,7 @@ function App() {
     fetchVpnState,
     connectVpn,
     checkForUpdates,
+    setWindowVisible,
   ]);
 
   useEffect(() => {
@@ -246,6 +263,7 @@ function App() {
             persistWindowState,
             hide: () => appWindow.hide(),
             close: () => appWindow.close(),
+            onHiddenToTray: () => setWindowVisible(false),
             shouldMinimizeToTray: () =>
               useSettingsStore.getState().settings.minimize_to_tray,
             isDisposed: () => disposed,

--- a/swifttunnel-desktop/src/App.tsx
+++ b/swifttunnel-desktop/src/App.tsx
@@ -22,6 +22,10 @@ import { cleanupEventListeners, initEventListeners } from "./lib/events";
 import { createCloseToTrayHandler } from "./lib/closeToTray";
 import { runAppBootstrap } from "./lib/appBootstrap";
 import { reportError } from "./lib/errors";
+import {
+  installRendererActivityListeners,
+  useRendererActivityStore,
+} from "./lib/rendererActivity";
 import { systemLaunchedFromStartup } from "./lib/commands";
 import {
   ensureWindowStateVisible,
@@ -60,6 +64,16 @@ function App() {
   const fetchVpnState = useVpnStore((s) => s.fetchState);
   const connectVpn = useVpnStore((s) => s.connect);
   const checkForUpdates = useUpdaterStore((s) => s.checkForUpdates);
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
+  const setWindowVisible = useRendererActivityStore((s) => s.setWindowVisible);
+
+  useEffect(() => installRendererActivityListeners(), []);
+
+  useEffect(() => {
+    document.documentElement.dataset.rendererActive = rendererActive
+      ? "true"
+      : "false";
+  }, [rendererActive]);
 
   useEffect(() => {
     let disposed = false;
@@ -85,10 +99,12 @@ function App() {
           const fromStartup = await systemLaunchedFromStartup();
           if (!fromStartup && !disposed) {
             await getCurrentWindow().show();
+            setWindowVisible(true);
           }
         } catch {
           if (!disposed) {
             await getCurrentWindow().show();
+            setWindowVisible(true);
           }
         }
       }
@@ -113,6 +129,7 @@ function App() {
     refreshAuthProfile,
     connectVpn,
     checkForUpdates,
+    setWindowVisible,
   ]);
 
   useEffect(() => {
@@ -250,6 +267,7 @@ function App() {
             persistWindowState,
             hide: () => appWindow.hide(),
             close: () => appWindow.close(),
+            onHiddenToTray: () => setWindowVisible(false),
             shouldMinimizeToTray: () =>
               useSettingsStore.getState().settings.minimize_to_tray,
             isDisposed: () => disposed,

--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -7,6 +7,10 @@ import { systemRestartAsAdmin } from "../../lib/commands";
 import { normalizeNetworkBoostConfig } from "../../lib/settings";
 import { notify } from "../../lib/notifications";
 import {
+  useActiveInterval,
+  useRendererActivityStore,
+} from "../../lib/rendererActivity";
+import {
   Toggle,
   SectionHeader,
   Tooltip,
@@ -53,6 +57,7 @@ export function BoostTab() {
 
   const boost = useBoostStore();
   const addToast = useToastStore((s) => s.addToast);
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
 
   const [restartAdminState, setRestartAdminState] = useState<
     "idle" | "restarting" | "error"
@@ -116,22 +121,23 @@ export function BoostTab() {
   );
   const windowValidationError = windowWidthError ?? windowHeightError;
 
-  useEffect(() => {
-    const id = setInterval(boost.fetchMetrics, 2000);
-    return () => clearInterval(id);
-  }, [boost.fetchMetrics]);
+  useActiveInterval(boost.fetchMetrics, 2000);
 
   useEffect(() => {
     void boost.fetchSystemMemory();
   }, [boost.fetchSystemMemory]);
 
   useEffect(() => {
-    const intervalMs = boost.isCleaningRam ? 250 : 1000;
-    const id = setInterval(() => {
+    if (rendererActive) {
+      void boost.fetchMetrics();
       void boost.fetchSystemMemory();
-    }, intervalMs);
-    return () => clearInterval(id);
-  }, [boost.fetchSystemMemory, boost.isCleaningRam]);
+    }
+  }, [boost.fetchMetrics, boost.fetchSystemMemory, rendererActive]);
+
+  useActiveInterval(
+    boost.fetchSystemMemory,
+    boost.isCleaningRam ? 250 : 1000,
+  );
 
   const applyChanges = useCallback(async () => {
     if (windowValidationError) return;

--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -7,6 +7,10 @@ import { systemRestartAsAdmin } from "../../lib/commands";
 import { normalizeNetworkBoostConfig } from "../../lib/settings";
 import { notify } from "../../lib/notifications";
 import {
+  useActiveInterval,
+  useRendererActivityStore,
+} from "../../lib/rendererActivity";
+import {
   Toggle,
   SectionHeader,
   Tooltip,
@@ -57,6 +61,7 @@ export function BoostTab() {
 
   const boost = useBoostStore();
   const addToast = useToastStore((s) => s.addToast);
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
 
   const [restartAdminState, setRestartAdminState] = useState<
     "idle" | "restarting" | "error"
@@ -142,22 +147,19 @@ export function BoostTab() {
   );
   const windowValidationError = windowWidthError ?? windowHeightError;
 
-  useEffect(() => {
-    const id = setInterval(boost.fetchMetrics, 2000);
-    return () => clearInterval(id);
-  }, [boost.fetchMetrics]);
+  useActiveInterval(boost.fetchMetrics, 2000);
 
   useEffect(() => {
-    void boost.fetchSystemMemory();
-  }, [boost.fetchSystemMemory]);
-
-  useEffect(() => {
-    const intervalMs = boost.isCleaningRam ? 250 : 1000;
-    const id = setInterval(() => {
+    if (rendererActive) {
+      void boost.fetchMetrics();
       void boost.fetchSystemMemory();
-    }, intervalMs);
-    return () => clearInterval(id);
-  }, [boost.fetchSystemMemory, boost.isCleaningRam]);
+    }
+  }, [boost.fetchMetrics, boost.fetchSystemMemory, rendererActive]);
+
+  useActiveInterval(
+    boost.fetchSystemMemory,
+    boost.isCleaningRam ? 250 : 1000,
+  );
 
   const applyChanges = useCallback(async () => {
     if (windowValidationError) return;

--- a/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
+++ b/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
@@ -11,6 +11,10 @@ import {
 import { formatConnectedServerLabel } from "../../lib/connectedServer";
 import { findRegionForVpnRegion } from "../../lib/regionMatch";
 import {
+  useActiveInterval,
+  useRendererActivityStore,
+} from "../../lib/rendererActivity";
+import {
   isConnectActionBusy,
   resolveConnectStatus,
   stateLabel,
@@ -66,6 +70,7 @@ export function ConnectTab() {
   const getLatency = useServerStore((s) => s.getLatency);
   const fetchLatencies = useServerStore((s) => s.fetchLatencies);
   const refreshServers = useServerStore((s) => s.refresh);
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
 
   const connectedRegion = findRegionForVpnRegion(regions, vpnRegion);
   const connectedServerLabel = formatConnectedServerLabel(
@@ -115,11 +120,7 @@ export function ConnectTab() {
     };
   }, [save]);
 
-  useEffect(() => {
-    if (!isConnected) return;
-    const id = setInterval(fetchThroughput, 1000);
-    return () => clearInterval(id);
-  }, [isConnected, fetchThroughput]);
+  useActiveInterval(fetchThroughput, 1000, isConnected);
 
   useEffect(() => {
     if (!isConnected) {
@@ -127,7 +128,13 @@ export function ConnectTab() {
       prevBytesRef.current = null;
       return;
     }
-    const id = setInterval(() => {
+    if (!rendererActive) {
+      prevBytesRef.current = null;
+    }
+  }, [isConnected, rendererActive]);
+
+  useActiveInterval(
+    () => {
       const { bytesUp, bytesDown } = useVpnStore.getState();
       const now = Date.now();
       const prev = prevBytesRef.current;
@@ -140,31 +147,24 @@ export function ConnectTab() {
         );
       }
       prevBytesRef.current = { up: bytesUp, down: bytesDown, t: now };
-    }, 1000);
-    return () => {
-      clearInterval(id);
-      prevBytesRef.current = null;
-    };
-  }, [isConnected]);
+    },
+    1000,
+    isConnected,
+  );
+
+  useActiveInterval(
+    () => fetchState(),
+    2000,
+    isConnected || isTransitioning,
+  );
 
   useEffect(() => {
-    if (!isConnected && !isTransitioning) return;
-    const id = setInterval(() => void fetchState(), 2000);
-    return () => clearInterval(id);
-  }, [isConnected, isTransitioning, fetchState]);
-
-  useEffect(() => {
+    if (!rendererActive) return;
     void fetchLatencies();
-    const id = setInterval(() => void fetchLatencies(), 15000);
-    return () => clearInterval(id);
-  }, [fetchLatencies]);
+  }, [fetchLatencies, rendererActive]);
 
-  useEffect(() => {
-    if (!isConnected) return;
-    void fetchPing();
-    const id = setInterval(() => void fetchPing(), 3000);
-    return () => clearInterval(id);
-  }, [isConnected, fetchPing]);
+  useActiveInterval(() => fetchLatencies(), 15000);
+  useActiveInterval(fetchPing, 3000, isConnected);
 
   useEffect(() => {
     if (connectedAt === null) {
@@ -172,12 +172,35 @@ export function ConnectTab() {
       return;
     }
     setElapsed(Math.floor((Date.now() - connectedAt) / 1000));
-    const id = setInterval(
-      () => setElapsed(Math.floor((Date.now() - connectedAt) / 1000)),
-      1000,
-    );
-    return () => clearInterval(id);
-  }, [connectedAt]);
+  }, [connectedAt, rendererActive]);
+
+  useActiveInterval(
+    () => {
+      if (connectedAt !== null) {
+        setElapsed(Math.floor((Date.now() - connectedAt) / 1000));
+      }
+    },
+    1000,
+    connectedAt !== null,
+  );
+
+  useEffect(() => {
+    if (!rendererActive) return;
+    if (isConnected || isTransitioning) {
+      void fetchState();
+    }
+    if (isConnected) {
+      void fetchThroughput();
+      void fetchPing();
+    }
+  }, [
+    fetchPing,
+    fetchState,
+    fetchThroughput,
+    isConnected,
+    isTransitioning,
+    rendererActive,
+  ]);
 
   function selectRegion(regionId: string) {
     update({ selected_region: regionId, auto_routing_enabled: false });

--- a/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
+++ b/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
@@ -5,6 +5,10 @@ import { useUpdaterStore } from "../../stores/updaterStore";
 import { useVpnStore } from "../../stores/vpnStore";
 import { useToastStore } from "../../stores/toastStore";
 import {
+  useActiveInterval,
+  useRendererActivityStore,
+} from "../../lib/rendererActivity";
+import {
   Toggle,
   Button,
   Chip,
@@ -51,6 +55,7 @@ export function SettingsTab() {
   const vpnState = useVpnStore((s) => s.state);
   const vpnDiagnostics = useVpnStore((s) => s.diagnostics);
   const fetchVpnDiagnostics = useVpnStore((s) => s.fetchDiagnostics);
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
 
   const addToast = useToastStore((s) => s.addToast);
 
@@ -145,13 +150,15 @@ export function SettingsTab() {
   }, []);
 
   useEffect(() => {
+    if (!rendererActive) return;
     void fetchVpnDiagnostics();
-    if (vpnState !== "connected") return;
-    const id = setInterval(() => {
-      void fetchVpnDiagnostics();
-    }, 3000);
-    return () => clearInterval(id);
-  }, [fetchVpnDiagnostics, vpnState]);
+  }, [fetchVpnDiagnostics, rendererActive]);
+
+  useActiveInterval(
+    fetchVpnDiagnostics,
+    3000,
+    vpnState === "connected",
+  );
 
   async function generateDiagnosticsBundle() {
     setIsGeneratingDiagnostics(true);

--- a/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
+++ b/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
@@ -5,6 +5,10 @@ import { useUpdaterStore } from "../../stores/updaterStore";
 import { useVpnStore } from "../../stores/vpnStore";
 import { useToastStore } from "../../stores/toastStore";
 import {
+  useActiveInterval,
+  useRendererActivityStore,
+} from "../../lib/rendererActivity";
+import {
   Toggle,
   Button,
   Chip,
@@ -51,6 +55,7 @@ export function SettingsTab() {
   const vpnState = useVpnStore((s) => s.state);
   const vpnDiagnostics = useVpnStore((s) => s.diagnostics);
   const fetchVpnDiagnostics = useVpnStore((s) => s.fetchDiagnostics);
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
 
   const addToast = useToastStore((s) => s.addToast);
 
@@ -145,13 +150,15 @@ export function SettingsTab() {
   }, []);
 
   useEffect(() => {
+    if (!rendererActive || vpnState !== "connected") return;
     void fetchVpnDiagnostics();
-    if (vpnState !== "connected") return;
-    const id = setInterval(() => {
-      void fetchVpnDiagnostics();
-    }, 3000);
-    return () => clearInterval(id);
-  }, [fetchVpnDiagnostics, vpnState]);
+  }, [fetchVpnDiagnostics, rendererActive, vpnState]);
+
+  useActiveInterval(
+    fetchVpnDiagnostics,
+    3000,
+    vpnState === "connected",
+  );
 
   async function generateDiagnosticsBundle() {
     setIsGeneratingDiagnostics(true);

--- a/swifttunnel-desktop/src/lib/closeToTray.test.ts
+++ b/swifttunnel-desktop/src/lib/closeToTray.test.ts
@@ -17,11 +17,13 @@ describe("createCloseToTrayHandler", () => {
     const persistGate = deferred<void>();
     const hide = vi.fn(async () => {});
     const close = vi.fn(async () => {});
+    const onHiddenToTray = vi.fn();
 
     const handler = createCloseToTrayHandler({
       persistWindowState: () => persistGate.promise,
       hide,
       close,
+      onHiddenToTray,
       shouldMinimizeToTray: () => true,
     });
 
@@ -36,6 +38,7 @@ describe("createCloseToTrayHandler", () => {
     await p;
 
     expect(hide).toHaveBeenCalledTimes(1);
+    expect(onHiddenToTray).toHaveBeenCalledTimes(1);
     expect(close).not.toHaveBeenCalled();
   });
 
@@ -83,6 +86,7 @@ describe("createCloseToTrayHandler", () => {
   it("falls back to a real close if hide fails (without recursion)", async () => {
     const preventDefault = vi.fn();
     const persistWindowState = vi.fn(async () => {});
+    const onHiddenToTray = vi.fn();
 
     const hide = vi.fn(async () => {
       throw new Error("hide failed");
@@ -98,6 +102,7 @@ describe("createCloseToTrayHandler", () => {
       persistWindowState,
       hide,
       close,
+      onHiddenToTray,
       shouldMinimizeToTray: () => true,
     });
 
@@ -106,6 +111,7 @@ describe("createCloseToTrayHandler", () => {
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(persistWindowState).toHaveBeenCalledTimes(1);
     expect(hide).toHaveBeenCalledTimes(1);
+    expect(onHiddenToTray).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/swifttunnel-desktop/src/lib/closeToTray.ts
+++ b/swifttunnel-desktop/src/lib/closeToTray.ts
@@ -8,6 +8,7 @@ type CloseToTrayDeps = {
   persistWindowState: () => Promise<void>;
   hide: () => Promise<void>;
   close: () => Promise<void>;
+  onHiddenToTray?: () => void;
   shouldMinimizeToTray?: () => boolean;
   isDisposed?: () => boolean;
 };
@@ -54,6 +55,7 @@ export function createCloseToTrayHandler(deps: CloseToTrayDeps) {
 
     try {
       await deps.hide();
+      deps.onHiddenToTray?.();
     } catch (error) {
       reportError("Failed to hide window to tray", error, {
         dedupeKey: "close-to-tray-hide",

--- a/swifttunnel-desktop/src/lib/rendererActivity.test.ts
+++ b/swifttunnel-desktop/src/lib/rendererActivity.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeRendererActive,
+  type RendererActivitySnapshot,
+} from "./rendererActivity";
+
+const base: RendererActivitySnapshot = {
+  documentVisible: true,
+  windowVisible: true,
+  windowMinimized: false,
+  windowFocused: true,
+};
+
+describe("computeRendererActive", () => {
+  it("keeps renderer work active for a visible but unfocused window", () => {
+    expect(computeRendererActive({ ...base, windowFocused: false })).toBe(true);
+  });
+
+  it("pauses renderer work when the document is hidden", () => {
+    expect(computeRendererActive({ ...base, documentVisible: false })).toBe(
+      false,
+    );
+  });
+
+  it("pauses renderer work when the Tauri window is hidden to tray", () => {
+    expect(computeRendererActive({ ...base, windowVisible: false })).toBe(
+      false,
+    );
+  });
+
+  it("pauses renderer work for minimized windows", () => {
+    expect(computeRendererActive({ ...base, windowMinimized: true })).toBe(
+      false,
+    );
+  });
+});

--- a/swifttunnel-desktop/src/lib/rendererActivity.ts
+++ b/swifttunnel-desktop/src/lib/rendererActivity.ts
@@ -1,0 +1,186 @@
+import { useEffect, useRef } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { create } from "zustand";
+import { reportError } from "./errors";
+
+export const WINDOW_VISIBILITY_CHANGED = "window-visibility-changed";
+
+export type RendererActivitySnapshot = {
+  documentVisible: boolean;
+  windowVisible: boolean;
+  windowMinimized: boolean;
+  windowFocused: boolean;
+};
+
+type RendererActivityStore = RendererActivitySnapshot & {
+  isActive: boolean;
+  refresh: () => Promise<void>;
+  setDocumentVisible: (visible: boolean) => void;
+  setWindowVisible: (visible: boolean) => void;
+  setWindowFocused: (focused: boolean) => void;
+  setWindowMinimized: (minimized: boolean) => void;
+};
+
+export function computeRendererActive(
+  snapshot: RendererActivitySnapshot,
+): boolean {
+  return (
+    snapshot.documentVisible &&
+    snapshot.windowVisible &&
+    !snapshot.windowMinimized
+  );
+}
+
+function documentIsVisible() {
+  return typeof document === "undefined" || document.visibilityState !== "hidden";
+}
+
+function withActive(
+  patch: Partial<RendererActivitySnapshot>,
+  current: RendererActivitySnapshot,
+) {
+  const next = { ...current, ...patch };
+  return { ...next, isActive: computeRendererActive(next) };
+}
+
+export const useRendererActivityStore = create<RendererActivityStore>(
+  (set) => ({
+    documentVisible: documentIsVisible(),
+    windowVisible: true,
+    windowMinimized: false,
+    windowFocused: true,
+    isActive: true,
+
+    refresh: async () => {
+      try {
+        const appWindow = getCurrentWindow();
+        const [windowVisible, windowMinimized, windowFocused] =
+          await Promise.all([
+            appWindow.isVisible(),
+            appWindow.isMinimized(),
+            appWindow.isFocused(),
+          ]);
+        set((current) =>
+          withActive(
+            {
+              documentVisible: documentIsVisible(),
+              windowVisible,
+              windowMinimized,
+              windowFocused,
+            },
+            current,
+          ),
+        );
+      } catch (error) {
+        reportError("Failed to refresh renderer activity", error, {
+          dedupeKey: "renderer-activity-refresh",
+        });
+      }
+    },
+
+    setDocumentVisible: (documentVisible) =>
+      set((current) => withActive({ documentVisible }, current)),
+    setWindowVisible: (windowVisible) =>
+      set((current) => withActive({ windowVisible }, current)),
+    setWindowFocused: (windowFocused) =>
+      set((current) => withActive({ windowFocused }, current)),
+    setWindowMinimized: (windowMinimized) =>
+      set((current) => withActive({ windowMinimized }, current)),
+  }),
+);
+
+export function useActiveInterval(
+  callback: () => void | Promise<void>,
+  delayMs: number,
+  active = true,
+) {
+  const rendererActive = useRendererActivityStore((s) => s.isActive);
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!active || !rendererActive) return;
+
+    const id = window.setInterval(() => {
+      void callbackRef.current();
+    }, delayMs);
+    return () => window.clearInterval(id);
+  }, [active, delayMs, rendererActive]);
+}
+
+export function installRendererActivityListeners() {
+  const unlisteners: UnlistenFn[] = [];
+  let disposed = false;
+
+  const refresh = () => {
+    if (!disposed) {
+      void useRendererActivityStore.getState().refresh();
+    }
+  };
+
+  const onDocumentVisibilityChange = () => {
+    useRendererActivityStore
+      .getState()
+      .setDocumentVisible(documentIsVisible());
+    refresh();
+  };
+
+  document.addEventListener("visibilitychange", onDocumentVisibilityChange);
+  window.addEventListener("focus", refresh);
+  window.addEventListener("blur", refresh);
+
+  void getCurrentWindow()
+    .onFocusChanged(({ payload }) => {
+      useRendererActivityStore.getState().setWindowFocused(payload);
+      refresh();
+    })
+    .then((unlisten) => {
+      if (disposed) {
+        unlisten();
+      } else {
+        unlisteners.push(unlisten);
+      }
+    })
+    .catch((error) => {
+      reportError("Failed to listen for Tauri focus changes", error, {
+        dedupeKey: "renderer-activity-focus-listen",
+      });
+    });
+
+  void listen<boolean>(WINDOW_VISIBILITY_CHANGED, (event) => {
+    useRendererActivityStore.getState().setWindowVisible(event.payload);
+    refresh();
+  })
+    .then((unlisten) => {
+      if (disposed) {
+        unlisten();
+      } else {
+        unlisteners.push(unlisten);
+      }
+    })
+    .catch((error) => {
+      reportError("Failed to listen for Tauri visibility changes", error, {
+        dedupeKey: "renderer-activity-visibility-listen",
+      });
+    });
+
+  useRendererActivityStore.getState().setDocumentVisible(documentIsVisible());
+  refresh();
+
+  return () => {
+    disposed = true;
+    document.removeEventListener(
+      "visibilitychange",
+      onDocumentVisibilityChange,
+    );
+    window.removeEventListener("focus", refresh);
+    window.removeEventListener("blur", refresh);
+    for (const unlisten of unlisteners) {
+      unlisten();
+    }
+  };
+}

--- a/swifttunnel-desktop/src/mocks/tauri-window.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-window.ts
@@ -25,6 +25,12 @@ class MockWindow {
   async isMinimized() {
     return false;
   }
+  async isVisible() {
+    return true;
+  }
+  async isFocused() {
+    return true;
+  }
   async setSize() {}
   async setPosition() {}
   async maximize() {}
@@ -40,6 +46,10 @@ class MockWindow {
     return () => {};
   }
   async onCloseRequested(handler: () => void) {
+    void handler;
+    return () => {};
+  }
+  async onFocusChanged(handler: ({ payload }: { payload: boolean }) => void) {
     void handler;
     return () => {};
   }

--- a/swifttunnel-desktop/src/styles/globals.css
+++ b/swifttunnel-desktop/src/styles/globals.css
@@ -121,6 +121,13 @@ body {
   font-feature-settings: "ss01", "cv11";
 }
 
+html[data-renderer-active="false"] *,
+html[data-renderer-active="false"] *::before,
+html[data-renderer-active="false"] *::after {
+  animation-play-state: paused !important;
+  transition: none !important;
+}
+
 /* Mono numerics everywhere — use `.mono` or a tailwind font-mono class */
 .mono,
 .font-mono {

--- a/swifttunnel-desktop/src/styles/globals.css
+++ b/swifttunnel-desktop/src/styles/globals.css
@@ -96,6 +96,13 @@ body {
   font-feature-settings: "ss01", "cv11", "cv05";
 }
 
+html[data-renderer-active="false"] *,
+html[data-renderer-active="false"] *::before,
+html[data-renderer-active="false"] *::after {
+  animation-play-state: paused !important;
+  transition: none !important;
+}
+
 .mono,
 .font-mono {
   font-family: "Geist Mono", "JetBrains Mono", "Cascadia Code", "Consolas", ui-monospace, monospace;


### PR DESCRIPTION
## Summary
- Add a renderer activity tracker for document/window visibility so UI-only timers stop while WebView2 is hidden, minimized, or backgrounded.
- Move connect, boost, and settings polling onto visibility-aware intervals, with immediate refreshes when the app becomes visible again.
- Pause CSS animation/transition playback while the renderer is inactive and emit a Tauri visibility event when restoring from tray.
- Rebased onto current main and addressed Greptile P2 feedback: removed the double memory fetch on Boost mount and restored immediate diagnostics refresh when VPN connects.

## Impact
This cuts unnecessary WebView2 CPU wakeups and animation work without changing VPN/backend behavior. Background tunnel/auth/server state still flows through backend events, and the UI refreshes current metrics on return.

## Validation
- npm ci
- npm test -- --run
- npx tsc --noEmit
- npm run build
- cargo fmt --check

## Note
- Cargo compilation is still delegated to GitHub Windows CI for this repo path because local macOS Rust hits the known windows-future/windows-core dependency mismatch before app code.