### PR TITLE
[codex] Avoid silent Gaming QoS legacy migration

### DIFF
--- a/swifttunnel-core/src/settings.rs
+++ b/swifttunnel-core/src/settings.rs
@@ -522,7 +522,7 @@ mod tests {
         assert!(settings.config.network_settings.enable_network_boost);
         assert!(settings.config.network_settings.disable_nagle);
         assert!(settings.config.network_settings.disable_network_throttling);
-        assert!(settings.config.network_settings.gaming_qos);
+        assert!(!settings.config.network_settings.gaming_qos);
         assert!(!settings.config.network_settings.firewall_fix);
     }
 

--- a/swifttunnel-core/src/structs.rs
+++ b/swifttunnel-core/src/structs.rs
@@ -573,16 +573,6 @@ mod tests {
     }
 
     #[test]
-    fn test_network_config_legacy_master_does_not_silently_enable_gaming_qos() {
-        let cfg: NetworkConfig = serde_json::from_str(r#"{"enable_network_boost": true}"#).unwrap();
-
-        assert!(cfg.enable_network_boost);
-        assert!(cfg.disable_nagle);
-        assert!(cfg.disable_network_throttling);
-        assert!(!cfg.gaming_qos);
-    }
-
-    #[test]
     fn test_network_config_does_not_invent_boosts_when_master_is_explicitly_stale() {
         let cfg: NetworkConfig = serde_json::from_str(
             r#"{

--- a/swifttunnel-core/src/structs.rs
+++ b/swifttunnel-core/src/structs.rs
@@ -266,7 +266,6 @@ impl<'de> Deserialize<'de> for NetworkConfig {
         if config.enable_network_boost && !has_any_specific_field {
             config.disable_nagle = true;
             config.disable_network_throttling = true;
-            config.gaming_qos = true;
         }
 
         config.normalize_legacy_master_boost();
@@ -568,9 +567,19 @@ mod tests {
         assert!(cfg.enable_network_boost);
         assert!(cfg.disable_nagle);
         assert!(cfg.disable_network_throttling);
-        assert!(cfg.gaming_qos);
+        assert!(!cfg.gaming_qos);
         assert!(!cfg.prioritize_roblox_traffic);
         assert!(!cfg.firewall_fix);
+    }
+
+    #[test]
+    fn test_network_config_legacy_master_does_not_silently_enable_gaming_qos() {
+        let cfg: NetworkConfig = serde_json::from_str(r#"{"enable_network_boost": true}"#).unwrap();
+
+        assert!(cfg.enable_network_boost);
+        assert!(cfg.disable_nagle);
+        assert!(cfg.disable_network_throttling);
+        assert!(!cfg.gaming_qos);
     }
 
     #[test]

--- a/swifttunnel-desktop/src/lib/settings.ts
+++ b/swifttunnel-desktop/src/lib/settings.ts
@@ -103,7 +103,6 @@ export function normalizeNetworkBoostConfig(
   ) {
     next.disable_nagle = true;
     next.disable_network_throttling = true;
-    next.gaming_qos = true;
   }
 
   next.enable_network_boost =

--- a/swifttunnel-desktop/src/stores/settingsStore.test.ts
+++ b/swifttunnel-desktop/src/stores/settingsStore.test.ts
@@ -82,7 +82,7 @@ describe("stores/settingsStore", () => {
     expect(network.enable_network_boost).toBe(true);
     expect(network.disable_nagle).toBe(true);
     expect(network.disable_network_throttling).toBe(true);
-    expect(network.gaming_qos).toBe(true);
+    expect(network.gaming_qos).toBe(false);
     expect(network.firewall_fix).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

This fixes the likely `v2.0.25` regression for users with saved legacy network boosts by keeping legacy master-only boost migration from silently enabling Gaming QoS / DSCP policy.

## Root Cause

`v2.0.25` made old `enable_network_boost: true` settings expand into concrete network toggles and then reapply at startup. That unintentionally included `gaming_qos`, which writes Windows QoS/DSCP policy for Roblox and relay traffic. Users who only had a legacy saved boost could start getting QoS behavior without explicitly opting into it.

## Changes

- Legacy master-only boost migration now restores only `disable_nagle` and `disable_network_throttling`.
- Explicit Gaming QoS toggles and boost presets can still enable `gaming_qos` normally.
- Added/updated tests so legacy migration does not silently enable Gaming QoS while still preserving the migrated boost state.

## Validation

- `cargo fmt --check`
- `bun run test src/stores/settingsStore.test.ts src/components/boost/boostConfig.test.ts`

Local macOS Rust test execution is still blocked by the known `windows-future` / `windows-core` mismatch before reaching these tests, so the Windows GitHub runner remains the authoritative Rust compile gate.