### PR TITLE
Enforce bans and repair Roblox FFlags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Built-in performance optimizations:
 - **FPS Unlocker** — Remove the 60 FPS cap
 - **Network Tweaks** — Optimize TCP/UDP settings, DNS, and adapter config
 - **System Boosts** — Process priority, timer resolution, memory management
+- **Roblox FFlags** — Ultraboost writes every valid Roblox `version-*` folder and re-applies saved flags on startup so Roblox updates do not drop the settings.
 
 ### 🔒 Lightweight & Safe
 - No kernel drivers required for basic operation
 - Anti-cheat friendly — uses standard Windows APIs
 - Minimal resource usage (~20MB RAM)
 - All optimizations are reversible
+- Banned accounts are blocked in-app and trigger best-effort cleanup of saved VPN, Roblox, network, and system boosts.
 
 ### 🌍 Auto Region Detection
 Starts on the lowest-latency region from the in-app ping test, then resolves detected Roblox game-server IPs through SwiftTunnel's IPinfo-backed web resolver. Manual server pins stay respected and still complete the relay-ticket handshake, drained relays are excluded through `/api/vpn/servers`, stale lookups cannot switch after a newer game-server IP, and live ping-test refreshes keep Auto Route's server choices current while connected.

--- a/swifttunnel-core/src/auth/http_client.rs
+++ b/swifttunnel-core/src/auth/http_client.rs
@@ -5,6 +5,7 @@ use super::types::{
 };
 use log::{debug, error, info};
 use reqwest::Client;
+use serde::Deserialize;
 use serde_json::json;
 
 /// Response from the user profile API
@@ -19,6 +20,20 @@ pub struct UserProfileResponse {
     pub is_admin: bool,
     #[serde(default)]
     pub is_tester: bool,
+    #[serde(default)]
+    pub is_banned: bool,
+    #[serde(default)]
+    pub banned_reason: Option<String>,
+    #[serde(default)]
+    pub banned_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorResponse {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    banned_reason: Option<String>,
 }
 
 const API_BASE_URL: &str = "https://swifttunnel.net";
@@ -160,6 +175,9 @@ impl AuthClient {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             error!("Get VPN config failed: {} - {}", status, body);
+            if let Some(error) = user_banned_error_from_body(&body) {
+                return Err(error);
+            }
             return Err(AuthError::ApiError(format!(
                 "Config fetch failed: {} - {}",
                 status, body
@@ -206,6 +224,9 @@ impl AuthClient {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             error!("Relay ticket fetch failed: {} - {}", status, body);
+            if let Some(error) = user_banned_error_from_body(&body) {
+                return Err(error);
+            }
             return Err(AuthError::ApiError(format!(
                 "Relay ticket fetch failed: {} - {}",
                 status, body
@@ -255,6 +276,9 @@ impl AuthClient {
             let body = response.text().await.unwrap_or_default();
             error!("Exchange token failed: {} - {}", status, body);
 
+            if let Some(error) = user_banned_error_from_body(&body) {
+                return Err(error);
+            }
             if body.contains("Invalid exchange token") {
                 return Err(AuthError::ApiError(
                     "Invalid or expired exchange token. Please try again.".to_string(),
@@ -306,6 +330,9 @@ impl AuthClient {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             error!("Fetch user profile failed: {} - {}", status, body);
+            if let Some(error) = user_banned_error_from_body(&body) {
+                return Err(error);
+            }
             return Err(AuthError::ApiError(format!(
                 "Profile fetch failed: {} - {}",
                 status, body
@@ -407,6 +434,25 @@ pub(crate) fn is_refresh_token_permanently_invalid(body: &str) -> bool {
         || body.contains("refresh_token_already_used")
 }
 
+fn user_banned_error_from_body(body: &str) -> Option<AuthError> {
+    let parsed: ApiErrorResponse = serde_json::from_str(body).ok()?;
+    if parsed.code.as_deref() != Some("user_banned") {
+        return None;
+    }
+
+    Some(AuthError::UserBanned(ban_reason_suffix(
+        parsed.banned_reason,
+    )))
+}
+
+fn ban_reason_suffix(reason: Option<String>) -> String {
+    reason
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(": {}", value))
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -436,5 +482,21 @@ mod tests {
         ));
         assert!(!is_refresh_token_permanently_invalid("rate_limit_exceeded"));
         assert!(!is_refresh_token_permanently_invalid(""));
+    }
+
+    #[test]
+    fn test_user_banned_error_uses_structured_code() {
+        let body = r#"{"error":"User banned","code":"user_banned","banned_reason":"chargeback"}"#;
+
+        let error = user_banned_error_from_body(body).unwrap();
+
+        assert_eq!(error.to_string(), "Account banned: chargeback");
+    }
+
+    #[test]
+    fn test_user_banned_error_ignores_incidental_text() {
+        let body = r#"{"error":"user_banned appeared in a log line","code":"internal_error"}"#;
+
+        assert!(user_banned_error_from_body(body).is_none());
     }
 }

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -3,7 +3,9 @@
 use super::http_client::{AuthClient, UserProfileResponse};
 use super::oauth_server::{DEFAULT_OAUTH_PORT, OAuthServer, OAuthServerResult};
 use super::storage::SecureStorage;
-use super::types::{AuthError, AuthSession, AuthState, OAuthPendingState, UserInfo};
+use super::types::{
+    AuthError, AuthSession, AuthState, OAuthPendingState, SupabaseAuthResponse, UserInfo,
+};
 use chrono::{Duration, Utc};
 use log::{debug, error, info, warn};
 use parking_lot::Mutex;
@@ -134,6 +136,29 @@ impl AuthManager {
         session.user.banned_reason = profile.banned_reason;
         session.user.banned_at = profile.banned_at;
         session
+    }
+
+    fn session_from_auth_response(
+        auth_response: SupabaseAuthResponse,
+        fallback_email: String,
+        is_tester: bool,
+        is_banned: bool,
+        banned_reason: Option<String>,
+        banned_at: Option<String>,
+    ) -> AuthSession {
+        AuthSession {
+            access_token: auth_response.access_token,
+            refresh_token: auth_response.refresh_token,
+            expires_at: Utc::now() + Duration::seconds(auth_response.expires_in),
+            user: UserInfo {
+                id: auth_response.user.id,
+                email: auth_response.user.email.unwrap_or(fallback_email),
+                is_tester,
+                is_banned,
+                banned_reason,
+                banned_at,
+            },
+        }
     }
 
     fn store_and_set_session_state(&self, session: AuthSession) -> Result<(), AuthError> {
@@ -289,6 +314,10 @@ impl AuthManager {
                         let _ = self.force_logout();
                         return Err(e);
                     }
+                    if matches!(e, AuthError::UserBanned(_)) {
+                        self.storage.reset_refresh_failures();
+                        return Err(e);
+                    }
 
                     warn!("Token refresh attempt {} failed: {}", attempt, e);
 
@@ -340,6 +369,21 @@ impl AuthManager {
             .await
         {
             Ok(profile) => profile,
+            Err(AuthError::UserBanned(reason)) => {
+                let banned_session = Self::session_from_auth_response(
+                    refresh_response,
+                    session.user.email.clone(),
+                    session.user.is_tester,
+                    true,
+                    Self::reason_from_ban_suffix(&reason),
+                    session.user.banned_at.clone(),
+                );
+                if let Err(e) = self.storage.store_session(&banned_session) {
+                    warn!("Failed to store banned refresh session: {}", e);
+                }
+                self.set_session_state(banned_session);
+                return Err(AuthError::UserBanned(reason));
+            }
             Err(e) => {
                 debug!(
                     "Failed to fetch profile on refresh (keeping old value): {}",
@@ -358,22 +402,14 @@ impl AuthManager {
             }
         };
 
-        Ok(AuthSession {
-            access_token: refresh_response.access_token,
-            refresh_token: refresh_response.refresh_token,
-            expires_at: Utc::now() + Duration::seconds(refresh_response.expires_in),
-            user: UserInfo {
-                id: refresh_response.user.id,
-                email: refresh_response
-                    .user
-                    .email
-                    .unwrap_or_else(|| session.user.email.clone()),
-                is_tester: profile.is_tester,
-                is_banned: profile.is_banned,
-                banned_reason: profile.banned_reason,
-                banned_at: profile.banned_at,
-            },
-        })
+        Ok(Self::session_from_auth_response(
+            refresh_response,
+            session.user.email.clone(),
+            profile.is_tester,
+            profile.is_banned,
+            profile.banned_reason,
+            profile.banned_at,
+        ))
     }
 
     /// Re-fetch the user profile and update the stored session
@@ -731,6 +767,21 @@ impl AuthManager {
                 );
                 profile
             }
+            Err(AuthError::UserBanned(reason)) => {
+                let session = Self::session_from_auth_response(
+                    auth_response,
+                    exchange_response.email,
+                    false,
+                    true,
+                    Self::reason_from_ban_suffix(&reason),
+                    None,
+                );
+                if let Err(e) = self.storage.store_session(&session) {
+                    warn!("Failed to store banned OAuth session: {}", e);
+                }
+                self.set_session_state(session);
+                return Err(AuthError::UserBanned(reason));
+            }
             Err(e) => {
                 error!("Failed to verify user profile after OAuth: {}", e);
                 {
@@ -742,19 +793,14 @@ impl AuthManager {
         };
 
         // Create session
-        let session = AuthSession {
-            access_token: auth_response.access_token,
-            refresh_token: auth_response.refresh_token,
-            expires_at: Utc::now() + Duration::seconds(auth_response.expires_in),
-            user: UserInfo {
-                id: auth_response.user.id,
-                email: auth_response.user.email.unwrap_or(exchange_response.email),
-                is_tester: profile.is_tester,
-                is_banned: profile.is_banned,
-                banned_reason: profile.banned_reason,
-                banned_at: profile.banned_at,
-            },
-        };
+        let session = Self::session_from_auth_response(
+            auth_response,
+            exchange_response.email,
+            profile.is_tester,
+            profile.is_banned,
+            profile.banned_reason,
+            profile.banned_at,
+        );
 
         self.store_and_set_session_state(session.clone())?;
 
@@ -798,6 +844,7 @@ impl Default for AuthManager {
 #[cfg(test)]
 mod tests {
     use super::AuthManager;
+    use crate::auth::types::{SupabaseAuthResponse, SupabaseUser};
     use url::form_urlencoded;
 
     #[test]
@@ -841,6 +888,39 @@ mod tests {
         assert_eq!(
             AuthManager::reason_from_ban_suffix(": chargeback"),
             Some("chargeback".to_string())
+        );
+    }
+
+    #[test]
+    fn auth_response_session_preserves_ban_fields_and_fallback_email() {
+        let response = SupabaseAuthResponse {
+            access_token: "access".to_string(),
+            refresh_token: "refresh".to_string(),
+            expires_in: 3600,
+            expires_at: None,
+            token_type: "bearer".to_string(),
+            user: SupabaseUser {
+                id: "user-1".to_string(),
+                email: None,
+            },
+        };
+
+        let session = AuthManager::session_from_auth_response(
+            response,
+            "fallback@example.com".to_string(),
+            true,
+            true,
+            Some("chargeback".to_string()),
+            Some("2026-05-07T00:00:00.000Z".to_string()),
+        );
+
+        assert_eq!(session.user.email, "fallback@example.com");
+        assert!(session.user.is_tester);
+        assert!(session.user.is_banned);
+        assert_eq!(session.user.banned_reason.as_deref(), Some("chargeback"));
+        assert_eq!(
+            session.user.banned_at.as_deref(),
+            Some("2026-05-07T00:00:00.000Z")
         );
     }
 }

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -154,6 +154,19 @@ impl AuthManager {
         session
     }
 
+    fn fallback_profile(user_id: String) -> UserProfileResponse {
+        UserProfileResponse {
+            id: user_id,
+            full_name: None,
+            username: None,
+            is_admin: false,
+            is_tester: false,
+            is_banned: false,
+            banned_reason: None,
+            banned_at: None,
+        }
+    }
+
     fn session_from_auth_response(
         auth_response: SupabaseAuthResponse,
         fallback_email: String,
@@ -246,10 +259,10 @@ impl AuthManager {
                         return Err(AuthError::UserBanned(reason));
                     }
                     Err(e) => {
-                        error!("Failed to verify user profile during sign-in: {}", e);
-                        let mut state = self.state.lock();
-                        *state = AuthState::Error(e.to_string());
-                        return Err(e);
+                        warn!(
+                            "Failed to fetch user profile during sign-in; continuing with default profile fields: {}",
+                            e
+                        );
                     }
                 }
 
@@ -818,12 +831,11 @@ impl AuthManager {
                 return Err(AuthError::UserBanned(reason));
             }
             Err(e) => {
-                error!("Failed to verify user profile after OAuth: {}", e);
-                {
-                    let mut state = self.state.lock();
-                    *state = AuthState::Error(e.to_string());
-                }
-                return Err(e);
+                warn!(
+                    "Failed to fetch user profile after OAuth; continuing with default profile fields: {}",
+                    e
+                );
+                Self::fallback_profile(auth_response.user.id.clone())
             }
         };
 
@@ -924,6 +936,16 @@ mod tests {
             AuthManager::reason_from_ban_suffix(": chargeback"),
             Some("chargeback".to_string())
         );
+    }
+
+    #[test]
+    fn fallback_profile_is_not_banned_or_tester() {
+        let profile = AuthManager::fallback_profile("user-1".to_string());
+        assert_eq!(profile.id, "user-1");
+        assert!(!profile.is_tester);
+        assert!(!profile.is_banned);
+        assert!(profile.banned_reason.is_none());
+        assert!(profile.banned_at.is_none());
     }
 
     #[test]

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -112,6 +112,22 @@ impl AuthManager {
         }
     }
 
+    pub fn mark_current_session_banned(&self, reason_suffix: &str) -> Result<(), AuthError> {
+        let mut session = match self.get_state() {
+            AuthState::LoggedIn(session) | AuthState::Banned(session) => session,
+            _ => return Err(AuthError::NotAuthenticated),
+        };
+
+        session.user.is_banned = true;
+        session.user.banned_reason = Self::reason_from_ban_suffix(reason_suffix);
+
+        if let Err(e) = self.storage.store_session(&session) {
+            warn!("Failed to store banned session: {}", e);
+        }
+        self.set_session_state(session);
+        Ok(())
+    }
+
     fn ban_suffix(reason: &Option<String>) -> String {
         reason
             .as_ref()

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -119,6 +119,15 @@ impl AuthManager {
             .unwrap_or_default()
     }
 
+    fn reason_from_ban_suffix(suffix: &str) -> Option<String> {
+        let trimmed = suffix.strip_prefix(':').unwrap_or(suffix).trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
     fn session_from_profile(mut session: AuthSession, profile: UserProfileResponse) -> AuthSession {
         session.user.is_tester = profile.is_tester;
         session.user.is_banned = profile.is_banned;
@@ -377,10 +386,20 @@ impl AuthManager {
             _ => return Ok(()),
         };
 
-        let profile = self
-            .client
-            .fetch_user_profile(&session.access_token)
-            .await?;
+        let profile = match self.client.fetch_user_profile(&session.access_token).await {
+            Ok(profile) => profile,
+            Err(AuthError::UserBanned(reason)) => {
+                let mut banned_session = session;
+                banned_session.user.is_banned = true;
+                banned_session.user.banned_reason = Self::reason_from_ban_suffix(&reason);
+                if let Err(e) = self.storage.store_session(&banned_session) {
+                    warn!("Failed to store banned profile session: {}", e);
+                }
+                self.set_session_state(banned_session);
+                return Err(AuthError::UserBanned(reason));
+            }
+            Err(err) => return Err(err),
+        };
         info!(
             "Profile refreshed on startup: is_tester={}, is_banned={}",
             profile.is_tester, profile.is_banned
@@ -812,6 +831,16 @@ mod tests {
         assert_eq!(
             AuthManager::ban_suffix(&Some("  chargeback  ".to_string())),
             ": chargeback"
+        );
+    }
+
+    #[test]
+    fn reason_from_ban_suffix_trims_display_prefix() {
+        assert_eq!(AuthManager::reason_from_ban_suffix(""), None);
+        assert_eq!(AuthManager::reason_from_ban_suffix(":   "), None);
+        assert_eq!(
+            AuthManager::reason_from_ban_suffix(": chargeback"),
+            Some("chargeback".to_string())
         );
     }
 }

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -190,8 +190,12 @@ impl AuthManager {
         match self.client.sign_in_with_password(email, password).await {
             Ok(response) => {
                 let mut user_info = UserInfo {
-                    id: response.user.id,
-                    email: response.user.email.unwrap_or_else(|| email.to_string()),
+                    id: response.user.id.clone(),
+                    email: response
+                        .user
+                        .email
+                        .clone()
+                        .unwrap_or_else(|| email.to_string()),
                     is_tester: false,
                     is_banned: false,
                     banned_reason: None,
@@ -209,6 +213,21 @@ impl AuthManager {
                             "User profile fetched: is_tester={}, is_banned={}",
                             user_info.is_tester, user_info.is_banned
                         );
+                    }
+                    Err(AuthError::UserBanned(reason)) => {
+                        let session = Self::session_from_auth_response(
+                            response,
+                            email.to_string(),
+                            false,
+                            true,
+                            Self::reason_from_ban_suffix(&reason),
+                            None,
+                        );
+                        if let Err(e) = self.storage.store_session(&session) {
+                            warn!("Failed to store banned password session: {}", e);
+                        }
+                        self.set_session_state(session);
+                        return Err(AuthError::UserBanned(reason));
                     }
                     Err(e) => {
                         error!("Failed to verify user profile during sign-in: {}", e);

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -113,6 +113,8 @@ impl AuthManager {
     fn ban_suffix(reason: &Option<String>) -> String {
         reason
             .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
             .map(|value| format!(": {}", value))
             .unwrap_or_default()
     }
@@ -776,6 +778,7 @@ impl Default for AuthManager {
 
 #[cfg(test)]
 mod tests {
+    use super::AuthManager;
     use url::form_urlencoded;
 
     #[test]
@@ -800,5 +803,15 @@ mod tests {
             .finish();
         // Spaces become +, & and = get percent-encoded
         assert_eq!(query, "state=hello+world%26foo%3Dbar");
+    }
+
+    #[test]
+    fn ban_suffix_trims_empty_reasons() {
+        assert_eq!(AuthManager::ban_suffix(&None), "");
+        assert_eq!(AuthManager::ban_suffix(&Some("   ".to_string())), "");
+        assert_eq!(
+            AuthManager::ban_suffix(&Some("  chargeback  ".to_string())),
+            ": chargeback"
+        );
     }
 }

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -1,6 +1,6 @@
 //! Authentication manager - handles login/logout and token management
 
-use super::http_client::AuthClient;
+use super::http_client::{AuthClient, UserProfileResponse};
 use super::oauth_server::{DEFAULT_OAUTH_PORT, OAuthServer, OAuthServerResult};
 use super::storage::SecureStorage;
 use super::types::{AuthError, AuthSession, AuthState, OAuthPendingState, UserInfo};
@@ -54,7 +54,11 @@ impl AuthManager {
                     info!("Session is expired but will be refreshed on first API call.");
                 }
                 info!("========================================");
-                AuthState::LoggedIn(session)
+                if session.user.is_banned {
+                    AuthState::Banned(session)
+                } else {
+                    AuthState::LoggedIn(session)
+                }
             }
             Ok(None) => {
                 info!("No stored session found in Windows Credential Manager.");
@@ -72,6 +76,7 @@ impl AuthManager {
             "AuthManager initialized with state: {:?}",
             match &initial_state {
                 AuthState::LoggedIn(_) => "LoggedIn",
+                AuthState::Banned(_) => "Banned",
                 AuthState::LoggedOut => "LoggedOut",
                 AuthState::LoggingIn => "LoggingIn",
                 AuthState::AwaitingOAuthCallback(_) => "AwaitingOAuthCallback",
@@ -100,8 +105,38 @@ impl AuthManager {
     /// Get the current user info if logged in
     pub fn get_user(&self) -> Option<UserInfo> {
         match self.get_state() {
-            AuthState::LoggedIn(session) => Some(session.user),
+            AuthState::LoggedIn(session) | AuthState::Banned(session) => Some(session.user),
             _ => None,
+        }
+    }
+
+    fn ban_suffix(reason: &Option<String>) -> String {
+        reason
+            .as_ref()
+            .map(|value| format!(": {}", value))
+            .unwrap_or_default()
+    }
+
+    fn session_from_profile(mut session: AuthSession, profile: UserProfileResponse) -> AuthSession {
+        session.user.is_tester = profile.is_tester;
+        session.user.is_banned = profile.is_banned;
+        session.user.banned_reason = profile.banned_reason;
+        session.user.banned_at = profile.banned_at;
+        session
+    }
+
+    fn store_and_set_session_state(&self, session: AuthSession) -> Result<(), AuthError> {
+        self.storage.store_session(&session)?;
+        self.set_session_state(session);
+        Ok(())
+    }
+
+    fn set_session_state(&self, session: AuthSession) {
+        let mut state = self.state.lock();
+        if session.user.is_banned {
+            *state = AuthState::Banned(session);
+        } else {
+            *state = AuthState::LoggedIn(session);
         }
     }
 
@@ -122,16 +157,28 @@ impl AuthManager {
                     id: response.user.id,
                     email: response.user.email.unwrap_or_else(|| email.to_string()),
                     is_tester: false,
+                    is_banned: false,
+                    banned_reason: None,
+                    banned_at: None,
                 };
 
-                // Fetch user profile to get tester status
+                // Fetch user profile to get tester and ban status.
                 match self.client.fetch_user_profile(&response.access_token).await {
                     Ok(profile) => {
                         user_info.is_tester = profile.is_tester;
-                        info!("User profile fetched: is_tester={}", profile.is_tester);
+                        user_info.is_banned = profile.is_banned;
+                        user_info.banned_reason = profile.banned_reason;
+                        user_info.banned_at = profile.banned_at;
+                        info!(
+                            "User profile fetched: is_tester={}, is_banned={}",
+                            user_info.is_tester, user_info.is_banned
+                        );
                     }
                     Err(e) => {
-                        warn!("Failed to fetch user profile (non-fatal): {}", e);
+                        error!("Failed to verify user profile during sign-in: {}", e);
+                        let mut state = self.state.lock();
+                        *state = AuthState::Error(e.to_string());
+                        return Err(e);
                     }
                 }
 
@@ -142,17 +189,17 @@ impl AuthManager {
                     user: user_info,
                 };
 
-                // Store session
-                self.storage.store_session(&session)?;
+                self.store_and_set_session_state(session.clone())?;
 
-                // Update state
-                {
-                    let mut state = self.state.lock();
-                    *state = AuthState::LoggedIn(session);
+                if session.user.is_banned {
+                    warn!("Sign in completed for banned user {}", session.user.id);
+                    Err(AuthError::UserBanned(Self::ban_suffix(
+                        &session.user.banned_reason,
+                    )))
+                } else {
+                    info!("Sign in successful!");
+                    Ok(())
                 }
-
-                info!("Sign in successful!");
-                Ok(())
             }
             Err(e) => {
                 error!("Sign in failed: {}", e);
@@ -175,6 +222,11 @@ impl AuthManager {
     pub async fn refresh_if_needed(&self) -> Result<(), AuthError> {
         let session = match self.get_state() {
             AuthState::LoggedIn(session) => session,
+            AuthState::Banned(session) => {
+                return Err(AuthError::UserBanned(Self::ban_suffix(
+                    &session.user.banned_reason,
+                )));
+            }
             _ => return Err(AuthError::NotAuthenticated),
         };
 
@@ -206,6 +258,12 @@ impl AuthManager {
 
                     {
                         let mut state = self.state.lock();
+                        if new_session.user.is_banned {
+                            let reason = new_session.user.banned_reason.clone();
+                            *state = AuthState::Banned(new_session);
+                            warn!("Token refresh detected banned account");
+                            return Err(AuthError::UserBanned(Self::ban_suffix(&reason)));
+                        }
                         *state = AuthState::LoggedIn(new_session);
                     }
 
@@ -264,19 +322,28 @@ impl AuthManager {
     async fn try_refresh_token(&self, session: &AuthSession) -> Result<AuthSession, AuthError> {
         let refresh_response = self.client.refresh_token(&session.refresh_token).await?;
 
-        // Re-fetch tester status on refresh (in case admin changed it)
-        let is_tester = match self
+        // Re-fetch profile status on refresh (in case admin changed tester or ban status)
+        let profile = match self
             .client
             .fetch_user_profile(&refresh_response.access_token)
             .await
         {
-            Ok(profile) => profile.is_tester,
+            Ok(profile) => profile,
             Err(e) => {
                 debug!(
                     "Failed to fetch profile on refresh (keeping old value): {}",
                     e
                 );
-                session.user.is_tester
+                UserProfileResponse {
+                    id: session.user.id.clone(),
+                    full_name: None,
+                    username: None,
+                    is_admin: false,
+                    is_tester: session.user.is_tester,
+                    is_banned: session.user.is_banned,
+                    banned_reason: session.user.banned_reason.clone(),
+                    banned_at: session.user.banned_at.clone(),
+                }
             }
         };
 
@@ -290,7 +357,10 @@ impl AuthManager {
                     .user
                     .email
                     .unwrap_or_else(|| session.user.email.clone()),
-                is_tester,
+                is_tester: profile.is_tester,
+                is_banned: profile.is_banned,
+                banned_reason: profile.banned_reason,
+                banned_at: profile.banned_at,
             },
         })
     }
@@ -301,7 +371,7 @@ impl AuthManager {
     /// (e.g., tester access granted/revoked) without requiring a full re-login.
     pub async fn refresh_profile(&self) -> Result<(), AuthError> {
         let session = match self.get_state() {
-            AuthState::LoggedIn(session) => session,
+            AuthState::LoggedIn(session) | AuthState::Banned(session) => session,
             _ => return Ok(()),
         };
 
@@ -310,29 +380,27 @@ impl AuthManager {
             .fetch_user_profile(&session.access_token)
             .await?;
         info!(
-            "Profile refreshed on startup: is_tester={}",
-            profile.is_tester
+            "Profile refreshed on startup: is_tester={}, is_banned={}",
+            profile.is_tester, profile.is_banned
         );
 
-        if profile.is_tester != session.user.is_tester {
+        if profile.is_tester != session.user.is_tester
+            || profile.is_banned != session.user.is_banned
+            || profile.banned_reason != session.user.banned_reason
+            || profile.banned_at != session.user.banned_at
+        {
             info!(
-                "Tester status changed: {} -> {}",
-                session.user.is_tester, profile.is_tester
+                "Profile status changed: tester {} -> {}, banned {} -> {}",
+                session.user.is_tester,
+                profile.is_tester,
+                session.user.is_banned,
+                profile.is_banned
             );
-            let updated_session = AuthSession {
-                user: UserInfo {
-                    is_tester: profile.is_tester,
-                    ..session.user
-                },
-                ..session
-            };
-
-            let _ = self.storage.store_session(&updated_session);
-
-            {
-                let mut state = self.state.lock();
-                *state = AuthState::LoggedIn(updated_session);
+            let updated_session = Self::session_from_profile(session, profile);
+            if let Err(e) = self.storage.store_session(&updated_session) {
+                warn!("Failed to store refreshed profile session: {}", e);
             }
+            self.set_session_state(updated_session);
         }
 
         Ok(())
@@ -344,6 +412,9 @@ impl AuthManager {
 
         match self.get_state() {
             AuthState::LoggedIn(session) => Ok(session.access_token),
+            AuthState::Banned(session) => Err(AuthError::UserBanned(Self::ban_suffix(
+                &session.user.banned_reason,
+            ))),
             _ => Err(AuthError::NotAuthenticated),
         }
     }
@@ -626,25 +697,26 @@ impl AuthManager {
             }
         };
 
-        // Fetch user profile to get tester status
-        let is_tester = match self
+        // Fetch user profile to get tester and ban status
+        let profile = match self
             .client
             .fetch_user_profile(&auth_response.access_token)
             .await
         {
             Ok(profile) => {
                 info!(
-                    "User profile fetched after OAuth: is_tester={}",
-                    profile.is_tester
+                    "User profile fetched after OAuth: is_tester={}, is_banned={}",
+                    profile.is_tester, profile.is_banned
                 );
-                profile.is_tester
+                profile
             }
             Err(e) => {
-                warn!(
-                    "Failed to fetch user profile after OAuth (non-fatal): {}",
-                    e
-                );
-                false
+                error!("Failed to verify user profile after OAuth: {}", e);
+                {
+                    let mut state = self.state.lock();
+                    *state = AuthState::Error(e.to_string());
+                }
+                return Err(e);
             }
         };
 
@@ -656,20 +728,20 @@ impl AuthManager {
             user: UserInfo {
                 id: auth_response.user.id,
                 email: auth_response.user.email.unwrap_or(exchange_response.email),
-                is_tester,
+                is_tester: profile.is_tester,
+                is_banned: profile.is_banned,
+                banned_reason: profile.banned_reason,
+                banned_at: profile.banned_at,
             },
         };
 
-        // Store session
-        self.storage.store_session(&session)?;
+        self.store_and_set_session_state(session.clone())?;
 
-        // Update state
-        {
-            let mut state = self.state.lock();
-            *state = AuthState::LoggedIn(session);
+        if session.user.is_banned {
+            warn!("Google OAuth completed for banned user {}", session.user.id);
+        } else {
+            info!("Google OAuth sign-in successful!");
         }
-
-        info!("Google OAuth sign-in successful!");
         Ok(())
     }
 

--- a/swifttunnel-core/src/auth/storage.rs
+++ b/swifttunnel-core/src/auth/storage.rs
@@ -728,6 +728,9 @@ mod tests {
                 id: format!("user_{}", suffix),
                 email: format!("{}@example.com", suffix),
                 is_tester: false,
+                is_banned: false,
+                banned_reason: None,
+                banned_at: None,
             },
         }
     }

--- a/swifttunnel-core/src/auth/types.rs
+++ b/swifttunnel-core/src/auth/types.rs
@@ -14,6 +14,8 @@ pub enum AuthState {
     AwaitingOAuthCallback(OAuthPendingState),
     /// Logged in with valid tokens
     LoggedIn(AuthSession),
+    /// Account is banned; tokens are kept only to display ban details and allow sign-out.
+    Banned(AuthSession),
     /// Error state
     Error(String),
 }
@@ -62,6 +64,13 @@ pub struct UserInfo {
     /// Whether user has tester access (gates experimental features)
     #[serde(default)]
     pub is_tester: bool,
+    /// Whether admin has blocked this account from desktop access.
+    #[serde(default)]
+    pub is_banned: bool,
+    #[serde(default)]
+    pub banned_reason: Option<String>,
+    #[serde(default)]
+    pub banned_at: Option<String>,
 }
 
 /// Supabase auth response
@@ -208,6 +217,9 @@ pub enum AuthError {
 
     #[error("Session expired, please sign in again")]
     RefreshTokenInvalid,
+
+    #[error("Account banned{0}")]
+    UserBanned(String),
 }
 
 #[cfg(test)]
@@ -224,6 +236,9 @@ mod tests {
                 id: "user-1".to_string(),
                 email: "test@example.com".to_string(),
                 is_tester: false,
+                is_banned: false,
+                banned_reason: None,
+                banned_at: None,
             },
         }
     }
@@ -318,6 +333,10 @@ mod tests {
         assert_eq!(
             AuthError::RefreshTokenInvalid.to_string(),
             "Session expired, please sign in again"
+        );
+        assert_eq!(
+            AuthError::UserBanned(": abuse".to_string()).to_string(),
+            "Account banned: abuse"
         );
     }
 

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -908,10 +908,7 @@ impl RobloxOptimizer {
             }
         }
 
-        for client_settings in client_settings_paths {
-            self.apply_client_fflags_in_path(config, &client_settings)?;
-        }
-        Ok(FFlagApplyOutcome::Applied)
+        self.apply_client_fflags_in_paths(config, client_settings_paths)
     }
 
     #[cfg(test)]
@@ -934,9 +931,62 @@ impl RobloxOptimizer {
             }
         }
 
-        for client_settings in client_settings_paths {
-            self.apply_client_fflags_in_path(config, &client_settings)?;
+        self.apply_client_fflags_in_paths(config, client_settings_paths)
+    }
+
+    fn apply_client_fflags_in_paths(
+        &self,
+        config: &RobloxSettingsConfig,
+        client_settings_paths: Vec<PathBuf>,
+    ) -> Result<FFlagApplyOutcome> {
+        let mut applied_any = false;
+        let mut active_failure = None;
+        let mut secondary_failures = Vec::new();
+
+        for (index, client_settings) in client_settings_paths.iter().enumerate() {
+            match self.apply_client_fflags_in_path(config, client_settings) {
+                Ok(_) => {
+                    applied_any = true;
+                }
+                Err(e) => {
+                    let failure = format!("{}: {}", client_settings.display(), e);
+                    warn!(
+                        "Failed to apply FFlags to Roblox version folder {}: {}",
+                        client_settings.display(),
+                        e
+                    );
+                    if index == 0 {
+                        active_failure = Some(failure);
+                    } else {
+                        secondary_failures.push(failure);
+                    }
+                }
+            }
         }
+
+        if let Some(failure) = active_failure {
+            return Err(anyhow::anyhow!(
+                "Failed to apply FFlags to the active Roblox version folder: {}",
+                failure
+            ));
+        }
+
+        if !applied_any {
+            return Err(anyhow::anyhow!(
+                "Failed to apply FFlags to {} Roblox version folder(s): {}",
+                secondary_failures.len(),
+                secondary_failures.join("; ")
+            ));
+        }
+
+        if !secondary_failures.is_empty() {
+            warn!(
+                "Applied FFlags to the active Roblox version, but failed to update {} older Roblox version folder(s): {}",
+                secondary_failures.len(),
+                secondary_failures.join("; ")
+            );
+        }
+
         Ok(FFlagApplyOutcome::Applied)
     }
 
@@ -1584,6 +1634,54 @@ mod tests {
             .join("ClientAppSettings.json");
         let content = fs::read_to_string(good_settings_path).unwrap();
         assert!(content.contains("FFlagDebugGraphicsPreferD3D11"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fflag_apply_reports_success_when_only_older_version_write_fails() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_apply_secondary_error");
+        let _ = fs::remove_dir_all(&dir);
+        let active_settings = dir.join("active").join("ClientSettings");
+        let old_settings = dir.join("old").join("ClientSettings");
+        fs::create_dir_all(&active_settings).unwrap();
+        fs::create_dir_all(old_settings.join("ClientAppSettings.json")).unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let config = RobloxSettingsConfig {
+            ultraboost: true,
+            ..Default::default()
+        };
+
+        let outcome =
+            opt.apply_client_fflags_in_paths(&config, vec![active_settings.clone(), old_settings]);
+
+        assert_eq!(outcome.unwrap(), FFlagApplyOutcome::Applied);
+        let content = fs::read_to_string(active_settings.join("ClientAppSettings.json")).unwrap();
+        assert!(content.contains("FFlagDebugGraphicsPreferD3D11"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fflag_apply_does_not_mask_active_version_write_failure() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_apply_primary_error");
+        let _ = fs::remove_dir_all(&dir);
+        let active_settings = dir.join("active").join("ClientSettings");
+        let old_settings = dir.join("old").join("ClientSettings");
+        fs::create_dir_all(active_settings.join("ClientAppSettings.json")).unwrap();
+        fs::create_dir_all(&old_settings).unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let config = RobloxSettingsConfig {
+            ultraboost: true,
+            ..Default::default()
+        };
+
+        let result = opt.apply_client_fflags_in_paths(&config, vec![active_settings, old_settings]);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("active Roblox"));
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -991,10 +991,16 @@ impl RobloxOptimizer {
             return Ok(());
         }
 
+        let mut failures = Vec::new();
+
         for client_settings in client_settings_paths {
             let settings_path = client_settings.join("ClientAppSettings.json");
 
-            if settings_path.exists() {
+            if !settings_path.exists() {
+                continue;
+            }
+
+            let result = (|| -> Result<()> {
                 let content = fs::read_to_string(&settings_path)?;
                 let mut settings: HashMap<String, serde_json::Value> =
                     serde_json::from_str(&content).unwrap_or_default();
@@ -1015,11 +1021,33 @@ impl RobloxOptimizer {
                     let json = serde_json::to_string_pretty(&settings)?;
                     fs::write(&settings_path, json)?;
                 }
-                info!("FFlag optimizations removed from ClientAppSettings.json");
+                Ok(())
+            })();
+
+            match result {
+                Ok(()) => {
+                    info!("FFlag optimizations removed from ClientAppSettings.json");
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to remove FFlags from {}: {}",
+                        settings_path.display(),
+                        e
+                    );
+                    failures.push(format!("{}: {}", settings_path.display(), e));
+                }
             }
         }
 
-        Ok(())
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Failed to remove FFlags from {} Roblox version folder(s): {}",
+                failures.len(),
+                failures.join("; ")
+            ))
+        }
     }
 
     #[cfg(test)]
@@ -1545,6 +1573,53 @@ mod tests {
             assert!(!content.contains("FFlagDebugGraphicsPreferD3D11"));
             assert!(content.contains("FStringUserOwnedFlag"));
         }
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_all_fflags_continues_after_folder_error() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_remove_partial_error");
+        let _ = fs::remove_dir_all(&dir);
+        let versions_dir = dir.join("Roblox").join("Versions");
+        let broken_version = versions_dir.join("version-broken");
+        let good_version = versions_dir.join("version-good");
+
+        for version in [&broken_version, &good_version] {
+            fs::create_dir_all(version.join("ClientSettings")).unwrap();
+            fs::write(version.join("RobloxPlayerBeta.exe"), "").unwrap();
+        }
+
+        fs::create_dir_all(
+            broken_version
+                .join("ClientSettings")
+                .join("ClientAppSettings.json"),
+        )
+        .unwrap();
+        fs::write(
+            good_version
+                .join("ClientSettings")
+                .join("ClientAppSettings.json"),
+            r#"{
+  "FFlagDebugGraphicsPreferD3D11": "True",
+  "FStringUserOwnedFlag": "keep-me"
+}"#,
+        )
+        .unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let result = opt.remove_all_fflags_in_paths(vec![
+            broken_version.join("ClientSettings"),
+            good_version.join("ClientSettings"),
+        ]);
+
+        assert!(result.is_err());
+        let good_settings_path = good_version
+            .join("ClientSettings")
+            .join("ClientAppSettings.json");
+        let content = fs::read_to_string(good_settings_path).unwrap();
+        assert!(!content.contains("FFlagDebugGraphicsPreferD3D11"));
+        assert!(content.contains("FStringUserOwnedFlag"));
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -755,31 +755,41 @@ impl RobloxOptimizer {
     }
 
     fn find_roblox_version_folder_in(local_app_data: &PathBuf) -> Option<PathBuf> {
+        Self::find_roblox_version_folders_in(local_app_data)
+            .into_iter()
+            .next()
+    }
+
+    fn find_roblox_version_folders() -> Vec<PathBuf> {
+        let Some(local_app_data) = std::env::var("LOCALAPPDATA").ok() else {
+            return Vec::new();
+        };
+        Self::find_roblox_version_folders_in(&PathBuf::from(local_app_data))
+    }
+
+    fn find_roblox_version_folders_in(local_app_data: &PathBuf) -> Vec<PathBuf> {
         let versions_dir = local_app_data.join("Roblox").join("Versions");
 
         if !versions_dir.exists() {
-            return None;
+            return Vec::new();
         }
 
-        // Find the most recently modified version-* folder
-        let mut latest_version: Option<(PathBuf, std::time::SystemTime)> = None;
+        let mut versions: Vec<(PathBuf, std::time::SystemTime)> = Vec::new();
 
         if let Ok(entries) = fs::read_dir(&versions_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.is_dir() {
-                    let name = path.file_name()?.to_string_lossy();
+                    let Some(name) = path.file_name().map(|value| value.to_string_lossy()) else {
+                        continue;
+                    };
                     if name.starts_with("version-") {
-                        // Check if RobloxPlayerBeta.exe exists in this folder
                         if path.join("RobloxPlayerBeta.exe").exists() {
                             if let Ok(metadata) = entry.metadata() {
-                                if let Ok(modified) = metadata.modified() {
-                                    if latest_version.is_none()
-                                        || modified > latest_version.as_ref()?.1
-                                    {
-                                        latest_version = Some((path, modified));
-                                    }
-                                }
+                                let modified = metadata
+                                    .modified()
+                                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                                versions.push((path, modified));
                             }
                         }
                     }
@@ -787,7 +797,8 @@ impl RobloxOptimizer {
             }
         }
 
-        latest_version.map(|(path, _)| path)
+        versions.sort_by(|(_, left), (_, right)| right.cmp(left));
+        versions.into_iter().map(|(path, _)| path).collect()
     }
 
     /// Get the ClientSettings folder path (creates it if needed).
@@ -797,6 +808,11 @@ impl RobloxOptimizer {
             None => return Ok(None),
         };
         Self::get_client_settings_path_for_version(&version_folder)
+    }
+
+    fn get_client_settings_paths(create_missing: bool) -> Result<Vec<PathBuf>> {
+        let version_folders = Self::find_roblox_version_folders();
+        Self::get_client_settings_paths_for_versions(&version_folders, create_missing)
     }
 
     #[cfg(test)]
@@ -811,10 +827,43 @@ impl RobloxOptimizer {
     }
 
     fn get_client_settings_path_for_version(version_folder: &PathBuf) -> Result<Option<PathBuf>> {
+        Self::get_client_settings_path_for_version_checked(version_folder, true)
+    }
+
+    fn get_client_settings_paths_for_versions(
+        version_folders: &[PathBuf],
+        create_missing: bool,
+    ) -> Result<Vec<PathBuf>> {
+        let mut paths = Vec::new();
+        for version_folder in version_folders {
+            if let Some(path) =
+                Self::get_client_settings_path_for_version_checked(version_folder, create_missing)?
+            {
+                paths.push(path);
+            }
+        }
+        Ok(paths)
+    }
+
+    #[cfg(test)]
+    fn get_client_settings_paths_for_local_app_data(
+        local_app_data: &PathBuf,
+        create_missing: bool,
+    ) -> Result<Vec<PathBuf>> {
+        let version_folders = Self::find_roblox_version_folders_in(local_app_data);
+        Self::get_client_settings_paths_for_versions(&version_folders, create_missing)
+    }
+
+    fn get_client_settings_path_for_version_checked(
+        version_folder: &PathBuf,
+        create_missing: bool,
+    ) -> Result<Option<PathBuf>> {
         let client_settings = version_folder.join("ClientSettings");
 
-        // Create ClientSettings folder if it doesn't exist
         if !client_settings.exists() {
+            if !create_missing {
+                return Ok(None);
+            }
             fs::create_dir_all(&client_settings)?;
             info!("Created ClientSettings folder at: {:?}", client_settings);
         } else if !client_settings.is_dir() {
@@ -830,16 +879,23 @@ impl RobloxOptimizer {
     /// When ultraboost is enabled, writes all allowlisted performance FFlags.
     /// Always cleans up old blocked FFlags from previous versions.
     fn apply_client_fflags(&self, config: &RobloxSettingsConfig) -> Result<FFlagApplyOutcome> {
-        match Self::get_client_settings_path()? {
-            Some(client_settings) => self.apply_client_fflags_in_path(config, &client_settings),
-            None if config.ultraboost => Err(anyhow::anyhow!(
-                "Roblox version folder was not found. Launch Roblox once, then apply Ultraboost again."
-            )),
-            None => {
+        let client_settings_paths = Self::get_client_settings_paths(config.ultraboost)?;
+        if client_settings_paths.is_empty() {
+            if config.ultraboost {
+                return Err(anyhow::anyhow!(
+                    "Roblox version folder was not found. Launch Roblox once, then apply Ultraboost again."
+                ));
+            }
+            {
                 info!("No Roblox version folder found, skipping FFlag cleanup");
-                Ok(FFlagApplyOutcome::SkippedMissingRobloxVersion)
+                return Ok(FFlagApplyOutcome::SkippedMissingRobloxVersion);
             }
         }
+
+        for client_settings in client_settings_paths {
+            self.apply_client_fflags_in_path(config, &client_settings)?;
+        }
+        Ok(FFlagApplyOutcome::Applied)
     }
 
     #[cfg(test)]
@@ -848,16 +904,24 @@ impl RobloxOptimizer {
         config: &RobloxSettingsConfig,
         local_app_data: &PathBuf,
     ) -> Result<FFlagApplyOutcome> {
-        match Self::get_client_settings_path_for_local_app_data(local_app_data)? {
-            Some(client_settings) => self.apply_client_fflags_in_path(config, &client_settings),
-            None if config.ultraboost => Err(anyhow::anyhow!(
-                "Roblox version folder was not found. Launch Roblox once, then apply Ultraboost again."
-            )),
-            None => {
+        let client_settings_paths =
+            Self::get_client_settings_paths_for_local_app_data(local_app_data, config.ultraboost)?;
+        if client_settings_paths.is_empty() {
+            if config.ultraboost {
+                return Err(anyhow::anyhow!(
+                    "Roblox version folder was not found. Launch Roblox once, then apply Ultraboost again."
+                ));
+            }
+            {
                 info!("No Roblox version folder found, skipping FFlag cleanup");
-                Ok(FFlagApplyOutcome::SkippedMissingRobloxVersion)
+                return Ok(FFlagApplyOutcome::SkippedMissingRobloxVersion);
             }
         }
+
+        for client_settings in client_settings_paths {
+            self.apply_client_fflags_in_path(config, &client_settings)?;
+        }
+        Ok(FFlagApplyOutcome::Applied)
     }
 
     fn apply_client_fflags_in_path(
@@ -917,41 +981,57 @@ impl RobloxOptimizer {
 
     /// Remove all SwiftTunnel FFlag settings from ClientAppSettings.json
     fn remove_all_fflags(&self) -> Result<()> {
-        let client_settings = match Self::get_client_settings_path()? {
-            Some(path) => path,
-            None => {
-                info!("No Roblox version folder found, skipping FFlag cleanup");
-                return Ok(());
+        let client_settings_paths = Self::get_client_settings_paths(false)?;
+        self.remove_all_fflags_in_paths(client_settings_paths)
+    }
+
+    fn remove_all_fflags_in_paths(&self, client_settings_paths: Vec<PathBuf>) -> Result<()> {
+        if client_settings_paths.is_empty() {
+            info!("No Roblox version folder found, skipping FFlag cleanup");
+            return Ok(());
+        }
+
+        for client_settings in client_settings_paths {
+            let settings_path = client_settings.join("ClientAppSettings.json");
+
+            if settings_path.exists() {
+                let content = fs::read_to_string(&settings_path)?;
+                let mut settings: HashMap<String, serde_json::Value> =
+                    serde_json::from_str(&content).unwrap_or_default();
+
+                // Remove all ultraboost FFlags
+                for (key, _) in Self::ULTRABOOST_FFLAGS {
+                    settings.remove(*key);
+                }
+
+                // Remove old blocked FFlags (legacy cleanup)
+                for key in Self::LEGACY_BLOCKED_FFLAGS {
+                    settings.remove(*key);
+                }
+
+                if settings.is_empty() {
+                    fs::remove_file(&settings_path)?;
+                } else {
+                    let json = serde_json::to_string_pretty(&settings)?;
+                    fs::write(&settings_path, json)?;
+                }
+                info!("FFlag optimizations removed from ClientAppSettings.json");
             }
-        };
-
-        let settings_path = client_settings.join("ClientAppSettings.json");
-
-        if settings_path.exists() {
-            let content = fs::read_to_string(&settings_path)?;
-            let mut settings: HashMap<String, serde_json::Value> =
-                serde_json::from_str(&content).unwrap_or_default();
-
-            // Remove all ultraboost FFlags
-            for (key, _) in Self::ULTRABOOST_FFLAGS {
-                settings.remove(*key);
-            }
-
-            // Remove old blocked FFlags (legacy cleanup)
-            for key in Self::LEGACY_BLOCKED_FFLAGS {
-                settings.remove(*key);
-            }
-
-            if settings.is_empty() {
-                fs::remove_file(&settings_path)?;
-            } else {
-                let json = serde_json::to_string_pretty(&settings)?;
-                fs::write(&settings_path, json)?;
-            }
-            info!("FFlag optimizations removed from ClientAppSettings.json");
         }
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    fn remove_all_fflags_for_local_app_data(&self, local_app_data: &PathBuf) -> Result<()> {
+        let client_settings_paths =
+            Self::get_client_settings_paths_for_local_app_data(local_app_data, false)?;
+        self.remove_all_fflags_in_paths(client_settings_paths)
+    }
+
+    /// Reapply saved ClientAppSettings FFlags after Roblox creates a new version folder.
+    pub fn reapply_saved_client_fflags(&self, config: &RobloxSettingsConfig) -> Result<()> {
+        self.apply_client_fflags(config).map(|_| ())
     }
 }
 
@@ -1362,6 +1442,109 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not a folder"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fflag_apply_updates_all_valid_version_folders() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_all_versions");
+        let _ = fs::remove_dir_all(&dir);
+        let versions_dir = dir.join("Roblox").join("Versions");
+        let old_version = versions_dir.join("version-old");
+        let new_version = versions_dir.join("version-new");
+        fs::create_dir_all(&old_version).unwrap();
+        fs::create_dir_all(&new_version).unwrap();
+        fs::write(old_version.join("RobloxPlayerBeta.exe"), "").unwrap();
+        fs::write(new_version.join("RobloxPlayerBeta.exe"), "").unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let config = RobloxSettingsConfig {
+            ultraboost: true,
+            ..Default::default()
+        };
+
+        let outcome = opt.apply_client_fflags_for_local_app_data(&config, &dir);
+
+        assert_eq!(outcome.unwrap(), FFlagApplyOutcome::Applied);
+        for version in [&old_version, &new_version] {
+            let settings_path = version
+                .join("ClientSettings")
+                .join("ClientAppSettings.json");
+            let content = fs::read_to_string(settings_path).unwrap();
+            assert!(content.contains("FFlagDebugGraphicsPreferD3D11"));
+        }
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fflag_apply_ignores_version_like_folder_without_player_exe() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_ignore_nearmiss");
+        let _ = fs::remove_dir_all(&dir);
+        let versions_dir = dir.join("Roblox").join("Versions");
+        let valid_version = versions_dir.join("version-valid");
+        let near_miss = versions_dir.join("version-without-player");
+        fs::create_dir_all(&valid_version).unwrap();
+        fs::create_dir_all(&near_miss).unwrap();
+        fs::write(valid_version.join("RobloxPlayerBeta.exe"), "").unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let config = RobloxSettingsConfig {
+            ultraboost: true,
+            ..Default::default()
+        };
+
+        opt.apply_client_fflags_for_local_app_data(&config, &dir)
+            .unwrap();
+
+        assert!(
+            valid_version
+                .join("ClientSettings")
+                .join("ClientAppSettings.json")
+                .exists()
+        );
+        assert!(
+            !near_miss.join("ClientSettings").exists(),
+            "version-like folders without RobloxPlayerBeta.exe must not be repaired"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_all_fflags_cleans_every_version_and_preserves_user_flags() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_remove_all_versions");
+        let _ = fs::remove_dir_all(&dir);
+        let versions_dir = dir.join("Roblox").join("Versions");
+        let first_version = versions_dir.join("version-first");
+        let second_version = versions_dir.join("version-second");
+
+        for version in [&first_version, &second_version] {
+            let client_settings = version.join("ClientSettings");
+            fs::create_dir_all(&client_settings).unwrap();
+            fs::write(version.join("RobloxPlayerBeta.exe"), "").unwrap();
+            fs::write(
+                client_settings.join("ClientAppSettings.json"),
+                r#"{
+  "FFlagDebugGraphicsPreferD3D11": "True",
+  "FStringUserOwnedFlag": "keep-me"
+}"#,
+            )
+            .unwrap();
+        }
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        opt.remove_all_fflags_for_local_app_data(&dir).unwrap();
+
+        for version in [&first_version, &second_version] {
+            let settings_path = version
+                .join("ClientSettings")
+                .join("ClientAppSettings.json");
+            let content = fs::read_to_string(settings_path).unwrap();
+            assert!(!content.contains("FFlagDebugGraphicsPreferD3D11"));
+            assert!(content.contains("FStringUserOwnedFlag"));
+        }
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -835,12 +835,14 @@ impl RobloxOptimizer {
         create_missing: bool,
     ) -> Result<Vec<PathBuf>> {
         let mut paths = Vec::new();
+        let mut failures = Vec::new();
         for version_folder in version_folders {
             match Self::get_client_settings_path_for_version_checked(version_folder, create_missing)
             {
                 Ok(Some(path)) => paths.push(path),
                 Ok(None) => {}
                 Err(e) => {
+                    failures.push(format!("{}: {}", version_folder.display(), e));
                     warn!(
                         "Skipping Roblox version folder {} while collecting ClientSettings: {}",
                         version_folder.display(),
@@ -848,6 +850,13 @@ impl RobloxOptimizer {
                     );
                 }
             }
+        }
+        if paths.is_empty() && !failures.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Failed to collect ClientSettings from {} Roblox version folder(s): {}",
+                failures.len(),
+                failures.join("; ")
+            ));
         }
         Ok(paths)
     }

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -836,10 +836,17 @@ impl RobloxOptimizer {
     ) -> Result<Vec<PathBuf>> {
         let mut paths = Vec::new();
         for version_folder in version_folders {
-            if let Some(path) =
-                Self::get_client_settings_path_for_version_checked(version_folder, create_missing)?
+            match Self::get_client_settings_path_for_version_checked(version_folder, create_missing)
             {
-                paths.push(path);
+                Ok(Some(path)) => paths.push(path),
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(
+                        "Skipping Roblox version folder {} while collecting ClientSettings: {}",
+                        version_folder.display(),
+                        e
+                    );
+                }
             }
         }
         Ok(paths)
@@ -1536,6 +1543,38 @@ mod tests {
             !near_miss.join("ClientSettings").exists(),
             "version-like folders without RobloxPlayerBeta.exe must not be repaired"
         );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fflag_apply_skips_broken_legacy_version_folder() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_skip_broken_legacy");
+        let _ = fs::remove_dir_all(&dir);
+        let versions_dir = dir.join("Roblox").join("Versions");
+        let broken_version = versions_dir.join("version-broken");
+        let good_version = versions_dir.join("version-good");
+
+        for version in [&broken_version, &good_version] {
+            fs::create_dir_all(version).unwrap();
+            fs::write(version.join("RobloxPlayerBeta.exe"), "").unwrap();
+        }
+        fs::write(broken_version.join("ClientSettings"), "not a directory").unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let config = RobloxSettingsConfig {
+            ultraboost: true,
+            ..Default::default()
+        };
+
+        let outcome = opt.apply_client_fflags_for_local_app_data(&config, &dir);
+
+        assert_eq!(outcome.unwrap(), FFlagApplyOutcome::Applied);
+        let good_settings_path = good_version
+            .join("ClientSettings")
+            .join("ClientAppSettings.json");
+        let content = fs::read_to_string(good_settings_path).unwrap();
+        assert!(content.contains("FFlagDebugGraphicsPreferD3D11"));
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -16,7 +16,7 @@ use super::process_watcher::{ProcessStartEvent, ProcessWatcher};
 use super::split_tunnel::{SplitTunnelConfig, SplitTunnelDriver};
 use super::{VpnError, VpnResult};
 use crate::auth::http_client::AuthClient;
-use crate::auth::types::{RelayPreflightMode, RelayQueueFullMode, VpnConfig};
+use crate::auth::types::{AuthError, RelayPreflightMode, RelayQueueFullMode, VpnConfig};
 use crate::settings::GameProcessPerformanceSettings;
 use crossbeam_channel::Receiver;
 use std::net::SocketAddr;
@@ -246,6 +246,13 @@ fn select_candidate_after_preflight(
         fallback.addr,
         fallback.queue_full_mode,
     ))
+}
+
+fn relay_ticket_ban_reason(error: &AuthError) -> Option<String> {
+    match error {
+        AuthError::UserBanned(reason) => Some(reason.clone()),
+        _ => None,
+    }
 }
 
 fn pick_lowest_latency_server<'a>(
@@ -1276,6 +1283,13 @@ impl VpnConnection {
                 {
                     Ok(ticket) => ticket,
                     Err(e) => {
+                        if let Some(reason) = relay_ticket_ban_reason(&e) {
+                            log::warn!(
+                                "V3: Relay ticket rejected because the current account is banned"
+                            );
+                            let _ = driver.close();
+                            return Err(VpnError::UserBanned(reason));
+                        }
                         log::warn!(
                             "V3: Relay ticket unavailable for '{}' ({})",
                             candidate_region,
@@ -3617,6 +3631,20 @@ mod tests {
     #[test]
     fn test_average_probe_latency_truncates_fractional_values() {
         assert_eq!(average_probe_latency(&[1, 2, 2]), Some(1));
+    }
+
+    #[test]
+    fn test_relay_ticket_ban_detection_uses_structured_error_only() {
+        assert_eq!(
+            relay_ticket_ban_reason(&AuthError::UserBanned(": abuse".to_string())),
+            Some(": abuse".to_string())
+        );
+        assert_eq!(
+            relay_ticket_ban_reason(&AuthError::ApiError(
+                r#"{"error":"user_banned appears in a log","code":"internal_error"}"#.to_string()
+            )),
+            None
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/error_messages.rs
+++ b/swifttunnel-core/src/vpn/error_messages.rs
@@ -104,6 +104,14 @@ pub fn user_friendly_error(error: &VpnError) -> String {
             "Not signed in.\n\nPlease sign in to continue.".to_string()
         }
 
+        VpnError::UserBanned(reason) => {
+            if reason.is_empty() {
+                "This account is banned.".to_string()
+            } else {
+                format!("This account is banned{}.", reason)
+            }
+        }
+
         // Split tunnel generic
         VpnError::SplitTunnel(msg) => {
             format!("Split tunnel error.\n\n{}", simplify_message(msg))
@@ -154,6 +162,7 @@ pub fn short_error(error: &VpnError) -> &'static str {
         VpnError::ConfigFetch(_) => "Config fetch failed",
         VpnError::InvalidConfig(_) => "Invalid config",
         VpnError::NotAuthenticated => "Not authenticated",
+        VpnError::UserBanned(_) => "Account banned",
         VpnError::SplitTunnel(_) => "Split tunnel error",
         VpnError::Io(_) => "System error",
     }
@@ -216,5 +225,13 @@ mod tests {
     fn test_short_error() {
         let error = VpnError::NotAuthenticated;
         assert_eq!(short_error(&error), "Not authenticated");
+    }
+
+    #[test]
+    fn test_user_friendly_user_banned() {
+        let error = VpnError::UserBanned(": abuse".to_string());
+        let msg = user_friendly_error(&error);
+        assert_eq!(msg, "This account is banned: abuse.");
+        assert_eq!(short_error(&error), "Account banned");
     }
 }

--- a/swifttunnel-core/src/vpn/mod.rs
+++ b/swifttunnel-core/src/vpn/mod.rs
@@ -94,6 +94,9 @@ pub enum VpnError {
     #[error("Not authenticated")]
     NotAuthenticated,
 
+    #[error("Account banned{0}")]
+    UserBanned(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -174,6 +177,12 @@ mod tests {
     fn test_vpn_error_display_not_authenticated() {
         let err = VpnError::NotAuthenticated;
         assert_eq!(err.to_string(), "Not authenticated");
+    }
+
+    #[test]
+    fn test_vpn_error_display_user_banned() {
+        let err = VpnError::UserBanned(": chargeback".to_string());
+        assert_eq!(err.to_string(), "Account banned: chargeback");
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -89,6 +89,7 @@ pub(crate) async fn emit_auth_state(app: &AppHandle, state: &AppState) {
         state: response.state,
         email: response.email,
         user_id: response.user_id,
+        is_tester: response.is_tester,
         is_banned: response.is_banned,
         banned_reason: response.banned_reason,
         banned_at: response.banned_at,

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -3,7 +3,7 @@ use tauri::{AppHandle, Emitter, State};
 
 use crate::events::{AUTH_STATE_CHANGED, AuthStateEvent};
 use crate::state::AppState;
-use swifttunnel_core::auth::types::AuthState;
+use swifttunnel_core::auth::types::{AuthError, AuthState};
 
 #[derive(Serialize)]
 pub struct AuthStateResponse {
@@ -252,9 +252,11 @@ pub async fn auth_refresh_profile(
     app: AppHandle,
 ) -> Result<(), String> {
     let auth = state.auth_manager.lock().await;
-    let result = auth.refresh_profile().await.map_err(|e| e.to_string());
+    let refresh_result = auth.refresh_profile().await;
+    let should_run_ban_cleanup = matches!(refresh_result, Ok(()) | Err(AuthError::UserBanned(_)));
+    let result = refresh_result.map_err(|e| e.to_string());
     drop(auth);
-    let emitted = result.is_ok() && apply_ban_cleanup(&app, &state).await;
+    let emitted = should_run_ban_cleanup && apply_ban_cleanup(&app, &state).await;
     if !emitted {
         emit_auth_state(&app, &state).await;
     }

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -211,12 +211,11 @@ pub async fn auth_complete_oauth(
     callback_state: String,
 ) -> Result<(), String> {
     let auth = state.auth_manager.lock().await;
-    let result = auth
-        .complete_oauth_callback(&token, &callback_state)
-        .await
-        .map_err(|e| e.to_string());
+    let complete_result = auth.complete_oauth_callback(&token, &callback_state).await;
+    let should_run_ban_cleanup = matches!(complete_result, Ok(()) | Err(AuthError::UserBanned(_)));
+    let result = complete_result.map_err(|e| e.to_string());
     drop(auth);
-    let emitted = result.is_ok() && apply_ban_cleanup(&app, &state).await;
+    let emitted = should_run_ban_cleanup && apply_ban_cleanup(&app, &state).await;
     if !emitted {
         emit_auth_state(&app, &state).await;
     }

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -4,7 +4,6 @@ use tauri::{AppHandle, Emitter, State};
 use crate::events::{AUTH_STATE_CHANGED, AuthStateEvent};
 use crate::state::AppState;
 use swifttunnel_core::auth::types::AuthState;
-use swifttunnel_core::structs::Config;
 
 #[derive(Serialize)]
 pub struct AuthStateResponse {
@@ -133,7 +132,6 @@ pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
 
     let snapshot = {
         let mut settings = state.settings.lock();
-        settings.config = Config::default();
         settings.resume_vpn_on_startup = false;
         settings.clone()
     };
@@ -145,10 +143,12 @@ pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
     true
 }
 
-async fn apply_ban_cleanup(app: &AppHandle, state: &AppState) {
+async fn apply_ban_cleanup(app: &AppHandle, state: &AppState) -> bool {
     if cleanup_banned_session(state).await {
         emit_auth_state(app, state).await;
+        return true;
     }
+    false
 }
 
 #[tauri::command]
@@ -216,10 +216,10 @@ pub async fn auth_complete_oauth(
         .await
         .map_err(|e| e.to_string());
     drop(auth);
-    if result.is_ok() {
-        apply_ban_cleanup(&app, &state).await;
+    let emitted = result.is_ok() && apply_ban_cleanup(&app, &state).await;
+    if !emitted {
+        emit_auth_state(&app, &state).await;
     }
-    emit_auth_state(&app, &state).await;
     result
 }
 
@@ -254,9 +254,9 @@ pub async fn auth_refresh_profile(
     let auth = state.auth_manager.lock().await;
     let result = auth.refresh_profile().await.map_err(|e| e.to_string());
     drop(auth);
-    if result.is_ok() {
-        apply_ban_cleanup(&app, &state).await;
+    let emitted = result.is_ok() && apply_ban_cleanup(&app, &state).await;
+    if !emitted {
+        emit_auth_state(&app, &state).await;
     }
-    emit_auth_state(&app, &state).await;
     result
 }

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -3,6 +3,8 @@ use tauri::{AppHandle, Emitter, State};
 
 use crate::events::{AUTH_STATE_CHANGED, AuthStateEvent};
 use crate::state::AppState;
+use swifttunnel_core::auth::types::AuthState;
+use swifttunnel_core::structs::Config;
 
 #[derive(Serialize)]
 pub struct AuthStateResponse {
@@ -10,44 +12,75 @@ pub struct AuthStateResponse {
     pub email: Option<String>,
     pub user_id: Option<String>,
     pub is_tester: bool,
+    pub is_banned: bool,
+    pub banned_reason: Option<String>,
+    pub banned_at: Option<String>,
 }
 
-fn map_auth_state(auth_state: swifttunnel_core::auth::types::AuthState) -> AuthStateResponse {
+fn map_auth_state(auth_state: AuthState) -> AuthStateResponse {
     match auth_state {
-        swifttunnel_core::auth::types::AuthState::LoggedIn(session) => AuthStateResponse {
+        AuthState::LoggedIn(session) => AuthStateResponse {
             state: "logged_in".to_string(),
             email: Some(session.user.email),
             user_id: Some(session.user.id),
             is_tester: session.user.is_tester,
+            is_banned: false,
+            banned_reason: None,
+            banned_at: None,
         },
-        swifttunnel_core::auth::types::AuthState::LoggedOut => AuthStateResponse {
+        AuthState::Banned(session) => AuthStateResponse {
+            state: "banned".to_string(),
+            email: Some(session.user.email),
+            user_id: Some(session.user.id),
+            is_tester: false,
+            is_banned: true,
+            banned_reason: session.user.banned_reason,
+            banned_at: session.user.banned_at,
+        },
+        AuthState::LoggedOut => AuthStateResponse {
             state: "logged_out".to_string(),
             email: None,
             user_id: None,
             is_tester: false,
+            is_banned: false,
+            banned_reason: None,
+            banned_at: None,
         },
-        swifttunnel_core::auth::types::AuthState::LoggingIn => AuthStateResponse {
+        AuthState::LoggingIn => AuthStateResponse {
             state: "logging_in".to_string(),
             email: None,
             user_id: None,
             is_tester: false,
+            is_banned: false,
+            banned_reason: None,
+            banned_at: None,
         },
-        swifttunnel_core::auth::types::AuthState::AwaitingOAuthCallback(_) => AuthStateResponse {
+        AuthState::AwaitingOAuthCallback(_) => AuthStateResponse {
             state: "awaiting_oauth".to_string(),
             email: None,
             user_id: None,
             is_tester: false,
+            is_banned: false,
+            banned_reason: None,
+            banned_at: None,
         },
-        swifttunnel_core::auth::types::AuthState::Error(msg) => AuthStateResponse {
+        AuthState::Error(msg) => AuthStateResponse {
             state: format!("error:{}", msg),
             email: None,
             user_id: None,
             is_tester: false,
+            is_banned: false,
+            banned_reason: None,
+            banned_at: None,
         },
     }
 }
 
-async fn emit_auth_state(app: &AppHandle, state: &AppState) {
+fn is_auth_banned(auth_state: &AuthState) -> bool {
+    matches!(auth_state, AuthState::Banned(_))
+}
+
+pub(crate) async fn emit_auth_state(app: &AppHandle, state: &AppState) {
     let auth = state.auth_manager.lock().await;
     let auth_state = auth.get_state();
     let response = map_auth_state(auth_state);
@@ -57,8 +90,65 @@ async fn emit_auth_state(app: &AppHandle, state: &AppState) {
         state: response.state,
         email: response.email,
         user_id: response.user_id,
+        is_banned: response.is_banned,
+        banned_reason: response.banned_reason,
+        banned_at: response.banned_at,
     };
     let _ = app.emit(AUTH_STATE_CHANGED, payload);
+}
+
+pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
+    let auth_state = {
+        let auth = state.auth_manager.lock().await;
+        auth.get_state()
+    };
+
+    if !is_auth_banned(&auth_state) {
+        return false;
+    }
+
+    log::warn!("Account is banned; disconnecting VPN and restoring saved boosts");
+
+    if let Err(e) = crate::commands::vpn::disconnect_and_persist(state).await {
+        log::warn!("Failed to disconnect VPN after ban detection: {}", e);
+    }
+
+    let roblox_pid = {
+        let mut monitor = state.performance_monitor.lock();
+        monitor.get_roblox_pid().unwrap_or(0)
+    };
+
+    if let Err(e) = state.system_optimizer.lock().restore(roblox_pid) {
+        log::warn!("Failed to restore system boosts after ban detection: {}", e);
+    }
+    if let Err(e) = state.network_booster.lock().restore() {
+        log::warn!(
+            "Failed to restore network boosts after ban detection: {}",
+            e
+        );
+    }
+    if let Err(e) = state.roblox_optimizer.lock().restore_settings() {
+        log::warn!("Failed to restore Roblox boosts after ban detection: {}", e);
+    }
+
+    let snapshot = {
+        let mut settings = state.settings.lock();
+        settings.config = Config::default();
+        settings.resume_vpn_on_startup = false;
+        settings.clone()
+    };
+
+    if let Err(e) = swifttunnel_core::settings::save_settings(&snapshot) {
+        log::warn!("Failed to persist boost cleanup after ban detection: {}", e);
+    }
+
+    true
+}
+
+async fn apply_ban_cleanup(app: &AppHandle, state: &AppState) {
+    if cleanup_banned_session(state).await {
+        emit_auth_state(app, state).await;
+    }
 }
 
 #[tauri::command]
@@ -126,6 +216,9 @@ pub async fn auth_complete_oauth(
         .await
         .map_err(|e| e.to_string());
     drop(auth);
+    if result.is_ok() {
+        apply_ban_cleanup(&app, &state).await;
+    }
     emit_auth_state(&app, &state).await;
     result
 }
@@ -161,6 +254,9 @@ pub async fn auth_refresh_profile(
     let auth = state.auth_manager.lock().await;
     let result = auth.refresh_profile().await.map_err(|e| e.to_string());
     drop(auth);
+    if result.is_ok() {
+        apply_ban_cleanup(&app, &state).await;
+    }
     emit_auth_state(&app, &state).await;
     result
 }

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -144,7 +144,7 @@ pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
     true
 }
 
-async fn apply_ban_cleanup(app: &AppHandle, state: &AppState) -> bool {
+pub(crate) async fn apply_ban_cleanup(app: &AppHandle, state: &AppState) -> bool {
     if cleanup_banned_session(state).await {
         emit_auth_state(app, state).await;
         return true;

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -6,9 +6,11 @@ use tauri::{AppHandle, Emitter, State};
 
 use crate::events::{SERVER_LIST_UPDATED, VPN_STATE_CHANGED, VpnStateEvent};
 use crate::state::AppState;
+use swifttunnel_core::auth::types::AuthError;
 use swifttunnel_core::settings::AdapterBindingMode;
 use swifttunnel_core::vpn::{
-    AdapterBindingPreference, BindingPreferenceSource, BindingPreflightInfo, preflight_binding,
+    AdapterBindingPreference, BindingPreferenceSource, BindingPreflightInfo, VpnError,
+    preflight_binding,
 };
 
 const VPN_CONNECT_COMMAND_TIMEOUT: Duration = Duration::from_secs(90);
@@ -216,6 +218,37 @@ fn persist_session_settings(
     swifttunnel_core::settings::save_settings(&snapshot)
 }
 
+fn vpn_error_is_user_banned(error: &VpnError) -> bool {
+    matches!(error, VpnError::UserBanned(_))
+}
+
+async fn emit_ban_cleanup(app: &AppHandle, state: &AppState) {
+    let emitted = crate::commands::auth::apply_ban_cleanup(app, state).await;
+    if !emitted {
+        crate::commands::auth::emit_auth_state(app, state).await;
+    }
+}
+
+async fn mark_and_emit_ban_cleanup(app: &AppHandle, state: &AppState, reason: &str) {
+    let mark_result = {
+        let auth = state.auth_manager.lock().await;
+        auth.mark_current_session_banned(reason)
+    };
+    if let Err(e) = mark_result {
+        log::warn!("Failed to mark session banned after VPN ban signal: {}", e);
+    }
+
+    emit_ban_cleanup(app, state).await;
+}
+
+async fn handle_connect_auth_error(app: &AppHandle, state: &AppState, error: AuthError) -> String {
+    let message = error.to_string();
+    if let AuthError::UserBanned(reason) = error {
+        mark_and_emit_ban_cleanup(app, state, &reason).await;
+    }
+    message
+}
+
 /// Tear down the live VPN session and drop all in-memory state that points at
 /// it. Always clears the published split-tunnel handle, sets Discord idle, and
 /// persists the disconnected session — even when the driver-level disconnect
@@ -330,6 +363,7 @@ pub async fn vpn_preflight_binding(
 #[tauri::command]
 pub async fn vpn_connect(
     state: State<'_, AppState>,
+    app: AppHandle,
     region: String,
     game_presets: Vec<String>,
 ) -> Result<(), String> {
@@ -409,7 +443,13 @@ pub async fn vpn_connect(
     // Get access token
     let access_token = {
         let auth = state.auth_manager.lock().await;
-        auth.get_access_token().await.map_err(|e| e.to_string())?
+        match auth.get_access_token().await {
+            Ok(token) => token,
+            Err(e) => {
+                drop(auth);
+                return Err(handle_connect_auth_error(&app, &state, e).await);
+            }
+        }
     };
 
     let mut vpn = state.vpn_connection.lock().await;
@@ -432,8 +472,16 @@ pub async fn vpn_connect(
     )
     .await;
 
+    let mut connect_ban_reason = None;
     let result = match connect_result {
-        Ok(result) => result.map_err(|e| swifttunnel_core::vpn::user_friendly_error(&e)),
+        Ok(result) => result.map_err(|e| {
+            if vpn_error_is_user_banned(&e) {
+                if let VpnError::UserBanned(reason) = &e {
+                    connect_ban_reason = Some(reason.clone());
+                }
+            }
+            swifttunnel_core::vpn::user_friendly_error(&e)
+        }),
         Err(_) => {
             log::error!(
                 "vpn_connect timed out after {}s; cleaning up partial tunnel state",
@@ -464,6 +512,10 @@ pub async fn vpn_connect(
         *state.split_tunnel_handle.write() = None;
     }
     drop(vpn);
+
+    if let Some(reason) = connect_ban_reason {
+        mark_and_emit_ban_cleanup(&app, &state, &reason).await;
+    }
 
     let discord_region = if result.is_ok() {
         let conn_state = state.vpn_state_handle.borrow().clone();
@@ -950,6 +1002,16 @@ mod tests {
             ServerListSource::Api,
         );
         list
+    }
+
+    #[test]
+    fn vpn_ban_detection_uses_typed_error_only() {
+        assert!(vpn_error_is_user_banned(&VpnError::UserBanned(
+            ": chargeback".to_string()
+        )));
+        assert!(!vpn_error_is_user_banned(&VpnError::Connection(
+            "Account banned appears in unrelated text".to_string()
+        )));
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/events.rs
+++ b/swifttunnel-desktop/src-tauri/src/events.rs
@@ -24,6 +24,7 @@ pub struct AuthStateEvent {
     pub state: String,
     pub email: Option<String>,
     pub user_id: Option<String>,
+    pub is_tester: bool,
     pub is_banned: bool,
     pub banned_reason: Option<String>,
     pub banned_at: Option<String>,

--- a/swifttunnel-desktop/src-tauri/src/events.rs
+++ b/swifttunnel-desktop/src-tauri/src/events.rs
@@ -24,6 +24,9 @@ pub struct AuthStateEvent {
     pub state: String,
     pub email: Option<String>,
     pub user_id: Option<String>,
+    pub is_banned: bool,
+    pub banned_reason: Option<String>,
+    pub banned_at: Option<String>,
 }
 
 /// Throughput stats event payload

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use log::{info, warn};
 use state::AppState;
+use swifttunnel_core::auth::types::AuthState;
 use tauri::{Emitter, Manager};
 use window_restore::restore_main_window;
 
@@ -257,6 +258,30 @@ fn reapply_saved_network_boosts(state: &AppState) {
 #[cfg(not(windows))]
 fn reapply_saved_network_boosts(_state: &AppState) {}
 
+#[cfg(windows)]
+fn reapply_saved_roblox_fflags(state: &AppState) {
+    let roblox_config = {
+        let settings = state.settings.lock();
+        settings.config.roblox_settings.clone()
+    };
+
+    if !roblox_config.ultraboost {
+        return;
+    }
+
+    info!("Reapplying saved Roblox FFlags on startup");
+    if let Err(e) = state
+        .roblox_optimizer
+        .lock()
+        .reapply_saved_client_fflags(&roblox_config)
+    {
+        warn!("Failed to reapply saved Roblox FFlags on startup: {}", e);
+    }
+}
+
+#[cfg(not(windows))]
+fn reapply_saved_roblox_fflags(_state: &AppState) {}
+
 pub fn run() {
     logging::init();
     let launched_from_startup = autostart::launched_from_startup_flag();
@@ -346,9 +371,41 @@ pub fn run() {
             let app_state = AppState::new(runtime.clone(), launched_from_startup)
                 .expect("Failed to initialize app state");
 
-            // Recover network booster state from persisted snapshot (crash recovery)
-            app_state.network_booster.lock().recover_from_snapshot();
-            reapply_saved_network_boosts(&app_state);
+            let account_is_banned = runtime.block_on(async {
+                let auth = app_state.auth_manager.lock().await;
+                if matches!(
+                    auth.get_state(),
+                    AuthState::LoggedIn(_) | AuthState::Banned(_)
+                ) {
+                    info!("Refreshing user profile before saved boost recovery");
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(8),
+                        auth.refresh_profile(),
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            warn!("Failed to refresh profile before boost recovery: {}", e);
+                        }
+                        Err(_) => {
+                            warn!("Timed out refreshing profile before boost recovery");
+                        }
+                    }
+                }
+
+                matches!(auth.get_state(), AuthState::Banned(_))
+            });
+
+            if account_is_banned {
+                info!("Stored account is banned; clearing boosts before startup recovery");
+                runtime.block_on(commands::auth::cleanup_banned_session(&app_state));
+            } else {
+                // Recover network booster state from persisted snapshot (crash recovery)
+                app_state.network_booster.lock().recover_from_snapshot();
+                reapply_saved_network_boosts(&app_state);
+                reapply_saved_roblox_fflags(&app_state);
+            }
 
             let run_on_startup_enabled = app_state.settings.lock().run_on_startup;
             let vpn_state_rx = app_state.vpn_state_handle.clone();
@@ -403,11 +460,25 @@ pub fn run() {
             let app_handle = app.handle().clone();
             runtime.spawn(async move {
                 if let Some(state) = app_handle.try_state::<AppState>() {
-                    let auth = state.auth_manager.lock().await;
-                    if auth.is_logged_in() {
+                    let should_refresh = {
+                        let auth = state.auth_manager.lock().await;
+                        matches!(
+                            auth.get_state(),
+                            AuthState::LoggedIn(_) | AuthState::Banned(_)
+                        )
+                    };
+
+                    if should_refresh {
                         info!("Refreshing user profile on startup...");
-                        if let Err(e) = auth.refresh_profile().await {
+                        let auth = state.auth_manager.lock().await;
+                        let result = auth.refresh_profile().await;
+                        drop(auth);
+
+                        if let Err(e) = result {
                             log::warn!("Failed to refresh profile on startup: {}", e);
+                        } else {
+                            commands::auth::cleanup_banned_session(&state).await;
+                            commands::auth::emit_auth_state(&app_handle, &state).await;
                         }
                     }
                 }

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use log::{info, warn};
 use state::AppState;
-use swifttunnel_core::auth::types::AuthState;
+use swifttunnel_core::auth::types::{AuthError, AuthState};
 use tauri::{Emitter, Manager};
 use window_restore::restore_main_window;
 
@@ -474,9 +474,15 @@ pub fn run() {
                         let result = auth.refresh_profile().await;
                         drop(auth);
 
-                        if let Err(e) = result {
-                            log::warn!("Failed to refresh profile on startup: {}", e);
-                        } else {
+                        let should_emit_state =
+                            matches!(result, Ok(()) | Err(AuthError::UserBanned(_)));
+                        if let Err(e) = &result {
+                            if !matches!(e, AuthError::UserBanned(_)) {
+                                log::warn!("Failed to refresh profile on startup: {}", e);
+                            }
+                        }
+
+                        if should_emit_state {
                             commands::auth::cleanup_banned_session(&state).await;
                             commands::auth::emit_auth_state(&app_handle, &state).await;
                         }

--- a/swifttunnel-desktop/src/App.tsx
+++ b/swifttunnel-desktop/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tauri-apps/api/window";
 import { AppShell } from "./components/shell/AppShell";
 import { LoginScreen } from "./components/auth/LoginScreen";
+import { BannedScreen } from "./components/auth/BannedScreen";
 import { ConnectTab } from "./components/connect/ConnectTab";
 import { BoostTab } from "./components/boost/BoostTab";
 import { NetworkTab } from "./components/network/NetworkTab";
@@ -48,6 +49,7 @@ function App() {
   const authState = useAuthStore((s) => s.state);
   const isLoading = useAuthStore((s) => s.isLoading);
   const fetchAuth = useAuthStore((s) => s.fetchState);
+  const refreshAuthProfile = useAuthStore((s) => s.refreshProfile);
   const isSettingsLoaded = useSettingsStore((s) => s.isLoaded);
   const setTab = useSettingsStore((s) => s.setTab);
   const updateSettings = useSettingsStore((s) => s.update);
@@ -70,6 +72,7 @@ function App() {
         fetchServers,
         fetchSystemInfo,
         fetchVpnState,
+        refreshAuthProfile,
         getSettings: () => useSettingsStore.getState().settings,
         getAuthState: () => useAuthStore.getState().state,
         getVpnState: () => useVpnStore.getState().state,
@@ -107,6 +110,7 @@ function App() {
     fetchServers,
     fetchSystemInfo,
     fetchVpnState,
+    refreshAuthProfile,
     connectVpn,
     checkForUpdates,
   ]);
@@ -306,6 +310,10 @@ function App() {
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-accent-primary border-t-transparent" />
       </div>
     );
+  }
+
+  if (authState === "banned") {
+    return <BannedScreen />;
   }
 
   if (authState !== "logged_in") {

--- a/swifttunnel-desktop/src/components/auth/BannedScreen.test.ts
+++ b/swifttunnel-desktop/src/components/auth/BannedScreen.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatBannedAt } from "./BannedScreen";
+
+describe("BannedScreen", () => {
+  it("formats valid ban timestamps", () => {
+    expect(formatBannedAt("2026-05-07T13:55:59.000Z")).toBeTruthy();
+  });
+
+  it("hides malformed ban timestamps", () => {
+    expect(formatBannedAt("null")).toBeNull();
+    expect(formatBannedAt("not-a-date")).toBeNull();
+    expect(formatBannedAt(null)).toBeNull();
+  });
+});

--- a/swifttunnel-desktop/src/components/auth/BannedScreen.tsx
+++ b/swifttunnel-desktop/src/components/auth/BannedScreen.tsx
@@ -8,6 +8,7 @@ export function BannedScreen() {
   const email = useAuthStore((s) => s.email);
   const reason = useAuthStore((s) => s.bannedReason);
   const bannedAt = useAuthStore((s) => s.bannedAt);
+  const error = useAuthStore((s) => s.error);
   const logout = useAuthStore((s) => s.logout);
   const refreshProfile = useAuthStore((s) => s.refreshProfile);
   const [refreshing, setRefreshing] = useState(false);
@@ -110,6 +111,12 @@ export function BannedScreen() {
             </div>
           )}
         </motion.div>
+
+        {error && (
+          <p className="text-center text-[11px] leading-5 text-status-error">
+            {error}
+          </p>
+        )}
 
         <div className="grid grid-cols-2 gap-3">
           <Button

--- a/swifttunnel-desktop/src/components/auth/BannedScreen.tsx
+++ b/swifttunnel-desktop/src/components/auth/BannedScreen.tsx
@@ -4,6 +4,19 @@ import { useAuthStore } from "../../stores/authStore";
 import { Button, Spinner } from "../ui";
 import swiftLogo from "../../assets/swift.png";
 
+export function formatBannedAt(bannedAt: string | null) {
+  if (!bannedAt) {
+    return null;
+  }
+
+  const date = new Date(bannedAt);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleString();
+}
+
 export function BannedScreen() {
   const email = useAuthStore((s) => s.email);
   const reason = useAuthStore((s) => s.bannedReason);
@@ -12,6 +25,7 @@ export function BannedScreen() {
   const logout = useAuthStore((s) => s.logout);
   const refreshProfile = useAuthStore((s) => s.refreshProfile);
   const [refreshing, setRefreshing] = useState(false);
+  const formattedBannedAt = formatBannedAt(bannedAt);
 
   const refresh = async () => {
     setRefreshing(true);
@@ -102,11 +116,11 @@ export function BannedScreen() {
               </p>
             </div>
           )}
-          {bannedAt && (
+          {formattedBannedAt && (
             <div className="flex items-center justify-between gap-3">
               <span className="text-[11px] text-text-muted">Banned</span>
               <span className="font-mono text-[11px] text-text-primary">
-                {new Date(bannedAt).toLocaleString()}
+                {formattedBannedAt}
               </span>
             </div>
           )}

--- a/swifttunnel-desktop/src/components/auth/BannedScreen.tsx
+++ b/swifttunnel-desktop/src/components/auth/BannedScreen.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { useAuthStore } from "../../stores/authStore";
+import { Button, Spinner } from "../ui";
+import swiftLogo from "../../assets/swift.png";
+
+export function BannedScreen() {
+  const email = useAuthStore((s) => s.email);
+  const reason = useAuthStore((s) => s.bannedReason);
+  const bannedAt = useAuthStore((s) => s.bannedAt);
+  const logout = useAuthStore((s) => s.logout);
+  const refreshProfile = useAuthStore((s) => s.refreshProfile);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const refresh = async () => {
+    setRefreshing(true);
+    try {
+      await refreshProfile();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <div
+      data-tauri-drag-region
+      className="flex h-screen w-screen items-center justify-center"
+      style={{ backgroundColor: "var(--color-bg-base)" }}
+    >
+      <div className="flex w-full max-w-[380px] flex-col gap-6 px-8">
+        <motion.div
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3 }}
+          className="flex flex-col items-center gap-3 text-center"
+        >
+          <img
+            src={swiftLogo}
+            alt="SwiftTunnel"
+            width={110}
+            height={110}
+            style={{ objectFit: "contain", filter: "grayscale(0.35)" }}
+          />
+          <div
+            className="flex h-11 w-11 items-center justify-center rounded-[6px]"
+            style={{
+              backgroundColor: "rgba(244, 63, 94, 0.10)",
+              border: "1px solid rgba(244, 63, 94, 0.25)",
+            }}
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="rgb(251, 113, 133)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="m4.9 4.9 14.2 14.2" />
+            </svg>
+          </div>
+          <div>
+            <p className="font-mono text-[9.5px] font-semibold uppercase tracking-[0.18em] text-status-error">
+              Access blocked
+            </p>
+            <h1 className="mt-2 text-[22px] font-semibold text-text-primary">
+              Account banned
+            </h1>
+            <p className="mt-2 text-[12px] leading-5 text-text-muted">
+              This SwiftTunnel account cannot use the desktop app.
+            </p>
+          </div>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3, delay: 0.05 }}
+          className="space-y-3 rounded-[var(--radius-card)] p-5"
+          style={{
+            backgroundColor: "var(--color-bg-card)",
+            border: "1px solid var(--color-border-subtle)",
+          }}
+        >
+          {email && (
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-[11px] text-text-muted">Account</span>
+              <span className="truncate text-right font-mono text-[11px] text-text-primary">
+                {email}
+              </span>
+            </div>
+          )}
+          {reason && (
+            <div className="space-y-1">
+              <span className="text-[11px] text-text-muted">Reason</span>
+              <p className="text-[12px] leading-5 text-text-primary">
+                {reason}
+              </p>
+            </div>
+          )}
+          {bannedAt && (
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-[11px] text-text-muted">Banned</span>
+              <span className="font-mono text-[11px] text-text-primary">
+                {new Date(bannedAt).toLocaleString()}
+              </span>
+            </div>
+          )}
+        </motion.div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={refresh}
+            disabled={refreshing}
+            leadingIcon={
+              refreshing ? (
+                <Spinner size={14} color="currentColor" />
+              ) : (
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+                  <path d="M3 21v-5h5" />
+                  <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+                  <path d="M16 8h5V3" />
+                </svg>
+              )
+            }
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={logout}
+            leadingIcon={
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+            }
+          >
+            Sign out
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/swifttunnel-desktop/src/lib/appBootstrap.test.ts
+++ b/swifttunnel-desktop/src/lib/appBootstrap.test.ts
@@ -34,11 +34,11 @@ describe("app bootstrap", () => {
     });
 
     expect(initEventListeners).toHaveBeenCalledTimes(1);
-    expect(fetchAuth).toHaveBeenCalledTimes(1);
     expect(loadSettings).toHaveBeenCalledTimes(1);
     expect(fetchServers).toHaveBeenCalledTimes(1);
     expect(fetchSystemInfo).toHaveBeenCalledTimes(1);
-    expect(fetchVpnState).toHaveBeenCalledTimes(1);
+    expect(fetchAuth).toHaveBeenCalledTimes(2);
+    expect(fetchVpnState).toHaveBeenCalledTimes(2);
     expect(refreshAuthProfile).toHaveBeenCalledTimes(1);
     expect(connectVpn).toHaveBeenCalledWith("singapore", ["roblox"]);
     expect(checkForUpdates).toHaveBeenCalledWith(false, true);
@@ -75,24 +75,35 @@ describe("app bootstrap", () => {
   it("refreshes profile before reconnect so a startup ban can block auto-connect", async () => {
     const connectVpn = vi.fn().mockResolvedValue(undefined);
     let authState: "logged_in" | "banned" = "logged_in";
+    let vpnState: "connected" | "disconnected" = "connected";
+    let fetchAuthCalls = 0;
+    let fetchVpnStateCalls = 0;
 
     await runAppBootstrap({
       initEventListeners: vi.fn().mockResolvedValue(undefined),
-      fetchAuth: vi.fn().mockResolvedValue(undefined),
+      fetchAuth: vi.fn().mockImplementation(async () => {
+        fetchAuthCalls += 1;
+        if (fetchAuthCalls > 1) {
+          authState = "banned";
+        }
+      }),
       loadSettings: vi.fn().mockResolvedValue(undefined),
       fetchServers: vi.fn().mockResolvedValue(undefined),
       fetchSystemInfo: vi.fn().mockResolvedValue(undefined),
-      fetchVpnState: vi.fn().mockResolvedValue(undefined),
-      refreshAuthProfile: vi.fn().mockImplementation(async () => {
-        authState = "banned";
+      fetchVpnState: vi.fn().mockImplementation(async () => {
+        fetchVpnStateCalls += 1;
+        if (fetchVpnStateCalls > 1) {
+          vpnState = "disconnected";
+        }
       }),
+      refreshAuthProfile: vi.fn().mockResolvedValue(undefined),
       getSettings: () => ({
         ...DEFAULT_SETTINGS,
         auto_reconnect: true,
         resume_vpn_on_startup: true,
       }),
       getAuthState: () => authState,
-      getVpnState: () => "disconnected",
+      getVpnState: () => vpnState,
       connectVpn,
       checkForUpdates: vi.fn().mockResolvedValue(undefined),
     });

--- a/swifttunnel-desktop/src/lib/appBootstrap.test.ts
+++ b/swifttunnel-desktop/src/lib/appBootstrap.test.ts
@@ -110,4 +110,35 @@ describe("app bootstrap", () => {
 
     expect(connectVpn).not.toHaveBeenCalled();
   });
+
+  it("does not refresh profile or reconnect once auth is already banned", async () => {
+    const fetchAuth = vi.fn().mockResolvedValue(undefined);
+    const fetchVpnState = vi.fn().mockResolvedValue(undefined);
+    const refreshAuthProfile = vi.fn().mockResolvedValue(undefined);
+    const connectVpn = vi.fn().mockResolvedValue(undefined);
+
+    await runAppBootstrap({
+      initEventListeners: vi.fn().mockResolvedValue(undefined),
+      fetchAuth,
+      loadSettings: vi.fn().mockResolvedValue(undefined),
+      fetchServers: vi.fn().mockResolvedValue(undefined),
+      fetchSystemInfo: vi.fn().mockResolvedValue(undefined),
+      fetchVpnState,
+      refreshAuthProfile,
+      getSettings: () => ({
+        ...DEFAULT_SETTINGS,
+        auto_reconnect: true,
+        resume_vpn_on_startup: true,
+      }),
+      getAuthState: () => "banned",
+      getVpnState: () => "disconnected",
+      connectVpn,
+      checkForUpdates: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(fetchAuth).toHaveBeenCalledTimes(1);
+    expect(fetchVpnState).toHaveBeenCalledTimes(1);
+    expect(refreshAuthProfile).not.toHaveBeenCalled();
+    expect(connectVpn).not.toHaveBeenCalled();
+  });
 });

--- a/swifttunnel-desktop/src/lib/appBootstrap.test.ts
+++ b/swifttunnel-desktop/src/lib/appBootstrap.test.ts
@@ -10,6 +10,7 @@ describe("app bootstrap", () => {
     const fetchServers = vi.fn().mockResolvedValue(undefined);
     const fetchSystemInfo = vi.fn().mockResolvedValue(undefined);
     const fetchVpnState = vi.fn().mockResolvedValue(undefined);
+    const refreshAuthProfile = vi.fn().mockResolvedValue(undefined);
     const connectVpn = vi.fn().mockResolvedValue(undefined);
     const checkForUpdates = vi.fn().mockResolvedValue(undefined);
 
@@ -20,6 +21,7 @@ describe("app bootstrap", () => {
       fetchServers,
       fetchSystemInfo,
       fetchVpnState,
+      refreshAuthProfile,
       getSettings: () => ({
         ...DEFAULT_SETTINGS,
         auto_reconnect: true,
@@ -37,6 +39,7 @@ describe("app bootstrap", () => {
     expect(fetchServers).toHaveBeenCalledTimes(1);
     expect(fetchSystemInfo).toHaveBeenCalledTimes(1);
     expect(fetchVpnState).toHaveBeenCalledTimes(1);
+    expect(refreshAuthProfile).toHaveBeenCalledTimes(1);
     expect(connectVpn).toHaveBeenCalledWith("singapore", ["roblox"]);
     expect(checkForUpdates).toHaveBeenCalledWith(false, true);
   });
@@ -44,6 +47,7 @@ describe("app bootstrap", () => {
   it("skips reconnect and update check when startup conditions are not met", async () => {
     const connectVpn = vi.fn().mockResolvedValue(undefined);
     const checkForUpdates = vi.fn().mockResolvedValue(undefined);
+    const refreshAuthProfile = vi.fn().mockResolvedValue(undefined);
 
     await runAppBootstrap({
       initEventListeners: vi.fn().mockResolvedValue(undefined),
@@ -52,6 +56,7 @@ describe("app bootstrap", () => {
       fetchServers: vi.fn().mockResolvedValue(undefined),
       fetchSystemInfo: vi.fn().mockResolvedValue(undefined),
       fetchVpnState: vi.fn().mockResolvedValue(undefined),
+      refreshAuthProfile,
       getSettings: () => ({
         ...DEFAULT_SETTINGS,
         update_settings: { auto_check: false, last_check: null },
@@ -64,5 +69,34 @@ describe("app bootstrap", () => {
 
     expect(connectVpn).not.toHaveBeenCalled();
     expect(checkForUpdates).not.toHaveBeenCalled();
+    expect(refreshAuthProfile).not.toHaveBeenCalled();
+  });
+
+  it("refreshes profile before reconnect so a startup ban can block auto-connect", async () => {
+    const connectVpn = vi.fn().mockResolvedValue(undefined);
+    let authState: "logged_in" | "banned" = "logged_in";
+
+    await runAppBootstrap({
+      initEventListeners: vi.fn().mockResolvedValue(undefined),
+      fetchAuth: vi.fn().mockResolvedValue(undefined),
+      loadSettings: vi.fn().mockResolvedValue(undefined),
+      fetchServers: vi.fn().mockResolvedValue(undefined),
+      fetchSystemInfo: vi.fn().mockResolvedValue(undefined),
+      fetchVpnState: vi.fn().mockResolvedValue(undefined),
+      refreshAuthProfile: vi.fn().mockImplementation(async () => {
+        authState = "banned";
+      }),
+      getSettings: () => ({
+        ...DEFAULT_SETTINGS,
+        auto_reconnect: true,
+        resume_vpn_on_startup: true,
+      }),
+      getAuthState: () => authState,
+      getVpnState: () => "disconnected",
+      connectVpn,
+      checkForUpdates: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(connectVpn).not.toHaveBeenCalled();
   });
 });

--- a/swifttunnel-desktop/src/lib/appBootstrap.ts
+++ b/swifttunnel-desktop/src/lib/appBootstrap.ts
@@ -8,11 +8,15 @@ type AppBootstrapDeps = {
   fetchServers: () => Promise<void>;
   fetchSystemInfo: () => Promise<void>;
   fetchVpnState: () => Promise<void>;
+  refreshAuthProfile?: () => Promise<void>;
   getSettings: () => AppSettings;
   getAuthState: () => AuthState;
   getVpnState: () => VpnState;
   connectVpn: (region: string, gamePresets: string[]) => Promise<void>;
-  checkForUpdates: (showNoUpdatesMessage: boolean, autoInstall?: boolean) => Promise<void>;
+  checkForUpdates: (
+    showNoUpdatesMessage: boolean,
+    autoInstall?: boolean,
+  ) => Promise<void>;
 };
 
 export async function runAppBootstrap(deps: AppBootstrapDeps) {
@@ -24,6 +28,14 @@ export async function runAppBootstrap(deps: AppBootstrapDeps) {
     deps.fetchSystemInfo(),
     deps.fetchVpnState(),
   ]);
+
+  const authState = deps.getAuthState();
+  if (
+    deps.refreshAuthProfile &&
+    (authState === "logged_in" || authState === "banned")
+  ) {
+    await deps.refreshAuthProfile();
+  }
 
   const loadedSettings = deps.getSettings();
   if (

--- a/swifttunnel-desktop/src/lib/appBootstrap.ts
+++ b/swifttunnel-desktop/src/lib/appBootstrap.ts
@@ -32,6 +32,7 @@ export async function runAppBootstrap(deps: AppBootstrapDeps) {
   const authState = deps.getAuthState();
   if (authState === "logged_in" || authState === "banned") {
     await deps.refreshAuthProfile();
+    await Promise.all([deps.fetchAuth(), deps.fetchVpnState()]);
   }
 
   const loadedSettings = deps.getSettings();

--- a/swifttunnel-desktop/src/lib/appBootstrap.ts
+++ b/swifttunnel-desktop/src/lib/appBootstrap.ts
@@ -30,7 +30,7 @@ export async function runAppBootstrap(deps: AppBootstrapDeps) {
   ]);
 
   const authState = deps.getAuthState();
-  if (authState === "logged_in" || authState === "banned") {
+  if (authState === "logged_in") {
     await deps.refreshAuthProfile();
     await Promise.all([deps.fetchAuth(), deps.fetchVpnState()]);
   }

--- a/swifttunnel-desktop/src/lib/appBootstrap.ts
+++ b/swifttunnel-desktop/src/lib/appBootstrap.ts
@@ -8,7 +8,7 @@ type AppBootstrapDeps = {
   fetchServers: () => Promise<void>;
   fetchSystemInfo: () => Promise<void>;
   fetchVpnState: () => Promise<void>;
-  refreshAuthProfile?: () => Promise<void>;
+  refreshAuthProfile: () => Promise<void>;
   getSettings: () => AppSettings;
   getAuthState: () => AuthState;
   getVpnState: () => VpnState;
@@ -30,10 +30,7 @@ export async function runAppBootstrap(deps: AppBootstrapDeps) {
   ]);
 
   const authState = deps.getAuthState();
-  if (
-    deps.refreshAuthProfile &&
-    (authState === "logged_in" || authState === "banned")
-  ) {
+  if (authState === "logged_in" || authState === "banned") {
     await deps.refreshAuthProfile();
   }
 

--- a/swifttunnel-desktop/src/lib/startup.test.ts
+++ b/swifttunnel-desktop/src/lib/startup.test.ts
@@ -18,6 +18,12 @@ describe("shouldAutoReconnectOnLaunch", () => {
         resume_vpn_on_startup: true,
       }),
     ).toBe(false);
+    expect(
+      shouldAutoReconnectOnLaunch("banned", "disconnected", {
+        auto_reconnect: true,
+        resume_vpn_on_startup: true,
+      }),
+    ).toBe(false);
   });
 
   it("returns false when reconnect is disabled or no prior active tunnel marker exists", () => {

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -7,6 +7,7 @@ export type AuthState =
   | "logging_in"
   | "awaiting_oauth"
   | "logged_in"
+  | "banned"
   | `error:${string}`;
 
 export interface AuthStateResponse {
@@ -14,6 +15,9 @@ export interface AuthStateResponse {
   email: string | null;
   user_id: string | null;
   is_tester: boolean;
+  is_banned: boolean;
+  banned_reason: string | null;
+  banned_at: string | null;
 }
 
 export interface OAuthPollResult {
@@ -393,7 +397,13 @@ export interface DriverCheckResponse {
   status: string;
   message: string;
   reboot_required: boolean;
-  recommended_action: "none" | "install" | "reset_service" | "reinstall" | "reboot" | string;
+  recommended_action:
+    | "none"
+    | "install"
+    | "reset_service"
+    | "reinstall"
+    | "reboot"
+    | string;
 }
 
 // ── Events ──
@@ -410,6 +420,9 @@ export interface AuthStateEvent {
   state: string;
   email: string | null;
   user_id: string | null;
+  is_banned?: boolean;
+  banned_reason?: string | null;
+  banned_at?: string | null;
 }
 
 export interface ThroughputEvent {

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -420,6 +420,7 @@ export interface AuthStateEvent {
   state: string;
   email: string | null;
   user_id: string | null;
+  is_tester?: boolean;
   is_banned?: boolean;
   banned_reason?: string | null;
   banned_at?: string | null;

--- a/swifttunnel-desktop/src/stores/authStore.test.ts
+++ b/swifttunnel-desktop/src/stores/authStore.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const commands = vi.hoisted(() => ({
+  authGetState: vi.fn(),
+  authStartOAuth: vi.fn(),
+  authPollOAuth: vi.fn(),
+  authCancelOAuth: vi.fn(),
+  authCompleteOAuth: vi.fn(),
+  authLogout: vi.fn(),
+  authRefreshProfile: vi.fn(),
+}));
+
+vi.mock("../lib/commands", () => commands);
+
+vi.mock("../lib/errors", () => ({
+  reportError: vi.fn(),
+}));
+
+async function loadStore() {
+  vi.resetModules();
+  return (await import("./authStore")).useAuthStore;
+}
+
+describe("stores/authStore", () => {
+  beforeEach(() => {
+    Object.values(commands).forEach((mock) => mock.mockReset());
+  });
+
+  it("updates tester status from auth state events after a ban transition", async () => {
+    const useAuthStore = await loadStore();
+
+    useAuthStore.getState().handleStateEvent({
+      state: "banned",
+      email: "tester@example.com",
+      user_id: "user-1",
+      is_tester: true,
+      is_banned: true,
+      banned_reason: "abuse",
+      banned_at: "2026-05-07T00:00:00.000Z",
+    });
+
+    expect(useAuthStore.getState().isTester).toBe(false);
+    expect(useAuthStore.getState().isBanned).toBe(true);
+
+    useAuthStore.getState().handleStateEvent({
+      state: "logged_in",
+      email: "tester@example.com",
+      user_id: "user-1",
+      is_tester: true,
+      is_banned: false,
+      banned_reason: null,
+      banned_at: null,
+    });
+
+    expect(useAuthStore.getState().isTester).toBe(true);
+    expect(useAuthStore.getState().isBanned).toBe(false);
+  });
+});

--- a/swifttunnel-desktop/src/stores/authStore.test.ts
+++ b/swifttunnel-desktop/src/stores/authStore.test.ts
@@ -55,4 +55,18 @@ describe("stores/authStore", () => {
     expect(useAuthStore.getState().isTester).toBe(true);
     expect(useAuthStore.getState().isBanned).toBe(false);
   });
+
+  it("surfaces refresh failures and clears stale refresh errors on retry", async () => {
+    commands.authRefreshProfile
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(undefined);
+
+    const useAuthStore = await loadStore();
+
+    await useAuthStore.getState().refreshProfile();
+    expect(useAuthStore.getState().error).toBe("Error: network down");
+
+    await useAuthStore.getState().refreshProfile();
+    expect(useAuthStore.getState().error).toBeNull();
+  });
 });

--- a/swifttunnel-desktop/src/stores/authStore.ts
+++ b/swifttunnel-desktop/src/stores/authStore.ts
@@ -138,7 +138,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       isBanned,
       bannedReason: event.banned_reason ?? null,
       bannedAt: event.banned_at ?? null,
-      isTester: isBanned ? false : get().isTester,
+      isTester: isBanned ? false : Boolean(event.is_tester),
     });
   },
 }));

--- a/swifttunnel-desktop/src/stores/authStore.ts
+++ b/swifttunnel-desktop/src/stores/authStore.ts
@@ -122,6 +122,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 
   refreshProfile: async () => {
     try {
+      set({ error: null });
       await authRefreshProfile();
     } catch (e) {
       set({ error: String(e) });

--- a/swifttunnel-desktop/src/stores/authStore.ts
+++ b/swifttunnel-desktop/src/stores/authStore.ts
@@ -16,6 +16,9 @@ interface AuthStore {
   email: string | null;
   userId: string | null;
   isTester: boolean;
+  isBanned: boolean;
+  bannedReason: string | null;
+  bannedAt: string | null;
   isLoading: boolean;
   error: string | null;
 
@@ -34,6 +37,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   email: null,
   userId: null,
   isTester: false,
+  isBanned: false,
+  bannedReason: null,
+  bannedAt: null,
   isLoading: true,
   error: null,
 
@@ -45,6 +51,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         email: resp.email,
         userId: resp.user_id,
         isTester: resp.is_tester,
+        isBanned: resp.is_banned,
+        bannedReason: resp.banned_reason,
+        bannedAt: resp.banned_at,
         isLoading: false,
         error: null,
       });
@@ -101,6 +110,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         email: null,
         userId: null,
         isTester: false,
+        isBanned: false,
+        bannedReason: null,
+        bannedAt: null,
         error: null,
       });
     } catch (e) {
@@ -118,10 +130,16 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   },
 
   handleStateEvent: (event) => {
+    const isBanned = Boolean(event.is_banned);
+
     set({
       state: event.state as AuthState,
       email: event.email,
       userId: event.user_id,
+      isBanned,
+      bannedReason: event.banned_reason ?? null,
+      bannedAt: event.banned_at ?? null,
+      isTester: isBanned ? false : get().isTester,
     });
   },
 }));

--- a/swifttunnel-desktop/src/stores/authStore.ts
+++ b/swifttunnel-desktop/src/stores/authStore.ts
@@ -123,7 +123,6 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   refreshProfile: async () => {
     try {
       await authRefreshProfile();
-      await get().fetchState();
     } catch (e) {
       set({ error: String(e) });
     }


### PR DESCRIPTION
## Summary
- add a structured banned auth state through the Rust auth manager, Tauri events/commands, frontend store, and a desktop banned screen
- clean up banned sessions by disconnecting best-effort, restoring network/system/Roblox boosts, disabling saved boost startup, and skipping reconnect/reapply while banned
- treat only structured `code: user_banned` API responses as ban triggers, with a negative test for similar incidental text
- apply and restore Roblox ClientAppSettings across every valid `version-*` folder so new Roblox updates get the saved FFlags on startup
- update desktop docs for banned accounts and all-version Roblox FFlags

## Verification
- `cargo fmt`
- `npm test` (swifttunnel-desktop)
- `npm run build` (swifttunnel-desktop)
- `git diff --check`
- GitHub Actions CI on `codex/ban-system`: https://github.com/Swift-tunnel/swifttunnel-app/actions/runs/25491915231
- Windows testbench VM: `cargo test -p swifttunnel-core roblox_optimizer --lib` (35 passed)
- Windows testbench VM: `cargo test -p swifttunnel-core test_user_banned_error --lib` (2 passed)
- Windows testbench VM desktop harness release build/preflight completed with driver available, 27 servers loaded, and binding preflight `ok`; the harness final status was blocked by its existing conhost shell-monitor assertion during PowerShell-backed preflight, so I did not count that as a passing gate

Note: local macOS `cargo test` still hits the known host-only `windows-future`/`windows-core` mismatch before project code compiles, so Windows CI/VM are the Rust authority here.