### PR TITLE
Enforce desktop HWID ban signals

### DIFF
--- a/swifttunnel-core/src/auth/device_identity.rs
+++ b/swifttunnel-core/src/auth/device_identity.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256};
 
 const HWID_HASH_INFO: &[u8] = b"swifttunnel-desktop-hwid-v1";
 const HWID_PREFIX: &str = "hwid:v1:";
+const ZERO_MACHINE_GUID: &str = "00000000-0000-0000-0000-000000000000";
 
 #[cfg(windows)]
 fn read_machine_guid() -> Option<String> {
@@ -26,7 +27,7 @@ fn read_machine_guid() -> Option<String> {
 
 pub(crate) fn desktop_hwid_from_machine_guid(machine_guid: &str) -> Option<String> {
     let normalized = machine_guid.trim().to_ascii_lowercase();
-    if normalized.is_empty() || normalized == "swifttunnel-unknown-machine" {
+    if is_invalid_machine_guid(&normalized) {
         return None;
     }
 
@@ -35,6 +36,15 @@ pub(crate) fn desktop_hwid_from_machine_guid(machine_guid: &str) -> Option<Strin
     hasher.update([0xff]);
     hasher.update(normalized.as_bytes());
     Some(format!("{}{:x}", HWID_PREFIX, hasher.finalize()))
+}
+
+fn is_invalid_machine_guid(machine_guid: &str) -> bool {
+    machine_guid.is_empty()
+        || machine_guid == ZERO_MACHINE_GUID
+        || machine_guid == "00000000000000000000000000000000"
+        || machine_guid == "swifttunnel-unknown-machine"
+        || machine_guid == "unknown"
+        || machine_guid == "n/a"
 }
 
 pub(crate) fn desktop_hwid() -> Option<String> {
@@ -65,5 +75,9 @@ mod tests {
         assert!(desktop_hwid_from_machine_guid("").is_none());
         assert!(desktop_hwid_from_machine_guid("   ").is_none());
         assert!(desktop_hwid_from_machine_guid("swifttunnel-unknown-machine").is_none());
+        assert!(desktop_hwid_from_machine_guid(ZERO_MACHINE_GUID).is_none());
+        assert!(desktop_hwid_from_machine_guid("00000000000000000000000000000000").is_none());
+        assert!(desktop_hwid_from_machine_guid("unknown").is_none());
+        assert!(desktop_hwid_from_machine_guid("N/A").is_none());
     }
 }

--- a/swifttunnel-core/src/auth/device_identity.rs
+++ b/swifttunnel-core/src/auth/device_identity.rs
@@ -1,0 +1,69 @@
+//! Desktop hardware identity for server-side abuse controls.
+//!
+//! The raw Windows MachineGuid never leaves the device. We send a stable,
+//! domain-separated hash so the API can correlate desktop launches from the
+//! same machine without receiving the registry value itself.
+
+use sha2::{Digest, Sha256};
+
+const HWID_HASH_INFO: &[u8] = b"swifttunnel-desktop-hwid-v1";
+const HWID_PREFIX: &str = "hwid:v1:";
+
+#[cfg(windows)]
+fn read_machine_guid() -> Option<String> {
+    use winreg::RegKey;
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    let key = hklm.open_subkey("SOFTWARE\\Microsoft\\Cryptography").ok()?;
+    key.get_value::<String, _>("MachineGuid").ok()
+}
+
+#[cfg(not(windows))]
+fn read_machine_guid() -> Option<String> {
+    None
+}
+
+pub(crate) fn desktop_hwid_from_machine_guid(machine_guid: &str) -> Option<String> {
+    let normalized = machine_guid.trim().to_ascii_lowercase();
+    if normalized.is_empty() || normalized == "swifttunnel-unknown-machine" {
+        return None;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(HWID_HASH_INFO);
+    hasher.update([0xff]);
+    hasher.update(normalized.as_bytes());
+    Some(format!("{}{:x}", HWID_PREFIX, hasher.finalize()))
+}
+
+pub(crate) fn desktop_hwid() -> Option<String> {
+    read_machine_guid()
+        .as_deref()
+        .and_then(desktop_hwid_from_machine_guid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_hwid_is_stable_and_hashes_raw_guid() {
+        let first = desktop_hwid_from_machine_guid("  ABCDEF12-3456-7890-ABCD-EF1234567890  ")
+            .expect("valid hwid");
+        let second = desktop_hwid_from_machine_guid("abcdef12-3456-7890-abcd-ef1234567890")
+            .expect("valid hwid");
+
+        assert_eq!(first, second);
+        assert!(first.starts_with("hwid:v1:"));
+        assert_eq!(first.len(), "hwid:v1:".len() + 64);
+        assert!(!first.contains("abcdef12"));
+    }
+
+    #[test]
+    fn desktop_hwid_ignores_missing_or_fallback_guid() {
+        assert!(desktop_hwid_from_machine_guid("").is_none());
+        assert!(desktop_hwid_from_machine_guid("   ").is_none());
+        assert!(desktop_hwid_from_machine_guid("swifttunnel-unknown-machine").is_none());
+    }
+}

--- a/swifttunnel-core/src/auth/http_client.rs
+++ b/swifttunnel-core/src/auth/http_client.rs
@@ -1,5 +1,6 @@
 //! HTTP client for SwiftTunnel API
 
+use super::device_identity::desktop_hwid;
 use super::types::{
     AuthError, ExchangeTokenResponse, RelayTicketResponse, SupabaseAuthResponse, VpnConfig,
 };
@@ -43,6 +44,7 @@ const SUPABASE_ANON_KEY: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOi
 /// HTTP client for authentication API calls
 pub struct AuthClient {
     client: Client,
+    device_hwid: Option<String>,
 }
 
 impl AuthClient {
@@ -54,7 +56,46 @@ impl AuthClient {
             .build()
             .expect("Failed to create HTTP client");
 
-        Self { client }
+        Self {
+            client,
+            device_hwid: desktop_hwid(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_device_hwid(device_hwid: Option<String>) -> Self {
+        let client = Client::builder()
+            .user_agent("SwiftTunnel-Desktop/0.1.0")
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            client,
+            device_hwid,
+        }
+    }
+
+    fn add_hwid_header(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.device_hwid {
+            Some(hwid) => request.header("X-SwiftTunnel-HWID", hwid),
+            None => request,
+        }
+    }
+
+    fn exchange_oauth_payload(&self, exchange_token: &str, state: &str) -> serde_json::Value {
+        let mut payload = json!({
+            "exchange_token": exchange_token,
+            "state": state,
+        });
+        if let Some(hwid) = &self.device_hwid {
+            payload["device_hwid"] = json!(hwid);
+        }
+        payload
+    }
+
+    pub(crate) fn device_hwid(&self) -> Option<&str> {
+        self.device_hwid.as_deref()
     }
 
     /// Sign in with email and password via Supabase
@@ -161,8 +202,7 @@ impl AuthClient {
         debug!("Fetching VPN config for region {}", region);
 
         let response = self
-            .client
-            .post(&url)
+            .add_hwid_header(self.client.post(&url))
             .header("Authorization", format!("Bearer {}", access_token))
             .json(&json!({
                 "region": region,
@@ -208,8 +248,7 @@ impl AuthClient {
         );
 
         let response = self
-            .client
-            .post(&url)
+            .add_hwid_header(self.client.post(&url))
             .header("Authorization", format!("Bearer {}", access_token))
             .header("Content-Type", "application/json")
             .json(&json!({
@@ -260,13 +299,9 @@ impl AuthClient {
         debug!("Exchanging OAuth token for session");
 
         let response = self
-            .client
-            .put(&url)
+            .add_hwid_header(self.client.put(&url))
             .header("Content-Type", "application/json")
-            .json(&json!({
-                "exchange_token": exchange_token,
-                "state": state,
-            }))
+            .json(&self.exchange_oauth_payload(exchange_token, state))
             .send()
             .await
             .map_err(|e| AuthError::NetworkError(e.to_string()))?;
@@ -319,8 +354,7 @@ impl AuthClient {
         debug!("Fetching user profile");
 
         let response = self
-            .client
-            .get(&url)
+            .add_hwid_header(self.client.get(&url))
             .header("Authorization", format!("Bearer {}", access_token))
             .send()
             .await
@@ -498,5 +532,25 @@ mod tests {
         let body = r#"{"error":"user_banned appeared in a log line","code":"internal_error"}"#;
 
         assert!(user_banned_error_from_body(body).is_none());
+    }
+
+    #[test]
+    fn exchange_oauth_payload_includes_hwid_when_available() {
+        let client = AuthClient::with_device_hwid(Some("hwid:v1:abc".to_string()));
+
+        let payload = client.exchange_oauth_payload("exchange", "state");
+
+        assert_eq!(payload["exchange_token"], "exchange");
+        assert_eq!(payload["state"], "state");
+        assert_eq!(payload["device_hwid"], "hwid:v1:abc");
+    }
+
+    #[test]
+    fn exchange_oauth_payload_omits_missing_hwid() {
+        let client = AuthClient::with_device_hwid(None);
+
+        let payload = client.exchange_oauth_payload("exchange", "state");
+
+        assert!(payload.get("device_hwid").is_none());
     }
 }

--- a/swifttunnel-core/src/auth/http_client.rs
+++ b/swifttunnel-core/src/auth/http_client.rs
@@ -94,10 +94,6 @@ impl AuthClient {
         payload
     }
 
-    pub(crate) fn device_hwid(&self) -> Option<&str> {
-        self.device_hwid.as_deref()
-    }
-
     /// Sign in with email and password via Supabase
     pub async fn sign_in_with_password(
         &self,

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -630,12 +630,16 @@ impl AuthManager {
             .collect();
 
         // Build the OAuth URL with the redirect port
-        let query = form_urlencoded::Serializer::new(String::new())
+        let mut query = form_urlencoded::Serializer::new(String::new());
+        query
             .append_pair("desktop", "true")
             .append_pair("state", &state)
             .append_pair("provider", "google")
-            .append_pair("redirect_port", &port.to_string())
-            .finish();
+            .append_pair("redirect_port", &port.to_string());
+        if let Some(hwid) = self.client.device_hwid() {
+            query.append_pair("hwid", hwid);
+        }
+        let query = query.finish();
         let oauth_url = format!("{}?{}", OAUTH_LOGIN_URL, query);
 
         info!("Opening browser to: {}", oauth_url);
@@ -916,6 +920,15 @@ mod tests {
             .finish();
         // Spaces become +, & and = get percent-encoded
         assert_eq!(query, "state=hello+world%26foo%3Dbar");
+    }
+
+    #[test]
+    fn test_form_urlencoded_preserves_hashed_hwid() {
+        let query = form_urlencoded::Serializer::new(String::new())
+            .append_pair("hwid", "hwid:v1:abc123")
+            .finish();
+
+        assert_eq!(query, "hwid=hwid%3Av1%3Aabc123");
     }
 
     #[test]

--- a/swifttunnel-core/src/auth/manager.rs
+++ b/swifttunnel-core/src/auth/manager.rs
@@ -630,16 +630,12 @@ impl AuthManager {
             .collect();
 
         // Build the OAuth URL with the redirect port
-        let mut query = form_urlencoded::Serializer::new(String::new());
-        query
+        let query = form_urlencoded::Serializer::new(String::new())
             .append_pair("desktop", "true")
             .append_pair("state", &state)
             .append_pair("provider", "google")
-            .append_pair("redirect_port", &port.to_string());
-        if let Some(hwid) = self.client.device_hwid() {
-            query.append_pair("hwid", hwid);
-        }
-        let query = query.finish();
+            .append_pair("redirect_port", &port.to_string())
+            .finish();
         let oauth_url = format!("{}?{}", OAUTH_LOGIN_URL, query);
 
         info!("Opening browser to: {}", oauth_url);
@@ -920,15 +916,6 @@ mod tests {
             .finish();
         // Spaces become +, & and = get percent-encoded
         assert_eq!(query, "state=hello+world%26foo%3Dbar");
-    }
-
-    #[test]
-    fn test_form_urlencoded_preserves_hashed_hwid() {
-        let query = form_urlencoded::Serializer::new(String::new())
-            .append_pair("hwid", "hwid:v1:abc123")
-            .finish();
-
-        assert_eq!(query, "hwid=hwid%3Av1%3Aabc123");
     }
 
     #[test]

--- a/swifttunnel-core/src/auth/mod.rs
+++ b/swifttunnel-core/src/auth/mod.rs
@@ -6,6 +6,7 @@
 //! - Secure token storage via Keychain
 //! - Token refresh management
 
+mod device_identity;
 pub(crate) mod http_client;
 mod manager;
 pub mod oauth_server;


### PR DESCRIPTION
## Summary
- Add an app-scoped domain-separated desktop HWID hash derived from the Windows MachineGuid without sending the raw registry value.
- Send the HWID only to SwiftTunnel-owned desktop auth/profile/relay APIs through `X-SwiftTunnel-HWID` and the desktop exchange payload; keep it out of browser/OAuth URLs.
- Preserve existing structured ban handling so HWID bans surface as the typed `user_banned` flow instead of substring matching.

## Failure-mode plan
- Primary success: the SwiftTunnel API can identify the desktop machine and return/propagate structured ban state; local UI state alone is not success.
- Repairable/diagnostic-only: missing MachineGuid, placeholder MachineGuid values, non-Windows dev builds, or malformed HWID produce no HWID signal and must not ban anyone.
- Fatal/enforced: structured API responses with `code: "user_banned"` remain the only ban trigger in the desktop client.
- Partial success/races: desktop exchange, profile refresh, and relay-ticket calls all include the HWID so enforcement is not dependent on browser callback state.
- Tests: positive payload/HWID hashing coverage plus negative tests for missing/fallback/placeholder HWID and incidental `user_banned` text.

## Verification
- `cargo fmt --check`
- `npm test -- --run`
- `npx tsc --noEmit`
- `npm run build`
- `cargo test -p swifttunnel-core desktop_hwid -- --nocapture` currently stops before project tests on the known macOS `windows-future` / `windows-core` mismatch (`IMarshal`, `marshaler`, `windows_threading::submit`). Windows CI is the authoritative Rust compile gate for this repo.

## Companion work
- Requires web/API PR Swift-tunnel/swifttunnel-web#30 plus the already-applied Supabase migrations for account-ban columns and `banned_hwids`.
