### PR TITLE
Clean SwiftTunnel power plan after bans

### DIFF
--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -38,6 +38,14 @@ const SWIFTTUNNEL_POWER_PLAN_DESCRIPTION: &str = "SwiftTunnel optimized gaming p
 const SWIFTTUNNEL_POWER_PLAN_BYTES: &[u8] =
     include_bytes!("../resources/swifttunnel_power_plan.pow");
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SwiftTunnelPowerPlanCleanup {
+    Noop,
+    DeleteInactive,
+    ActivateBalancedThenDelete,
+    UnknownActivePlan,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct MmcssSnapshot {
     scheduling_category: Option<String>,
@@ -287,13 +295,74 @@ impl SystemOptimizer {
         original_restore_succeeded || balanced_fallback_succeeded
     }
 
-    fn delete_power_plan_guid(guid: &str) {
+    fn delete_power_plan_guid(guid: &str) -> bool {
         let output = hidden_command("powercfg").args(["/delete", guid]).output();
 
         match output {
-            Ok(result) if result.status.success() => {}
-            Ok(_) => warn!("Failed to delete SwiftTunnel power plan {}", guid),
-            Err(e) => warn!("Failed to delete SwiftTunnel power plan {}: {}", guid, e),
+            Ok(result) if result.status.success() => true,
+            Ok(_) => {
+                warn!("Failed to delete SwiftTunnel power plan {}", guid);
+                false
+            }
+            Err(e) => {
+                warn!("Failed to delete SwiftTunnel power plan {}: {}", guid, e);
+                false
+            }
+        }
+    }
+
+    fn swifttunnel_power_plan_cleanup_decision(
+        active_guid: Option<&str>,
+        installed: Option<bool>,
+    ) -> SwiftTunnelPowerPlanCleanup {
+        if active_guid.is_some_and(|guid| guid.eq_ignore_ascii_case(SWIFTTUNNEL_POWER_PLAN_GUID)) {
+            return SwiftTunnelPowerPlanCleanup::ActivateBalancedThenDelete;
+        }
+
+        match (active_guid, installed) {
+            (Some(_), Some(true)) => SwiftTunnelPowerPlanCleanup::DeleteInactive,
+            (None, Some(true)) => SwiftTunnelPowerPlanCleanup::UnknownActivePlan,
+            _ => SwiftTunnelPowerPlanCleanup::Noop,
+        }
+    }
+
+    /// Remove SwiftTunnel's custom power plan during ban cleanup even when
+    /// the in-memory import snapshot was lost across an app restart.
+    pub fn cleanup_swifttunnel_power_plan_after_ban(&mut self) -> Result<()> {
+        let active_guid = Self::active_power_plan_guid();
+        let installed = Self::is_power_plan_installed(SWIFTTUNNEL_POWER_PLAN_GUID);
+
+        match Self::swifttunnel_power_plan_cleanup_decision(active_guid.as_deref(), installed) {
+            SwiftTunnelPowerPlanCleanup::Noop => Ok(()),
+            SwiftTunnelPowerPlanCleanup::DeleteInactive => {
+                if Self::delete_power_plan_guid(SWIFTTUNNEL_POWER_PLAN_GUID) {
+                    self.swifttunnel_power_plan_imported = false;
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "SwiftTunnel power plan is inactive but could not be deleted"
+                    ))
+                }
+            }
+            SwiftTunnelPowerPlanCleanup::ActivateBalancedThenDelete => {
+                if !Self::set_active_power_plan_guid(BALANCED_POWER_PLAN_GUID) {
+                    return Err(anyhow::anyhow!(
+                        "SwiftTunnel power plan is active and Balanced fallback could not be activated"
+                    ));
+                }
+
+                if Self::delete_power_plan_guid(SWIFTTUNNEL_POWER_PLAN_GUID) {
+                    self.swifttunnel_power_plan_imported = false;
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Balanced fallback is active, but SwiftTunnel power plan could not be deleted"
+                    ))
+                }
+            }
+            SwiftTunnelPowerPlanCleanup::UnknownActivePlan => Err(anyhow::anyhow!(
+                "SwiftTunnel power plan is installed, but the active power plan could not be determined"
+            )),
         }
     }
 
@@ -966,8 +1035,9 @@ impl SystemOptimizer {
                 original_power_plan_restored,
                 balanced_fallback_restored,
             ) {
-                Self::delete_power_plan_guid(SWIFTTUNNEL_POWER_PLAN_GUID);
-                self.swifttunnel_power_plan_imported = false;
+                if Self::delete_power_plan_guid(SWIFTTUNNEL_POWER_PLAN_GUID) {
+                    self.swifttunnel_power_plan_imported = false;
+                }
             } else {
                 warn!(
                     "Skipping SwiftTunnel power plan deletion because no safe replacement plan could be activated"
@@ -1111,6 +1181,47 @@ mod tests {
             false, true
         ));
         assert!(!SystemOptimizer::can_delete_imported_swifttunnel_power_plan(false, false));
+    }
+
+    #[test]
+    fn stale_active_swifttunnel_power_plan_switches_to_balanced_before_delete() {
+        assert_eq!(
+            SystemOptimizer::swifttunnel_power_plan_cleanup_decision(
+                Some(SWIFTTUNNEL_POWER_PLAN_GUID),
+                Some(true),
+            ),
+            SwiftTunnelPowerPlanCleanup::ActivateBalancedThenDelete
+        );
+    }
+
+    #[test]
+    fn inactive_swifttunnel_power_plan_can_be_deleted_without_switching() {
+        assert_eq!(
+            SystemOptimizer::swifttunnel_power_plan_cleanup_decision(
+                Some(BALANCED_POWER_PLAN_GUID),
+                Some(true),
+            ),
+            SwiftTunnelPowerPlanCleanup::DeleteInactive
+        );
+    }
+
+    #[test]
+    fn similar_active_power_plan_does_not_trigger_balanced_fallback() {
+        assert_eq!(
+            SystemOptimizer::swifttunnel_power_plan_cleanup_decision(
+                Some("44444444-4444-4444-4444-444444444453"),
+                Some(false),
+            ),
+            SwiftTunnelPowerPlanCleanup::Noop
+        );
+    }
+
+    #[test]
+    fn installed_swifttunnel_power_plan_is_not_deleted_when_active_plan_is_unknown() {
+        assert_eq!(
+            SystemOptimizer::swifttunnel_power_plan_cleanup_decision(None, Some(true)),
+            SwiftTunnelPowerPlanCleanup::UnknownActivePlan
+        );
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -4,6 +4,8 @@ use tauri::{AppHandle, Emitter, State};
 use crate::events::{AUTH_STATE_CHANGED, AuthStateEvent};
 use crate::state::AppState;
 use swifttunnel_core::auth::types::{AuthError, AuthState};
+use swifttunnel_core::settings::AppSettings;
+use swifttunnel_core::structs::PowerPlan;
 
 #[derive(Serialize)]
 pub struct AuthStateResponse {
@@ -79,6 +81,12 @@ fn is_auth_banned(auth_state: &AuthState) -> bool {
     matches!(auth_state, AuthState::Banned(_))
 }
 
+fn apply_banned_session_cleanup_settings(settings: &mut AppSettings) {
+    settings.resume_vpn_on_startup = false;
+    settings.config.system_optimization.power_plan = PowerPlan::Balanced;
+    settings.config.system_optimization.previous_power_plan = None;
+}
+
 pub(crate) async fn emit_auth_state(app: &AppHandle, state: &AppState) {
     let auth = state.auth_manager.lock().await;
     let auth_state = auth.get_state();
@@ -118,8 +126,17 @@ pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
         monitor.get_roblox_pid().unwrap_or(0)
     };
 
-    if let Err(e) = state.system_optimizer.lock().restore(roblox_pid) {
-        log::warn!("Failed to restore system boosts after ban detection: {}", e);
+    {
+        let mut optimizer = state.system_optimizer.lock();
+        if let Err(e) = optimizer.restore(roblox_pid) {
+            log::warn!("Failed to restore system boosts after ban detection: {}", e);
+        }
+        if let Err(e) = optimizer.cleanup_swifttunnel_power_plan_after_ban() {
+            log::warn!(
+                "Failed to clean up SwiftTunnel power plan after ban detection: {}",
+                e
+            );
+        }
     }
     if let Err(e) = state.network_booster.lock().restore() {
         log::warn!(
@@ -133,7 +150,7 @@ pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
 
     let snapshot = {
         let mut settings = state.settings.lock();
-        settings.resume_vpn_on_startup = false;
+        apply_banned_session_cleanup_settings(&mut settings);
         settings.clone()
     };
 
@@ -142,6 +159,34 @@ pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn banned_cleanup_settings_disable_power_plan_resume() {
+        let mut settings = AppSettings::default();
+        settings.resume_vpn_on_startup = true;
+        settings.config.system_optimization.power_plan = PowerPlan::SwiftTunnel;
+        settings.config.system_optimization.previous_power_plan = Some(PowerPlan::Balanced);
+
+        apply_banned_session_cleanup_settings(&mut settings);
+
+        assert!(!settings.resume_vpn_on_startup);
+        assert_eq!(
+            settings.config.system_optimization.power_plan,
+            PowerPlan::Balanced
+        );
+        assert!(
+            settings
+                .config
+                .system_optimization
+                .previous_power_plan
+                .is_none()
+        );
+    }
 }
 
 pub(crate) async fn apply_ban_cleanup(app: &AppHandle, state: &AppState) -> bool {


### PR DESCRIPTION
## Summary
- Add a stateless ban-cleanup fallback for SwiftTunnel's custom Windows power plan.
- If the SwiftTunnel plan is active after a restart, ban cleanup switches to Balanced before deleting the plan.
- Persist banned-session settings back to Balanced so startup recovery cannot reapply the SwiftTunnel power plan.

## Failure-mode plan
- Primary success: after ban cleanup, the active Windows power plan is not SwiftTunnel; deletion is secondary and must not mask a failed safe fallback.
- Repairable/retryable: active SwiftTunnel plan switches to Balanced, then deletes the SwiftTunnel plan; inactive installed plan deletes without switching.
- Fatal/diagnostic-only: if the active plan cannot be determined while SwiftTunnel is installed, cleanup refuses blind deletion and logs the failure.
- Structured signals: decisions compare exact normalized GUIDs, not display text or broad substrings.
- Partial success/races: if Balanced activates but deletion fails, the user is off SwiftTunnel power behavior and the remaining artifact is reported.
- Tests: added stale-active, inactive-installed, superficially similar GUID, unknown-active, and persisted-settings tests.

## Verification
- `cargo fmt --check`
- `npm test -- --run`
- `npx tsc --noEmit`
- `npm run build`
- `cargo test -p swifttunnel-core swifttunnel_power_plan -- --nocapture` stops before project tests on the known macOS `windows-future` / `windows-core` mismatch (`IMarshal`, `marshaler`, `windows_threading::submit`); Windows CI is the authoritative Rust compile gate.
