### PR TITLE
Bypass DNS during API tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers — everything else goes directly to the internet.
+SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers — DNS stays on the local connection so Roblox can resolve launch-time settings endpoints normally.
 
 Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
 

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -61,7 +61,7 @@ use super::ipv6_recovery::{
     IPV6_BLOCK_REMOTE_IPS, IPV6_BLOCK_RULE_NAME, delete_ipv6_marker, restore_ipv6_from_marker,
     write_ipv6_marker_firewall,
 };
-use super::process_cache::{LockFreeProcessCache, ProcessSnapshot};
+use super::process_cache::{DNS_PORT, LockFreeProcessCache, ProcessSnapshot};
 use super::process_tracker::{ConnectionKey, Protocol};
 use super::tso_recovery::{delete_tso_marker, restore_tso_from_marker, write_tso_marker};
 use super::{VpnError, VpnResult};
@@ -10111,7 +10111,7 @@ mod tests {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let dst_ip = Ipv4Addr::new(1, 1, 1, 1);
         let src_port = 40000;
-        let dst_port = 53;
+        let dst_port = 3478;
 
         let snapshot = ProcessSnapshot {
             connections: HashMap::new(),
@@ -10131,6 +10131,38 @@ mod tests {
         inline_cache.insert((src_ip, src_port, Protocol::Udp), true);
 
         assert!(should_route_to_vpn_with_inline_cache(
+            &frame,
+            &snapshot,
+            &mut inline_cache,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_should_route_bypasses_dns_even_for_inline_cache_hit() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let dst_ip = Ipv4Addr::new(1, 1, 1, 1);
+        let src_port = 40000;
+        let dst_port = DNS_PORT;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: HashSet::new(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame = build_ipv4_frame(17, src_ip, dst_ip, src_port, dst_port);
+        let mut inline_cache: InlineCache = HashMap::new();
+        inline_cache.insert((src_ip, src_port, Protocol::Udp), true);
+
+        assert!(!should_route_to_vpn_with_inline_cache(
             &frame,
             &snapshot,
             &mut inline_cache,
@@ -10529,6 +10561,50 @@ mod tests {
         inline_cache.clear();
         assert!(should_route_to_vpn_with_inline_cache(
             &frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+    }
+
+    #[test]
+    fn test_dns_bypasses_for_tunnel_process_with_api_tunneling_enabled() {
+        let src_ip = Ipv4Addr::new(192, 168, 1, 100);
+        let dns_ip = Ipv4Addr::new(1, 1, 1, 1);
+        let src_port = 50000;
+        let pid = 1234;
+
+        let mut connections = HashMap::new();
+        connections.insert(ConnectionKey::new(src_ip, src_port, Protocol::Udp), pid);
+        connections.insert(ConnectionKey::new(src_ip, src_port + 1, Protocol::Tcp), pid);
+
+        let tunnel_pids: HashSet<u32> = [pid].into_iter().collect();
+        let snapshot = ProcessSnapshot {
+            connections,
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids,
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let udp_dns = build_ipv4_frame(17, src_ip, dns_ip, src_port, DNS_PORT);
+        let tcp_dns = build_ipv4_frame(6, src_ip, dns_ip, src_port + 1, DNS_PORT);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(!should_route_to_vpn_with_inline_cache(
+            &udp_dns,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        inline_cache.clear();
+        assert!(!should_route_to_vpn_with_inline_cache(
+            &tcp_dns,
             &snapshot,
             &mut inline_cache,
             true,

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -31,6 +31,7 @@ use std::time::{Duration, Instant};
 /// refresh sees no UDP/TCP endpoints and would otherwise erase the PID before
 /// the first game packet is classified.
 const IMMEDIATE_PROCESS_RETENTION: Duration = Duration::from_secs(45);
+pub(crate) const DNS_PORT: u16 = 53;
 
 #[derive(Clone)]
 struct ImmediateProcessRegistration {
@@ -120,10 +121,14 @@ fn ip_in_range(ip: Ipv4Addr, network: u32, mask: u32) -> bool {
 #[inline(always)]
 pub fn is_roblox_game_server(
     dst_ip: Ipv4Addr,
-    _dst_port: u16,
+    dst_port: u16,
     protocol: Protocol,
     api_tunneling: bool,
 ) -> bool {
+    if dst_port == DNS_PORT {
+        return false;
+    }
+
     match protocol {
         Protocol::Udp => {}
         Protocol::Tcp if api_tunneling => {}
@@ -155,7 +160,11 @@ pub fn is_roblox_game_server(
 /// - Voice chat
 /// - Any other UDP the game needs
 #[inline(always)]
-pub fn is_likely_game_traffic(_dst_port: u16, protocol: Protocol, api_tunneling: bool) -> bool {
+pub fn is_likely_game_traffic(dst_port: u16, protocol: Protocol, api_tunneling: bool) -> bool {
+    if dst_port == DNS_PORT {
+        return false;
+    }
+
     match protocol {
         Protocol::Udp => true,
         Protocol::Tcp => api_tunneling,
@@ -1317,6 +1326,18 @@ mod tests {
         assert!(!is_likely_game_traffic(443, Protocol::Tcp, false));
         assert!(is_likely_game_traffic(443, Protocol::Udp, false));
         assert!(is_likely_game_traffic(443, Protocol::Udp, true));
+    }
+
+    #[test]
+    fn test_dns_traffic_bypasses_even_for_tunnel_processes() {
+        assert!(!is_likely_game_traffic(DNS_PORT, Protocol::Udp, false));
+        assert!(!is_likely_game_traffic(DNS_PORT, Protocol::Udp, true));
+        assert!(!is_likely_game_traffic(DNS_PORT, Protocol::Tcp, true));
+
+        // The DNS bypass must stay narrow: ordinary Roblox UDP and API HTTPS
+        // should still tunnel.
+        assert!(is_likely_game_traffic(3478, Protocol::Udp, false));
+        assert!(is_likely_game_traffic(443, Protocol::Tcp, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep DNS traffic on port 53 local even when the source process is Roblox/API-tunneled
- prevent inline-cache and tunnel-process hits from routing DNS queries through the relay
- document that DNS stays on the local connection while game/API traffic is optimized

## Failure-mode plan
- Primary success: Roblox must resolve launch-time settings domains such as `clientsettingscdn.roblox.com` before fetching critical settings.
- Secondary success: API HTTPS/game traffic may still route through the relay, but must not mask DNS resolution failure.
- Repairable/retryable/fatal: port-53 DNS misrouting is repairable by bypassing local DNS; relay HTTPS failure remains diagnostic; unrelated TCP/UDP traffic should not be bypassed.
- Structured trigger: destination port 53 and protocol, not incidental Roblox error text.
- Partial success/races: cached tunnel ownership or inline-cache hits must not force DNS through the relay; HTTPS and STUN traffic remain tunneled.

## Tests
- Windows testbench: `cargo test -p swifttunnel-core dns --lib`
- macOS: `cargo fmt --check`
- macOS Rust unit tests hit known `windows-future` / `windows-core` dependency mismatch before crate tests, so Windows testbench is the authoritative Rust gate here.

## Incident evidence
- User machine could fetch `clientsettingscdn.roblox.com` with `curl --resolve`, confirming HTTPS works when DNS is bypassed.
- Normal DNS failed only while SwiftTunnel/API tunneling was active.
