### PR TITLE
Repair Roblox critical settings DNS for API tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers — DNS stays on the local connection so Roblox can resolve launch-time settings endpoints normally.
+SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when API tunneling is enabled, SwiftTunnel also repairs the exact Roblox critical-settings hostnames with temporary hosts-file entries resolved over HTTPS DNS so broken local resolvers do not block launch.
 
 Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
 

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -1,61 +1,157 @@
-//! Windows hosts-file management for the Roblox proxy.
+//! Windows hosts-file management for Roblox critical-settings DNS repair.
 //!
-//! Adds / removes `127.66.0.1` entries for Roblox domains so that
-//! Roblox's HTTPS traffic is redirected to the local TCP relay.
-//! All entries are bookended with marker comments so they can be
-//! identified and cleaned up reliably.
+//! Adds / removes marker-delimited entries for the small set of Roblox
+//! settings hostnames that must resolve before Roblox can open its
+//! launch-time HTTPS connection. The marker names are retained from the
+//! legacy local-proxy implementation so old `127.66.0.1` entries are
+//! removed reliably.
 
 use log::{debug, info, warn};
+use serde::Deserialize;
 use std::fs;
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 const MARKER_START: &str = "# SwiftTunnel Roblox Proxy - START";
 const MARKER_END: &str = "# SwiftTunnel Roblox Proxy - END";
-const LOOPBACK_IP: &str = "127.66.0.1";
-
-/// Roblox domains to intercept via the local proxy.
-pub const ROBLOX_DOMAINS: &[&str] = &[
-    "clientsettings.roblox.com",
-    "clientsettingscdn.roblox.com",
-    "setup.rbxcdn.com",
-    "roblox.com",
-    "www.roblox.com",
-    "apis.roblox.com",
-    "auth.roblox.com",
-    "avatar.roblox.com",
-    "catalog.roblox.com",
-    "games.roblox.com",
-    "groups.roblox.com",
-    "thumbnails.roblox.com",
-    "users.roblox.com",
-    "assetdelivery.roblox.com",
-    "economy.roblox.com",
-    "inventory.roblox.com",
+const DNS_REPAIR_TIMEOUT: Duration = Duration::from_secs(3);
+const DNS_REPAIR_RESOLVERS: &[&str] = &[
+    // IP literals avoid depending on the user's broken local DNS to find
+    // the DNS-over-HTTPS resolver itself.
+    "https://1.1.1.1/dns-query",
+    "https://8.8.8.8/resolve",
 ];
+
+/// Exact Roblox hostnames repaired when API tunneling is enabled.
+pub const CRITICAL_SETTINGS_DOMAINS: &[&str] =
+    &["clientsettingscdn.roblox.com", "clientsettings.roblox.com"];
 
 fn hosts_path() -> PathBuf {
     PathBuf::from(r"C:\Windows\System32\drivers\etc\hosts")
 }
 
-/// Append Roblox domain overrides to the Windows hosts file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HostOverride {
+    ip: Ipv4Addr,
+    domain: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DohJsonResponse {
+    #[serde(rename = "Status")]
+    status: u32,
+    #[serde(rename = "Answer", default)]
+    answer: Vec<DohJsonAnswer>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DohJsonAnswer {
+    #[serde(rename = "type")]
+    record_type: u16,
+    data: String,
+}
+
+/// Resolve and append critical Roblox settings overrides to the Windows hosts file.
 ///
 /// Existing SwiftTunnel entries are removed first (idempotent).
-pub fn apply_overrides() -> Result<(), String> {
+pub async fn apply_critical_settings_overrides() -> Result<(), String> {
+    let overrides = resolve_critical_settings_overrides().await?;
+    write_overrides(&overrides)
+}
+
+async fn resolve_critical_settings_overrides() -> Result<Vec<HostOverride>, String> {
+    let client = reqwest::Client::builder()
+        .timeout(DNS_REPAIR_TIMEOUT)
+        .build()
+        .map_err(|e| format!("Failed to build DNS repair client: {e}"))?;
+
+    let mut overrides = Vec::new();
+    let mut failures = Vec::new();
+
+    for domain in CRITICAL_SETTINGS_DOMAINS {
+        match resolve_domain_ipv4(&client, domain).await {
+            Ok(ip) => overrides.push(HostOverride {
+                ip,
+                domain: (*domain).to_string(),
+            }),
+            Err(e) => failures.push(e),
+        }
+    }
+
+    if overrides.is_empty() {
+        return Err(format!(
+            "No critical settings hosts resolved via DNS-over-HTTPS: {}",
+            failures.join("; ")
+        ));
+    }
+
+    if !failures.is_empty() {
+        warn!(
+            "Partial Roblox critical settings DNS repair: {}",
+            failures.join("; ")
+        );
+    }
+
+    Ok(overrides)
+}
+
+async fn resolve_domain_ipv4(client: &reqwest::Client, domain: &str) -> Result<Ipv4Addr, String> {
+    let mut failures = Vec::new();
+
+    for resolver in DNS_REPAIR_RESOLVERS {
+        let url = format!("{resolver}?name={domain}&type=A");
+        let response = match client
+            .get(&url)
+            .header("accept", "application/dns-json")
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(e) => {
+                failures.push(format!("{resolver}: request failed: {e}"));
+                continue;
+            }
+        };
+
+        if !response.status().is_success() {
+            failures.push(format!("{resolver}: HTTP {}", response.status()));
+            continue;
+        }
+
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(e) => {
+                failures.push(format!("{resolver}: response read failed: {e}"));
+                continue;
+            }
+        };
+
+        match parse_usable_a_records(&body) {
+            Ok(ips) if !ips.is_empty() => return Ok(ips[0]),
+            Ok(_) => failures.push(format!("{resolver}: no usable public A records")),
+            Err(e) => failures.push(format!("{resolver}: {e}")),
+        }
+    }
+
+    Err(format!(
+        "{domain} could not be repaired via DNS-over-HTTPS ({})",
+        failures.join("; ")
+    ))
+}
+
+fn write_overrides(overrides: &[HostOverride]) -> Result<(), String> {
+    if overrides.is_empty() {
+        return Err("No hosts overrides to write".to_string());
+    }
+
     let path = hosts_path();
 
     let content =
         fs::read_to_string(&path).map_err(|e| format!("Failed to read hosts file: {e}"))?;
 
     let clean = remove_marker_block(&content);
-
-    let mut block = String::new();
-    block.push_str(MARKER_START);
-    block.push('\n');
-    for domain in ROBLOX_DOMAINS {
-        block.push_str(&format!("{LOOPBACK_IP} {domain}\n"));
-    }
-    block.push_str(MARKER_END);
-    block.push('\n');
+    let block = build_hosts_block(overrides);
 
     let mut out = clean;
     if !out.ends_with('\n') {
@@ -66,8 +162,8 @@ pub fn apply_overrides() -> Result<(), String> {
     fs::write(&path, &out).map_err(|e| format!("Failed to write hosts file: {e}"))?;
 
     info!(
-        "Applied {} Roblox domain overrides to hosts file",
-        ROBLOX_DOMAINS.len()
+        "Applied {} Roblox critical settings DNS override(s) to hosts file",
+        overrides.len()
     );
 
     flush_dns_cache();
@@ -145,6 +241,51 @@ fn remove_marker_block(content: &str) -> String {
     out
 }
 
+fn build_hosts_block(overrides: &[HostOverride]) -> String {
+    let mut block = String::new();
+    block.push_str(MARKER_START);
+    block.push('\n');
+    for entry in overrides {
+        block.push_str(&format!("{} {}\n", entry.ip, entry.domain));
+    }
+    block.push_str(MARKER_END);
+    block.push('\n');
+    block
+}
+
+fn parse_usable_a_records(body: &str) -> Result<Vec<Ipv4Addr>, String> {
+    let response: DohJsonResponse =
+        serde_json::from_str(body).map_err(|e| format!("invalid DNS JSON: {e}"))?;
+
+    if response.status != 0 {
+        return Err(format!("DNS status {}", response.status));
+    }
+
+    Ok(response
+        .answer
+        .into_iter()
+        .filter(|answer| answer.record_type == 1)
+        .filter_map(|answer| answer.data.parse::<Ipv4Addr>().ok())
+        .filter(|ip| is_usable_public_ipv4(*ip))
+        .collect())
+}
+
+fn is_usable_public_ipv4(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    !(ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_multicast()
+        || ip.is_broadcast()
+        || octets[0] == 0
+        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+        || (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
+        || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
+        || (octets[0] == 203 && octets[1] == 0 && octets[2] == 113)
+        || (octets[0] == 198 && (18..=19).contains(&octets[1])))
+}
+
 /// Flush the Windows DNS resolver cache (`ipconfig /flushdns`).
 fn flush_dns_cache() {
     let output = crate::hidden_command("ipconfig").arg("/flushdns").output();
@@ -217,13 +358,81 @@ mod tests {
 
     #[test]
     fn domain_list_is_not_empty() {
-        assert!(ROBLOX_DOMAINS.len() >= 10);
+        assert!(!CRITICAL_SETTINGS_DOMAINS.is_empty());
     }
 
     #[test]
     fn domain_list_contains_critical_entries() {
-        assert!(ROBLOX_DOMAINS.contains(&"clientsettings.roblox.com"));
-        assert!(ROBLOX_DOMAINS.contains(&"clientsettingscdn.roblox.com"));
-        assert!(ROBLOX_DOMAINS.contains(&"setup.rbxcdn.com"));
+        assert!(CRITICAL_SETTINGS_DOMAINS.contains(&"clientsettings.roblox.com"));
+        assert!(CRITICAL_SETTINGS_DOMAINS.contains(&"clientsettingscdn.roblox.com"));
+    }
+
+    #[test]
+    fn domain_list_stays_narrow() {
+        assert_eq!(CRITICAL_SETTINGS_DOMAINS.len(), 2);
+        assert!(!CRITICAL_SETTINGS_DOMAINS.contains(&"roblox.com"));
+        assert!(!CRITICAL_SETTINGS_DOMAINS.contains(&"setup.rbxcdn.com"));
+    }
+
+    #[test]
+    fn build_hosts_block_uses_resolved_public_ips() {
+        let overrides = vec![
+            HostOverride {
+                ip: Ipv4Addr::new(65, 9, 168, 80),
+                domain: "clientsettingscdn.roblox.com".to_string(),
+            },
+            HostOverride {
+                ip: Ipv4Addr::new(128, 116, 46, 3),
+                domain: "clientsettings.roblox.com".to_string(),
+            },
+        ];
+
+        let block = build_hosts_block(&overrides);
+
+        assert!(block.contains(MARKER_START));
+        assert!(block.contains("65.9.168.80 clientsettingscdn.roblox.com"));
+        assert!(block.contains("128.116.46.3 clientsettings.roblox.com"));
+        assert!(block.contains(MARKER_END));
+        assert!(!block.contains("127.66.0.1"));
+    }
+
+    #[test]
+    fn parse_usable_a_records_accepts_cname_chain_with_public_answers() {
+        let body = r#"{
+            "Status": 0,
+            "Answer": [
+                {"name":"clientsettingscdn.roblox.com","type":5,"TTL":60,"data":"example.cloudfront.net."},
+                {"name":"example.cloudfront.net","type":1,"TTL":60,"data":"65.9.168.80"},
+                {"name":"example.cloudfront.net","type":1,"TTL":60,"data":"65.9.168.121"}
+            ]
+        }"#;
+
+        assert_eq!(
+            parse_usable_a_records(body).unwrap(),
+            vec![
+                Ipv4Addr::new(65, 9, 168, 80),
+                Ipv4Addr::new(65, 9, 168, 121)
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_usable_a_records_rejects_non_repairable_private_answer() {
+        let body = r#"{
+            "Status": 0,
+            "Answer": [
+                {"name":"clientsettingscdn.roblox.com","type":1,"TTL":60,"data":"127.0.0.1"},
+                {"name":"clientsettingscdn.roblox.com","type":1,"TTL":60,"data":"192.168.0.10"}
+            ]
+        }"#;
+
+        assert!(parse_usable_a_records(body).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_usable_a_records_rejects_nxdomain() {
+        let body = r#"{"Status": 3, "Answer": []}"#;
+
+        assert_eq!(parse_usable_a_records(body).unwrap_err(), "DNS status 3");
     }
 }

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -297,6 +297,7 @@ fn is_usable_public_ipv4(ip: Ipv4Addr) -> bool {
         || ip.is_multicast()
         || ip.is_broadcast()
         || octets[0] == 0
+        || octets[0] >= 240
         || (octets[0] == 100 && (64..=127).contains(&octets[1]))
         || (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
         || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
@@ -452,7 +453,8 @@ mod tests {
             "Status": 0,
             "Answer": [
                 {"name":"clientsettingscdn.roblox.com","type":1,"TTL":60,"data":"127.0.0.1"},
-                {"name":"clientsettingscdn.roblox.com","type":1,"TTL":60,"data":"192.168.0.10"}
+                {"name":"clientsettingscdn.roblox.com","type":1,"TTL":60,"data":"192.168.0.10"},
+                {"name":"clientsettingscdn.roblox.com","type":1,"TTL":60,"data":"240.0.0.1"}
             ]
         }"#;
 

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -57,7 +57,9 @@ struct DohJsonAnswer {
 /// Existing SwiftTunnel entries are removed first (idempotent).
 pub async fn apply_critical_settings_overrides() -> Result<(), String> {
     let overrides = resolve_critical_settings_overrides().await?;
-    write_overrides(&overrides)
+    tokio::task::spawn_blocking(move || write_overrides(&overrides))
+        .await
+        .map_err(|e| format!("Failed to join hosts repair task: {e}"))?
 }
 
 async fn resolve_critical_settings_overrides() -> Result<Vec<HostOverride>, String> {
@@ -100,7 +102,7 @@ async fn resolve_domain_ipv4(client: &reqwest::Client, domain: &str) -> Result<I
     let mut failures = Vec::new();
 
     for resolver in DNS_REPAIR_RESOLVERS {
-        let url = format!("{resolver}?name={domain}&type=A");
+        let url = build_doh_url(resolver, domain);
         let response = match client
             .get(&url)
             .header("accept", "application/dns-json")
@@ -170,7 +172,8 @@ fn write_overrides(overrides: &[HostOverride]) -> Result<(), String> {
     Ok(())
 }
 
-/// Remove any SwiftTunnel Roblox Proxy entries from the hosts file.
+/// Synchronous version used from startup recovery and `Drop`.
+/// Call `remove_overrides_async` from async contexts.
 pub fn remove_overrides() -> Result<(), String> {
     let path = hosts_path();
 
@@ -186,6 +189,13 @@ pub fn remove_overrides() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Remove any SwiftTunnel Roblox Proxy entries without blocking a Tokio worker.
+pub async fn remove_overrides_async() -> Result<(), String> {
+    tokio::task::spawn_blocking(remove_overrides)
+        .await
+        .map_err(|e| format!("Failed to join hosts cleanup task: {e}"))?
 }
 
 /// Called on app startup to clean up entries left by a previous crash.
@@ -251,6 +261,14 @@ fn build_hosts_block(overrides: &[HostOverride]) -> String {
     block.push_str(MARKER_END);
     block.push('\n');
     block
+}
+
+fn build_doh_url(resolver: &str, domain: &str) -> String {
+    let query = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("name", domain)
+        .append_pair("type", "A")
+        .finish();
+    format!("{resolver}?{query}")
 }
 
 fn parse_usable_a_records(body: &str) -> Result<Vec<Ipv4Addr>, String> {
@@ -394,6 +412,18 @@ mod tests {
         assert!(block.contains("128.116.46.3 clientsettings.roblox.com"));
         assert!(block.contains(MARKER_END));
         assert!(!block.contains("127.66.0.1"));
+    }
+
+    #[test]
+    fn build_doh_url_encodes_domain_query_value() {
+        assert_eq!(
+            build_doh_url("https://1.1.1.1/dns-query", "clientsettingscdn.roblox.com"),
+            "https://1.1.1.1/dns-query?name=clientsettingscdn.roblox.com&type=A"
+        );
+        assert_eq!(
+            build_doh_url("https://1.1.1.1/dns-query", "bad&name=wrong"),
+            "https://1.1.1.1/dns-query?name=bad%26name%3Dwrong&type=A"
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/roblox_proxy/mod.rs
+++ b/swifttunnel-core/src/roblox_proxy/mod.rs
@@ -1,8 +1,9 @@
-//! Roblox proxy hosts-file cleanup (legacy migration).
+//! Roblox critical-settings DNS repair.
 //!
-//! The local TCP proxy feature has been removed. This module only
-//! retains the hosts-file cleanup logic so that users upgrading from
-//! older versions have any stale `127.66.0.1` entries removed
-//! automatically on first launch.
+//! API tunneling can carry Roblox HTTPS traffic through a SwiftTunnel
+//! relay, but Roblox still needs a working local hostname lookup before
+//! it opens that TCP connection. This module keeps a narrow hosts-file
+//! repair for the critical settings endpoints and also removes stale
+//! entries from older local-proxy builds.
 
 pub mod hosts;

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -800,6 +800,8 @@ pub struct VpnConnection {
     auto_lookup_handle: Option<tokio::task::JoinHandle<()>>,
     /// Per-process game performance tuning manager (Windows-only behavior).
     process_performance_manager: Option<Arc<Mutex<GameProcessPerformanceManager>>>,
+    /// Tracks whether this connection wrote the temporary Roblox settings hosts repair.
+    critical_settings_dns_repair_applied: bool,
 }
 
 impl VpnConnection {
@@ -814,6 +816,7 @@ impl VpnConnection {
             auto_router: None,
             auto_lookup_handle: None,
             process_performance_manager: None,
+            critical_settings_dns_repair_applied: false,
         }
     }
 
@@ -1043,6 +1046,7 @@ impl VpnConnection {
         if enable_api_tunneling && !tunnel_apps.is_empty() {
             match crate::roblox_proxy::hosts::apply_critical_settings_overrides().await {
                 Ok(()) => {
+                    self.critical_settings_dns_repair_applied = true;
                     log::info!("V3: Applied Roblox critical settings DNS repair for API tunneling");
                 }
                 Err(e) => {
@@ -2399,8 +2403,15 @@ impl VpnConnection {
         // Cleanup WFP block filters
         super::wfp_block::cleanup();
 
-        if let Err(e) = crate::roblox_proxy::hosts::remove_overrides() {
-            log::warn!("Failed to remove Roblox critical settings DNS repair: {e}");
+        if self.critical_settings_dns_repair_applied {
+            match crate::roblox_proxy::hosts::remove_overrides_async().await {
+                Ok(()) => {
+                    self.critical_settings_dns_repair_applied = false;
+                }
+                Err(e) => {
+                    log::warn!("Failed to remove Roblox critical settings DNS repair: {e}");
+                }
+            }
         }
 
         // Reset auto-router
@@ -2615,8 +2626,10 @@ impl Drop for VpnConnection {
 
         super::wfp_block::cleanup();
 
-        if let Err(e) = crate::roblox_proxy::hosts::remove_overrides() {
-            log::warn!("Failed to remove Roblox critical settings DNS repair during drop: {e}");
+        if self.critical_settings_dns_repair_applied {
+            if let Err(e) = crate::roblox_proxy::hosts::remove_overrides() {
+                log::warn!("Failed to remove Roblox critical settings DNS repair during drop: {e}");
+            }
         }
     }
 }

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -1040,6 +1040,20 @@ impl VpnConnection {
         self.set_state(ConnectionState::ConfiguringSplitTunnel)
             .await;
 
+        if enable_api_tunneling && !tunnel_apps.is_empty() {
+            match crate::roblox_proxy::hosts::apply_critical_settings_overrides().await {
+                Ok(()) => {
+                    log::info!("V3: Applied Roblox critical settings DNS repair for API tunneling");
+                }
+                Err(e) => {
+                    log::warn!(
+                        "V3: Roblox critical settings DNS repair skipped; API tunneling will continue without hosts repair: {}",
+                        e
+                    );
+                }
+            }
+        }
+
         let mut active_server_region = config.region.clone();
         let mut active_server_endpoint = config.endpoint.clone();
 
@@ -2385,6 +2399,10 @@ impl VpnConnection {
         // Cleanup WFP block filters
         super::wfp_block::cleanup();
 
+        if let Err(e) = crate::roblox_proxy::hosts::remove_overrides() {
+            log::warn!("Failed to remove Roblox critical settings DNS repair: {e}");
+        }
+
         // Reset auto-router
         if let Some(ref auto_router) = self.auto_router {
             auto_router.reset();
@@ -2596,6 +2614,10 @@ impl Drop for VpnConnection {
         }
 
         super::wfp_block::cleanup();
+
+        if let Err(e) = crate::roblox_proxy::hosts::remove_overrides() {
+            log::warn!("Failed to remove Roblox critical settings DNS repair during drop: {e}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Repair Roblox critical-settings DNS when API tunneling is enabled by resolving the exact settings hostnames over HTTPS DNS to IP-literal resolvers.
- Write only temporary, marker-delimited hosts entries for `clientsettingscdn.roblox.com` and `clientsettings.roblox.com`, then flush DNS.
- Remove the repair block on disconnect, connection cleanup, drop, and existing startup stale-state recovery.
- Update the README packet-flow docs to describe the narrow API-tunneling DNS repair.

## Failure-Mode Plan

- Primary success: Roblox can resolve the critical settings hostnames and then open its launch-time HTTPS connection while API tunneling is enabled.
- Repairable failures: local resolver hijack, country-shaped DNS failure, NXDOMAIN from the system resolver, or plain DNS interception for the two known critical-settings hosts.
- Retryable failures: first HTTPS DNS resolver times out or returns no usable public A records; the repair tries the next configured resolver.
- Fatal/diagnostic-only failures: hosts file write permission errors, all HTTPS DNS lookups failing, endpoint HTTP/TLS errors after DNS is repaired, or a selected relay country being blocked at the actual HTTPS/CDN layer. Those are logged and API tunneling continues without claiming the DNS repair succeeded.
- Structured markers: cleanup only removes the exact SwiftTunnel marker-delimited hosts block; it does not scan incidental error text or broad domain substrings.
- Partial success and races: if only one critical hostname resolves, SwiftTunnel writes the one safe override and logs partial repair; stale entries are removed before writing new entries and again during cleanup/startup recovery.
- Tests: added positive parsing/block generation tests, a narrow-domain-list guard, NXDOMAIN rejection, and a negative test for superficially similar private/loopback answers that must not be written.

## Verification

- `cargo fmt --check` passed.
- `git diff --check` passed.
- `cargo test -p swifttunnel-core roblox_proxy::hosts --lib` blocked on macOS before SwiftTunnel tests by the known `windows-future` / `windows-core` mismatch (`IMarshal`, `marshaler`, `windows_threading::submit`).
- `cargo test -p swifttunnel-core dns --lib` blocked by the same macOS dependency mismatch.
- `cargo check -p swifttunnel-core --target x86_64-pc-windows-msvc` blocked locally because this Mac lacks the Windows/MSVC C toolchain for `ring` (`assert.h` missing under `--target=x86_64-pc-windows-msvc`).

Windows GitHub CI is the required Rust compile/test authority for this packet/app path.
