### PR TITLE
Repair Roblox bootstrap DNS for API tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when API tunneling is enabled, SwiftTunnel also repairs the exact Roblox critical-settings hostnames with temporary hosts-file entries resolved over HTTPS DNS so broken local resolvers do not block launch.
+SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when API tunneling is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS so broken local resolvers do not block launch.
 
 Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
 

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 const MARKER_START: &str = "# SwiftTunnel Roblox Proxy - START";
 const MARKER_END: &str = "# SwiftTunnel Roblox Proxy - END";
 const DNS_REPAIR_TIMEOUT: Duration = Duration::from_secs(3);
+const DNS_REPAIR_TOTAL_TIMEOUT: Duration = Duration::from_secs(10);
 const DNS_REPAIR_RESOLVERS: &[&str] = &[
     // IP literals avoid depending on the user's broken local DNS to find
     // the DNS-over-HTTPS resolver itself.
@@ -98,7 +99,16 @@ async fn resolve_bootstrap_overrides() -> Result<Vec<HostOverride>, String> {
         .iter()
         .map(|domain| async { (*domain, resolve_domain_ipv4(&client, domain).await) });
 
-    for (domain, result) in join_all(lookups).await {
+    let resolved = tokio::time::timeout(DNS_REPAIR_TOTAL_TIMEOUT, join_all(lookups))
+        .await
+        .map_err(|_| {
+            format!(
+                "Roblox bootstrap DNS repair exceeded {}s total timeout",
+                DNS_REPAIR_TOTAL_TIMEOUT.as_secs()
+            )
+        })?;
+
+    for (domain, result) in resolved {
         match result {
             Ok(ip) => overrides.push(HostOverride {
                 ip,
@@ -420,7 +430,7 @@ mod tests {
 
     #[test]
     fn domain_list_stays_allowlisted_and_exact() {
-        assert!(ROBLOX_BOOTSTRAP_DOMAINS.len() <= 32);
+        assert_eq!(ROBLOX_BOOTSTRAP_DOMAINS.len(), 19);
         assert!(!ROBLOX_BOOTSTRAP_DOMAINS.contains(&"roblox.com"));
         assert!(!ROBLOX_BOOTSTRAP_DOMAINS.contains(&"rbxcdn.com"));
         assert!(!ROBLOX_BOOTSTRAP_DOMAINS.contains(&"evilroblox.com"));

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -1,11 +1,11 @@
-//! Windows hosts-file management for Roblox critical-settings DNS repair.
+//! Windows hosts-file management for Roblox bootstrap DNS repair.
 //!
-//! Adds / removes marker-delimited entries for the small set of Roblox
-//! settings hostnames that must resolve before Roblox can open its
-//! launch-time HTTPS connection. The marker names are retained from the
-//! legacy local-proxy implementation so old `127.66.0.1` entries are
-//! removed reliably.
+//! Adds / removes marker-delimited entries for the small set of Roblox launch
+//! and API hostnames that must resolve before Roblox can open its launch-time
+//! HTTPS connections. The marker names are retained from the legacy local-proxy
+//! implementation so old `127.66.0.1` entries are removed reliably.
 
+use futures_util::future::join_all;
 use log::{debug, info, warn};
 use serde::Deserialize;
 use std::fs;
@@ -24,8 +24,31 @@ const DNS_REPAIR_RESOLVERS: &[&str] = &[
 ];
 
 /// Exact Roblox hostnames repaired when API tunneling is enabled.
-pub const CRITICAL_SETTINGS_DOMAINS: &[&str] =
-    &["clientsettingscdn.roblox.com", "clientsettings.roblox.com"];
+///
+/// This intentionally stays as an allowlist of concrete launch/API names. Do
+/// not add bare `roblox.com` or lookalike domains: hosts-file repair is a DNS
+/// bypass for known Roblox bootstrap dependencies, not a wildcard resolver.
+pub const ROBLOX_BOOTSTRAP_DOMAINS: &[&str] = &[
+    "clientsettingscdn.roblox.com",
+    "clientsettings.roblox.com",
+    "www.roblox.com",
+    "web.roblox.com",
+    "apis.roblox.com",
+    "auth.roblox.com",
+    "accountsettings.roblox.com",
+    "accountinformation.roblox.com",
+    "users.roblox.com",
+    "games.roblox.com",
+    "gamejoin.roblox.com",
+    "assetdelivery.roblox.com",
+    "thumbnails.roblox.com",
+    "presence.roblox.com",
+    "friends.roblox.com",
+    "chat.roblox.com",
+    "locale.roblox.com",
+    "setup.rbxcdn.com",
+    "apis.rbxcdn.com",
+];
 
 fn hosts_path() -> PathBuf {
     PathBuf::from(r"C:\Windows\System32\drivers\etc\hosts")
@@ -52,17 +75,17 @@ struct DohJsonAnswer {
     data: String,
 }
 
-/// Resolve and append critical Roblox settings overrides to the Windows hosts file.
+/// Resolve and append Roblox bootstrap overrides to the Windows hosts file.
 ///
 /// Existing SwiftTunnel entries are removed first (idempotent).
-pub async fn apply_critical_settings_overrides() -> Result<(), String> {
-    let overrides = resolve_critical_settings_overrides().await?;
+pub async fn apply_bootstrap_overrides() -> Result<(), String> {
+    let overrides = resolve_bootstrap_overrides().await?;
     tokio::task::spawn_blocking(move || write_overrides(&overrides))
         .await
         .map_err(|e| format!("Failed to join hosts repair task: {e}"))?
 }
 
-async fn resolve_critical_settings_overrides() -> Result<Vec<HostOverride>, String> {
+async fn resolve_bootstrap_overrides() -> Result<Vec<HostOverride>, String> {
     let client = reqwest::Client::builder()
         .timeout(DNS_REPAIR_TIMEOUT)
         .build()
@@ -71,11 +94,15 @@ async fn resolve_critical_settings_overrides() -> Result<Vec<HostOverride>, Stri
     let mut overrides = Vec::new();
     let mut failures = Vec::new();
 
-    for domain in CRITICAL_SETTINGS_DOMAINS {
-        match resolve_domain_ipv4(&client, domain).await {
+    let lookups = ROBLOX_BOOTSTRAP_DOMAINS
+        .iter()
+        .map(|domain| async { (*domain, resolve_domain_ipv4(&client, domain).await) });
+
+    for (domain, result) in join_all(lookups).await {
+        match result {
             Ok(ip) => overrides.push(HostOverride {
                 ip,
-                domain: (*domain).to_string(),
+                domain: domain.to_string(),
             }),
             Err(e) => failures.push(e),
         }
@@ -83,14 +110,14 @@ async fn resolve_critical_settings_overrides() -> Result<Vec<HostOverride>, Stri
 
     if overrides.is_empty() {
         return Err(format!(
-            "No critical settings hosts resolved via DNS-over-HTTPS: {}",
+            "No Roblox bootstrap hosts resolved via DNS-over-HTTPS: {}",
             failures.join("; ")
         ));
     }
 
     if !failures.is_empty() {
         warn!(
-            "Partial Roblox critical settings DNS repair: {}",
+            "Partial Roblox bootstrap DNS repair: {}",
             failures.join("; ")
         );
     }
@@ -164,7 +191,7 @@ fn write_overrides(overrides: &[HostOverride]) -> Result<(), String> {
     fs::write(&path, &out).map_err(|e| format!("Failed to write hosts file: {e}"))?;
 
     info!(
-        "Applied {} Roblox critical settings DNS override(s) to hosts file",
+        "Applied {} Roblox bootstrap DNS override(s) to hosts file",
         overrides.len()
     );
 
@@ -377,20 +404,33 @@ mod tests {
 
     #[test]
     fn domain_list_is_not_empty() {
-        assert!(!CRITICAL_SETTINGS_DOMAINS.is_empty());
+        assert!(!ROBLOX_BOOTSTRAP_DOMAINS.is_empty());
     }
 
     #[test]
-    fn domain_list_contains_critical_entries() {
-        assert!(CRITICAL_SETTINGS_DOMAINS.contains(&"clientsettings.roblox.com"));
-        assert!(CRITICAL_SETTINGS_DOMAINS.contains(&"clientsettingscdn.roblox.com"));
+    fn domain_list_contains_launch_entries() {
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.contains(&"clientsettings.roblox.com"));
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.contains(&"clientsettingscdn.roblox.com"));
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.contains(&"www.roblox.com"));
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.contains(&"apis.roblox.com"));
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.contains(&"auth.roblox.com"));
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.contains(&"gamejoin.roblox.com"));
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.contains(&"setup.rbxcdn.com"));
     }
 
     #[test]
-    fn domain_list_stays_narrow() {
-        assert_eq!(CRITICAL_SETTINGS_DOMAINS.len(), 2);
-        assert!(!CRITICAL_SETTINGS_DOMAINS.contains(&"roblox.com"));
-        assert!(!CRITICAL_SETTINGS_DOMAINS.contains(&"setup.rbxcdn.com"));
+    fn domain_list_stays_allowlisted_and_exact() {
+        assert!(ROBLOX_BOOTSTRAP_DOMAINS.len() <= 32);
+        assert!(!ROBLOX_BOOTSTRAP_DOMAINS.contains(&"roblox.com"));
+        assert!(!ROBLOX_BOOTSTRAP_DOMAINS.contains(&"rbxcdn.com"));
+        assert!(!ROBLOX_BOOTSTRAP_DOMAINS.contains(&"evilroblox.com"));
+        assert!(!ROBLOX_BOOTSTRAP_DOMAINS.contains(&"roblox.com.evil.test"));
+    }
+
+    #[test]
+    fn domain_list_has_no_duplicates() {
+        let unique: std::collections::HashSet<_> = ROBLOX_BOOTSTRAP_DOMAINS.iter().collect();
+        assert_eq!(unique.len(), ROBLOX_BOOTSTRAP_DOMAINS.len());
     }
 
     #[test]
@@ -404,6 +444,10 @@ mod tests {
                 ip: Ipv4Addr::new(128, 116, 46, 3),
                 domain: "clientsettings.roblox.com".to_string(),
             },
+            HostOverride {
+                ip: Ipv4Addr::new(128, 116, 121, 3),
+                domain: "www.roblox.com".to_string(),
+            },
         ];
 
         let block = build_hosts_block(&overrides);
@@ -411,6 +455,7 @@ mod tests {
         assert!(block.contains(MARKER_START));
         assert!(block.contains("65.9.168.80 clientsettingscdn.roblox.com"));
         assert!(block.contains("128.116.46.3 clientsettings.roblox.com"));
+        assert!(block.contains("128.116.121.3 www.roblox.com"));
         assert!(block.contains(MARKER_END));
         assert!(!block.contains("127.66.0.1"));
     }

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -108,6 +108,8 @@ async fn resolve_bootstrap_overrides() -> Result<Vec<HostOverride>, String> {
 
     loop {
         tokio::select! {
+            biased;
+
             result = lookups.next() => {
                 match result {
                     Some((domain, Ok(ip))) => overrides.push(HostOverride {

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -5,7 +5,7 @@
 //! HTTPS connections. The marker names are retained from the legacy local-proxy
 //! implementation so old `127.66.0.1` entries are removed reliably.
 
-use futures_util::future::join_all;
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use log::{debug, info, warn};
 use serde::Deserialize;
 use std::fs;
@@ -92,29 +92,43 @@ async fn resolve_bootstrap_overrides() -> Result<Vec<HostOverride>, String> {
         .build()
         .map_err(|e| format!("Failed to build DNS repair client: {e}"))?;
 
+    let mut lookups: FuturesUnordered<_> = ROBLOX_BOOTSTRAP_DOMAINS
+        .iter()
+        .map(|domain| {
+            let client = client.clone();
+            let domain = *domain;
+            async move { (domain, resolve_domain_ipv4(&client, domain).await) }
+        })
+        .collect();
+
     let mut overrides = Vec::new();
     let mut failures = Vec::new();
+    let total_deadline = tokio::time::sleep(DNS_REPAIR_TOTAL_TIMEOUT);
+    tokio::pin!(total_deadline);
 
-    let lookups = ROBLOX_BOOTSTRAP_DOMAINS
-        .iter()
-        .map(|domain| async { (*domain, resolve_domain_ipv4(&client, domain).await) });
-
-    let resolved = tokio::time::timeout(DNS_REPAIR_TOTAL_TIMEOUT, join_all(lookups))
-        .await
-        .map_err(|_| {
-            format!(
-                "Roblox bootstrap DNS repair exceeded {}s total timeout",
-                DNS_REPAIR_TOTAL_TIMEOUT.as_secs()
-            )
-        })?;
-
-    for (domain, result) in resolved {
-        match result {
-            Ok(ip) => overrides.push(HostOverride {
-                ip,
-                domain: domain.to_string(),
-            }),
-            Err(e) => failures.push(e),
+    loop {
+        tokio::select! {
+            result = lookups.next() => {
+                match result {
+                    Some((domain, Ok(ip))) => overrides.push(HostOverride {
+                        ip,
+                        domain: domain.to_string(),
+                    }),
+                    Some((_domain, Err(e))) => failures.push(e),
+                    None => break,
+                }
+            }
+            _ = &mut total_deadline => {
+                let remaining = lookups.len();
+                if remaining > 0 {
+                    failures.push(format!(
+                        "{} Roblox bootstrap DNS lookup(s) exceeded {}s total timeout",
+                        remaining,
+                        DNS_REPAIR_TOTAL_TIMEOUT.as_secs()
+                    ));
+                }
+                break;
+            }
         }
     }
 

--- a/swifttunnel-core/src/roblox_proxy/mod.rs
+++ b/swifttunnel-core/src/roblox_proxy/mod.rs
@@ -1,9 +1,9 @@
-//! Roblox critical-settings DNS repair.
+//! Roblox bootstrap DNS repair.
 //!
 //! API tunneling can carry Roblox HTTPS traffic through a SwiftTunnel
 //! relay, but Roblox still needs a working local hostname lookup before
 //! it opens that TCP connection. This module keeps a narrow hosts-file
-//! repair for the critical settings endpoints and also removes stale
+//! repair for launch/API endpoints and also removes stale
 //! entries from older local-proxy builds.
 
 pub mod hosts;

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -800,8 +800,8 @@ pub struct VpnConnection {
     auto_lookup_handle: Option<tokio::task::JoinHandle<()>>,
     /// Per-process game performance tuning manager (Windows-only behavior).
     process_performance_manager: Option<Arc<Mutex<GameProcessPerformanceManager>>>,
-    /// Tracks whether this connection wrote the temporary Roblox settings hosts repair.
-    critical_settings_dns_repair_applied: bool,
+    /// Tracks whether this connection wrote the temporary Roblox bootstrap hosts repair.
+    bootstrap_dns_repair_applied: bool,
 }
 
 impl VpnConnection {
@@ -816,7 +816,7 @@ impl VpnConnection {
             auto_router: None,
             auto_lookup_handle: None,
             process_performance_manager: None,
-            critical_settings_dns_repair_applied: false,
+            bootstrap_dns_repair_applied: false,
         }
     }
 
@@ -1044,14 +1044,14 @@ impl VpnConnection {
             .await;
 
         if enable_api_tunneling && !tunnel_apps.is_empty() {
-            match crate::roblox_proxy::hosts::apply_critical_settings_overrides().await {
+            match crate::roblox_proxy::hosts::apply_bootstrap_overrides().await {
                 Ok(()) => {
-                    self.critical_settings_dns_repair_applied = true;
-                    log::info!("V3: Applied Roblox critical settings DNS repair for API tunneling");
+                    self.bootstrap_dns_repair_applied = true;
+                    log::info!("V3: Applied Roblox bootstrap DNS repair for API tunneling");
                 }
                 Err(e) => {
                     log::warn!(
-                        "V3: Roblox critical settings DNS repair skipped; API tunneling will continue without hosts repair: {}",
+                        "V3: Roblox bootstrap DNS repair skipped; API tunneling will continue without hosts repair: {}",
                         e
                     );
                 }
@@ -2403,13 +2403,13 @@ impl VpnConnection {
         // Cleanup WFP block filters
         super::wfp_block::cleanup();
 
-        if self.critical_settings_dns_repair_applied {
+        if self.bootstrap_dns_repair_applied {
             match crate::roblox_proxy::hosts::remove_overrides_async().await {
                 Ok(()) => {
-                    self.critical_settings_dns_repair_applied = false;
+                    self.bootstrap_dns_repair_applied = false;
                 }
                 Err(e) => {
-                    log::warn!("Failed to remove Roblox critical settings DNS repair: {e}");
+                    log::warn!("Failed to remove Roblox bootstrap DNS repair: {e}");
                 }
             }
         }
@@ -2626,9 +2626,9 @@ impl Drop for VpnConnection {
 
         super::wfp_block::cleanup();
 
-        if self.critical_settings_dns_repair_applied {
+        if self.bootstrap_dns_repair_applied {
             if let Err(e) = crate::roblox_proxy::hosts::remove_overrides() {
-                log::warn!("Failed to remove Roblox critical settings DNS repair during drop: {e}");
+                log::warn!("Failed to remove Roblox bootstrap DNS repair during drop: {e}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- expand API tunneling DNS repair from only Roblox critical settings to exact Roblox launch/API bootstrap hostnames
- resolve the host allowlist concurrently through IP-literal DNS-over-HTTPS so one slow lookup does not stall connect
- keep marker-delimited hosts cleanup and crash recovery unchanged
- update README packet-flow docs for the broader bootstrap DNS repair

## Failure-mode plan
- Primary success: Roblox can resolve and reach the launch/API hostnames needed after critical settings while API tunneling is enabled.
- Repairable: local/country DNS NXDOMAIN, poisoned resolver answers, or resolver interception for the exact allowlisted Roblox bootstrap hostnames.
- Retryable: one DoH resolver timing out, returning no usable public A record, or failing for a single hostname; the next resolver/hostname still proceeds.
- Fatal/diagnostic-only: hosts-file permission failures, all DoH lookups failing, Roblox/CDN HTTP rejection from the selected relay country, and non-DNS network failures after the hosts repair.
- Structured markers: cleanup only removes the `# SwiftTunnel Roblox Proxy` marker block; it does not broad-substring delete arbitrary hosts entries.
- Partial success/races: writes every hostname that resolves, logs partial failures, runs resolution concurrently under a bounded request timeout, and removes stale entries before writing plus on disconnect/startup/drop.
- Negative coverage: tests reject bare `roblox.com`, bare `rbxcdn.com`, and lookalike domains so the repair cannot silently become a wildcard DNS bypass.

## Tests
- `node scripts/check-desktop-version-sync.mjs`
- `cargo fmt --check`
- `git diff --check`
- `npm test -- --run`
- `npx tsc --noEmit`
- `npm run build`

## Notes
- `cargo test -p swifttunnel-core roblox_proxy::hosts --lib` is blocked locally on macOS by the known `windows-future` / `windows-core` mismatch before it reaches crate tests; GitHub Windows CI is the authoritative Rust gate for this path.
