### PR TITLE
[codex] Add Roblox Route Assist browser tunneling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ on:
       - ".github/workflows/ci.yml"
       - ".github/workflows/release.yml"
   workflow_dispatch:
+    inputs:
+      force_testbench:
+        description: "Queue the self-hosted Windows testbench without probing runner availability. Use only after confirming the runner is online."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -129,9 +135,9 @@ jobs:
         run: |
           set -o pipefail
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${{ inputs.force_testbench || false }}" == "true" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Manual CI dispatch requested; queueing the split tunnel testbench."
+            echo "::notice::Manual CI dispatch requested with force_testbench=true; caller confirmed the split tunnel testbench runner is online."
             exit 0
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -o pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Manual CI dispatch requested; queueing the split tunnel testbench."
+            exit 0
+          fi
+
           set +e
           matching_runner_count="$(
             gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runners" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Ensure Git Bash
+        shell: powershell
+        run: |
+          $gitBashPaths = @(
+            'C:\Program Files\Git\bin',
+            'C:\Program Files\Git\usr\bin'
+          ) | Where-Object { Test-Path $_ }
+
+          if ($gitBashPaths.Count -eq 0) {
+            throw 'Git Bash was not found on the testbench runner.'
+          }
+
+          foreach ($path in $gitBashPaths) {
+            $path | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            $env:Path = "$path;$env:Path"
+          }
+
+          bash --version
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
       - name: Run split tunnel API tunneling testbench
         shell: powershell
         env:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@
 ### 🎯 Smart Split Tunneling
 Only game traffic is optimized through SwiftTunnel. Discord, Spotify, Chrome — everything else uses your normal internet. No bandwidth wasted.
 
+### 🧭 Roblox Route Assist
+Optional Roblox login/API HTTP(S) routing helps users bypass network bans and gives Roblox a better chance of placing sessions near the SwiftTunnel region they picked. Browser traffic is still scoped to Roblox destinations only; unrelated websites keep using the normal connection.
+
 ### ⚡ Low Latency Gaming Servers
 27 gaming-optimized relays across 12 gaming regions. Each relay runs:
 - **BBR** congestion control for faster throughput
@@ -103,7 +106,7 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when API tunneling is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS so broken local resolvers do not block launch.
+SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic, through the selected relay. Non-Roblox browser traffic still bypasses SwiftTunnel.
 
 Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
 

--- a/swifttunnel-core/src/settings.rs
+++ b/swifttunnel-core/src/settings.rs
@@ -173,10 +173,11 @@ pub struct AppSettings {
     #[serde(default)]
     pub game_process_performance: GameProcessPerformanceSettings,
 
-    /// Route game TCP/HTTPS traffic through the relay to bypass ISP blocking.
+    /// Route Roblox TCP/HTTPS traffic through the relay to bypass ISP blocking.
     ///
-    /// When enabled, TCP packets from tunnel apps are forwarded through the
-    /// V3 relay alongside UDP game traffic. Off by default.
+    /// When enabled, TCP packets from tunnel apps and browser-owned Roblox
+    /// login/API HTTP(S) flows are forwarded through the V3 relay alongside
+    /// UDP game traffic. Off by default.
     #[serde(default)]
     pub enable_api_tunneling: bool,
 }

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6574,6 +6574,31 @@ fn process_name_in_tunnel_scope(name: &str, snapshot: &ProcessSnapshot) -> bool 
     process_name_matches_any_tunnel_app(&name_lower, &snapshot.tunnel_apps)
 }
 
+fn process_name_stem_lower(name: &str) -> String {
+    let file_name = name.rsplit(['\\', '/']).next().unwrap_or(name).trim();
+    let lower = file_name.to_ascii_lowercase();
+    lower
+        .strip_suffix(".exe")
+        .unwrap_or(lower.as_str())
+        .to_string()
+}
+
+fn process_name_in_browser_http_scope(name: &str) -> bool {
+    matches!(
+        process_name_stem_lower(name).as_str(),
+        "arc"
+            | "brave"
+            | "brave-browser"
+            | "chrome"
+            | "firefox"
+            | "msedge"
+            | "opera"
+            | "opera_gx"
+            | "operagx"
+            | "vivaldi"
+    )
+}
+
 fn tcp_owner_matches_tunnel_scope<P>(
     pid: u32,
     snapshot: &ProcessSnapshot,
@@ -6593,6 +6618,24 @@ where
     process_name_lookup(pid)
         .as_deref()
         .map(|name| process_name_in_tunnel_scope(name, snapshot))
+        .unwrap_or(false)
+}
+
+fn tcp_owner_matches_browser_http_scope<P>(
+    pid: u32,
+    snapshot: &ProcessSnapshot,
+    process_name_lookup: &P,
+) -> bool
+where
+    P: Fn(u32) -> Option<String>,
+{
+    if let Some(name) = snapshot.pid_names.get(&pid) {
+        return process_name_in_browser_http_scope(name);
+    }
+
+    process_name_lookup(pid)
+        .as_deref()
+        .map(process_name_in_browser_http_scope)
         .unwrap_or(false)
 }
 
@@ -6833,13 +6876,18 @@ where
         //
         // TCP speculation is allowed only when API tunneling is enabled and a
         // tunnel process is already known. This catches first SYNs for Roblox
-        // API/teleport flows before the owner table publishes the source port,
-        // without enabling broad browser-only Roblox traffic tunneling.
+        // API/teleport flows before the owner table publishes the source port.
+        // Browser-owned HTTP(S) is allowed only for Roblox destinations so
+        // login/account flows can share the selected relay without tunneling
+        // unrelated browser traffic.
         let has_tunnel_scope = !snapshot.tunnel_pids.is_empty() || !snapshot.tunnel_apps.is_empty();
         let can_speculate_tcp_api = protocol == Protocol::Tcp && api_tunneling && has_tunnel_scope;
         let is_tcp_api_bootstrap_syn =
             can_speculate_tcp_api && is_tcp_initial_syn && matches!(dst_port, 80 | 443);
-        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn {
+        let is_roblox_http_dst = can_speculate_tcp_api
+            && matches!(dst_port, 80 | 443)
+            && super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling);
+        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn || is_roblox_http_dst {
             tcp_owner_lookup(src_ip, src_port)
         } else {
             None
@@ -6847,12 +6895,20 @@ where
         let tcp_api_bootstrap_owned_by_tunnel = tcp_api_bootstrap_owner
             .map(|pid| tcp_owner_matches_tunnel_scope(pid, snapshot, &process_name_lookup))
             .unwrap_or(false);
+        let tcp_api_bootstrap_owned_by_browser = tcp_api_bootstrap_owner
+            .map(|pid| tcp_owner_matches_browser_http_scope(pid, snapshot, &process_name_lookup))
+            .unwrap_or(false);
+        let tcp_api_bootstrap_owned_by_browser_roblox =
+            tcp_api_bootstrap_owned_by_browser && is_roblox_http_dst;
         let tcp_api_bootstrap_known_unrelated = tcp_api_bootstrap_owner
-            .map(|pid| !tcp_owner_matches_tunnel_scope(pid, snapshot, &process_name_lookup))
+            .map(|_| {
+                !tcp_api_bootstrap_owned_by_tunnel && !tcp_api_bootstrap_owned_by_browser_roblox
+            })
             .unwrap_or(false);
         let tcp_api_bootstrap_allowed =
             is_tcp_api_bootstrap_syn && !tcp_api_bootstrap_known_unrelated;
-        let is_game_dst = (protocol == Protocol::Udp || can_speculate_tcp_api)
+        let is_game_dst = (protocol == Protocol::Udp
+            || (can_speculate_tcp_api && !tcp_api_bootstrap_known_unrelated))
             && super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling);
         if is_game_dst || tcp_api_bootstrap_allowed {
             // Log speculative tunneling for debugging (first 20 times only)
@@ -6869,14 +6925,15 @@ where
                 });
                 if spec_count < 20 {
                     log::info!(
-                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (Roblox destination or API bootstrap, initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={})",
+                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (Roblox destination or API bootstrap, initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={}, owner_is_browser_roblox={})",
                         src_ip,
                         src_port,
                         dst_ip,
                         dst_port,
                         is_tcp_initial_syn,
                         tcp_api_bootstrap_owner,
-                        tcp_api_bootstrap_owned_by_tunnel
+                        tcp_api_bootstrap_owned_by_tunnel,
+                        tcp_api_bootstrap_owned_by_browser_roblox
                     );
                 }
             } else {
@@ -10936,6 +10993,161 @@ mod tests {
                 |pid| {
                     if pid == unrelated_pid {
                         Some("chrome.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_allows_browser_owned_roblox_http_syn() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let roblox_api_ip = Ipv4Addr::new(128, 116, 50, 3);
+        let src_port = 40010;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+        let browser_pid = 9002;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, roblox_api_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(browser_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == browser_pid {
+                        Some(
+                            "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+                                .to_string(),
+                        )
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_does_not_allow_browser_owned_non_roblox_http_syn() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let unrelated_ip = Ipv4Addr::new(93, 184, 216, 34);
+        let src_port = 40011;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+        let browser_pid = 9002;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, unrelated_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(browser_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == browser_pid {
+                        Some("chrome.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_does_not_allow_unrelated_owner_to_roblox_http_syn() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let roblox_api_ip = Ipv4Addr::new(128, 116, 50, 3);
+        let src_port = 40012;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+        let unrelated_pid = 9003;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, roblox_api_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(unrelated_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == unrelated_pid {
+                        Some("Discord.exe".to_string())
                     } else {
                         None
                     }

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6899,9 +6899,11 @@ where
             .unwrap_or(false);
         let tcp_api_bootstrap_allowed =
             is_tcp_api_bootstrap_syn && !tcp_api_bootstrap_known_unrelated;
-        let is_game_dst = (protocol == Protocol::Udp
-            || (can_speculate_tcp_api && !tcp_api_bootstrap_known_unrelated))
-            && super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling);
+        let is_game_dst = if protocol == Protocol::Udp {
+            super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
+        } else {
+            is_roblox_http_dst && is_tcp_initial_syn && !tcp_api_bootstrap_known_unrelated
+        };
         if is_game_dst || tcp_api_bootstrap_allowed {
             // Log speculative tunneling for debugging (first 20 times only)
             thread_local! {
@@ -10729,7 +10731,7 @@ mod tests {
             created_at: std::time::Instant::now(),
         };
 
-        let frame = build_ipv4_frame(6, src_ip, dst_ip, src_port, dst_port);
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x02);
         let mut inline_cache: InlineCache = HashMap::new();
 
         assert!(should_route_to_vpn_with_inline_cache_and_tcp_owner_lookup(
@@ -11163,6 +11165,62 @@ mod tests {
     }
 
     #[test]
+    fn test_tcp_api_tunneling_does_not_tunnel_follow_on_packet_after_rejected_syn() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let roblox_api_ip = Ipv4Addr::new(128, 116, 50, 3);
+        let src_port = 40013;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+        let unrelated_pid = 9004;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let syn_frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, roblox_api_ip, src_port, dst_port, 0x02);
+        let follow_on_frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, roblox_api_ip, src_port, dst_port, 0x18);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        let mut route = |frame: &[u8]| {
+            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(unrelated_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == unrelated_pid {
+                        Some("Discord.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        };
+
+        assert!(!route(&syn_frame));
+        assert!(!route(&follow_on_frame));
+        assert!(inline_cache.is_empty());
+    }
+
+    #[test]
     fn test_tcp_api_tunneling_does_not_bootstrap_non_syn_asset_packet() {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let cdn_ip = Ipv4Addr::new(184, 87, 193, 160);
@@ -11217,6 +11275,39 @@ mod tests {
         };
 
         let frame = build_ipv4_tcp_frame_with_flags(src_ip, cdn_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(!should_route_to_vpn_with_inline_cache(
+            &frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_does_not_speculate_roblox_non_http_syn() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let roblox_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let src_port = 40014;
+        let dst_port = 8443;
+        let tunnel_pid = 1234;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, roblox_ip, src_port, dst_port, 0x02);
         let mut inline_cache: InlineCache = HashMap::new();
 
         assert!(!should_route_to_vpn_with_inline_cache(

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6590,53 +6590,46 @@ fn process_name_in_browser_http_scope(name: &str) -> bool {
             | "brave"
             | "brave-browser"
             | "chrome"
+            | "chromium"
+            | "chromium-browser"
             | "firefox"
             | "msedge"
             | "opera"
+            | "opera-browser"
             | "opera_gx"
             | "operagx"
             | "vivaldi"
     )
 }
 
-fn tcp_owner_matches_tunnel_scope<P>(
+fn tcp_owner_scope_match<P>(
     pid: u32,
     snapshot: &ProcessSnapshot,
     process_name_lookup: &P,
-) -> bool
+) -> (bool, bool)
 where
     P: Fn(u32) -> Option<String>,
 {
     if snapshot.is_tunnel_pid_public(pid) {
-        return true;
+        return (true, false);
     }
 
     if let Some(name) = snapshot.pid_names.get(&pid) {
-        return process_name_in_tunnel_scope(name, snapshot);
+        return (
+            process_name_in_tunnel_scope(name, snapshot),
+            process_name_in_browser_http_scope(name),
+        );
     }
 
-    process_name_lookup(pid)
-        .as_deref()
-        .map(|name| process_name_in_tunnel_scope(name, snapshot))
-        .unwrap_or(false)
-}
+    let name = process_name_lookup(pid);
+    let Some(name) = name.as_deref() else {
+        return (false, false);
+    };
 
-fn tcp_owner_matches_browser_http_scope<P>(
-    pid: u32,
-    snapshot: &ProcessSnapshot,
-    process_name_lookup: &P,
-) -> bool
-where
-    P: Fn(u32) -> Option<String>,
-{
-    if let Some(name) = snapshot.pid_names.get(&pid) {
-        return process_name_in_browser_http_scope(name);
-    }
-
-    process_name_lookup(pid)
-        .as_deref()
-        .map(process_name_in_browser_http_scope)
-        .unwrap_or(false)
+    (
+        process_name_in_tunnel_scope(name, snapshot),
+        process_name_in_browser_http_scope(name),
+    )
 }
 
 /// Debug counters for inline cache diagnostics
@@ -6885,6 +6878,7 @@ where
         let is_tcp_api_bootstrap_syn =
             can_speculate_tcp_api && is_tcp_initial_syn && matches!(dst_port, 80 | 443);
         let is_roblox_http_dst = can_speculate_tcp_api
+            && is_tcp_initial_syn
             && matches!(dst_port, 80 | 443)
             && super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling);
         let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn || is_roblox_http_dst {
@@ -6892,12 +6886,10 @@ where
         } else {
             None
         };
-        let tcp_api_bootstrap_owned_by_tunnel = tcp_api_bootstrap_owner
-            .map(|pid| tcp_owner_matches_tunnel_scope(pid, snapshot, &process_name_lookup))
-            .unwrap_or(false);
-        let tcp_api_bootstrap_owned_by_browser = tcp_api_bootstrap_owner
-            .map(|pid| tcp_owner_matches_browser_http_scope(pid, snapshot, &process_name_lookup))
-            .unwrap_or(false);
+        let (tcp_api_bootstrap_owned_by_tunnel, tcp_api_bootstrap_owned_by_browser) =
+            tcp_api_bootstrap_owner
+                .map(|pid| tcp_owner_scope_match(pid, snapshot, &process_name_lookup))
+                .unwrap_or((false, false));
         let tcp_api_bootstrap_owned_by_browser_roblox =
             tcp_api_bootstrap_owned_by_browser && is_roblox_http_dst;
         let tcp_api_bootstrap_known_unrelated = tcp_api_bootstrap_owner
@@ -11000,6 +10992,19 @@ mod tests {
             )
         );
         assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_browser_http_scope_matches_exact_browser_stems() {
+        assert!(process_name_in_browser_http_scope(
+            "C:\\Program Files\\Google\\Chrome\\Application\\Chrome.exe"
+        ));
+        assert!(process_name_in_browser_http_scope(
+            "C:\\Browsers\\chromium-browser.exe"
+        ));
+        assert!(process_name_in_browser_http_scope("opera-browser.exe"));
+        assert!(!process_name_in_browser_http_scope("chrome_helper.exe"));
+        assert!(!process_name_in_browser_http_scope("Discord.exe"));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6881,7 +6881,7 @@ where
             && is_tcp_initial_syn
             && matches!(dst_port, 80 | 443)
             && super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling);
-        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn || is_roblox_http_dst {
+        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn {
             tcp_owner_lookup(src_ip, src_port)
         } else {
             None

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -383,9 +383,9 @@ impl ProcessSnapshot {
         }
 
         // Process not detected - use strict IP range check for speculative tunneling.
-        // This remains UDP-only. TCP API tunneling must be tied to a detected
-        // tunnel process or a tunnel-owned source port, otherwise arbitrary
-        // Roblox web traffic from other apps can be routed through the relay.
+        // This remains UDP-only in the snapshot cache. The packet classifier
+        // handles TCP API tunneling separately so owner-table checks can keep
+        // browser routing scoped to Roblox HTTP(S) instead of all web traffic.
         protocol == Protocol::Udp && is_game_server(dst_ip, dst_port, protocol, api_tunneling)
     }
 

--- a/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
+++ b/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
@@ -16,7 +16,7 @@ import {
   stateLabel,
 } from "./connectState";
 import { LiveGraph, type DataSample } from "./LiveGraph";
-import { Button, EmptyState, Tooltip, InfoIcon } from "../ui";
+import { Button, EmptyState, Tooltip, InfoIcon, Toggle } from "../ui";
 import type { ServerRegion } from "../../lib/types";
 
 type ConnectStatus = ReturnType<typeof resolveConnectStatus>;
@@ -194,6 +194,11 @@ export function ConnectTab() {
     if (server) cur[regionId] = server;
     else delete cur[regionId];
     update({ forced_servers: cur });
+    saveDebounced();
+  }
+
+  function setRouteAssist(enabled: boolean) {
+    update({ enable_api_tunneling: enabled });
     saveDebounced();
   }
 
@@ -379,6 +384,12 @@ export function ConnectTab() {
         </Button>
       </section>
 
+      <RouteAssistPanel
+        enabled={settings.enable_api_tunneling}
+        disabled={isConnected || isTransitioning}
+        onChange={setRouteAssist}
+      />
+
       {/* ── Throughput (connected) ── */}
       {isConnected && (
         <motion.section
@@ -542,6 +553,66 @@ export function ConnectTab() {
 }
 
 // ── Sub-components ──
+
+function RouteAssistPanel({
+  enabled,
+  disabled,
+  onChange,
+}: {
+  enabled: boolean;
+  disabled: boolean;
+  onChange: (enabled: boolean) => void;
+}) {
+  return (
+    <section
+      className="flex items-center justify-between gap-4 rounded-[var(--radius-card)] px-4 py-3"
+      style={{
+        backgroundColor: enabled
+          ? "var(--color-accent-primary-soft-10)"
+          : "var(--color-bg-card)",
+        border: `1px solid ${
+          enabled
+            ? "var(--color-accent-primary)"
+            : "var(--color-border-subtle)"
+        }`,
+      }}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="text-[13px] font-semibold text-text-primary">
+            Roblox Route Assist
+          </h3>
+          <Tooltip content="Routes Roblox login/API HTTP(S) through the selected relay, including browser-owned Roblox auth traffic. Non-Roblox browser traffic still bypasses SwiftTunnel.">
+            <span className="inline-flex">
+              <InfoIcon />
+            </span>
+          </Tooltip>
+          {enabled && (
+            <span
+              className="rounded-[4px] px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-[0.1em]"
+              style={{
+                backgroundColor: "var(--color-bg-base)",
+                color: "var(--color-text-primary)",
+              }}
+            >
+              On
+            </span>
+          )}
+        </div>
+        <p className="mt-1 max-w-[620px] text-[11.5px] leading-relaxed text-text-muted">
+          Use this if you are bypassing a network ban or want a higher chance of
+          Roblox placing you near the region you tunnel to.
+        </p>
+      </div>
+      <Toggle
+        enabled={enabled}
+        disabled={disabled}
+        ariaLabel="Roblox Route Assist"
+        onChange={onChange}
+      />
+    </section>
+  );
+}
 
 function MetricCell({
   label,

--- a/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
+++ b/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
@@ -449,10 +449,10 @@ export function SettingsTab() {
         )}
 
         <Row
-          label="API Tunneling"
-          desc="Route game API calls through relay to bypass ISP blocking"
+          label="Roblox Route Assist"
+          desc="Use when bypassing a network ban or to improve region-matching odds"
           tooltip={
-            <Tooltip content="TCP traffic from game processes is also tunneled through the relay server. Helps when your ISP blocks game API endpoints.">
+            <Tooltip content="Routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic, through the relay. Non-Roblox browser traffic still bypasses SwiftTunnel.">
               <span className="inline-flex">
                 <InfoIcon />
               </span>
@@ -461,7 +461,7 @@ export function SettingsTab() {
         >
           <Toggle
             enabled={settings.enable_api_tunneling}
-            ariaLabel="API Tunneling"
+            ariaLabel="Roblox Route Assist"
             onChange={(v) => set({ enable_api_tunneling: v })}
           />
         </Row>


### PR DESCRIPTION
## Summary
- rename the user-facing API Tunneling setting to Roblox Route Assist and surface it on the Connect page
- allow browser-owned Roblox HTTP(S) traffic to use the selected relay while keeping unrelated browser traffic on the normal connection
- update README/settings docs for the new behavior

## Failure-mode plan
- Primary success: Roblox login/API HTTP(S) owned by a browser process tunnels only when the destination is a Roblox IP and Route Assist is enabled.
- Repairable failures: missing/stale Roblox bootstrap DNS repair can still fall back to existing hosts repair and owner-table retry behavior.
- Fatal or diagnostic-only: missing TCP owner, Route Assist disabled, no tunnel scope, or a non-Roblox destination must not trigger browser tunneling.
- Structured signals: process identity uses exact browser process stems and Roblox destination classification, not broad substring matching.
- Partial/race states: unknown owners can still use the existing first-packet TCP bootstrap path when a tunnel scope exists; once an owner is known unrelated, the packet bypasses and does not seed the inline cache.
- Tests: positive browser-owned Roblox HTTP(S), negative browser-owned non-Roblox HTTP(S), negative unrelated-owner Roblox HTTP(S), and negative follow-on traffic after a rejected SYN.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p swifttunnel-core test_tcp_api_tunneling -- --nocapture` hit the known macOS `windows-future` / `windows-core` mismatch before project tests (`IMarshal`, `marshaler`, `windows_threading::submit`); Windows CI below is the authoritative Rust proof for this path
- `npm ci`
- `npm test -- --run` (123 tests)
- `npx tsc --noEmit`
- `npm run build`
- local browser render check: Connect page shows Roblox Route Assist copy, exactly one matching switch, and no console errors
- PR CI run 25748142101: Frontend Build passed; Rust Check (GitHub Windows) passed; Split Tunnel Testbench Availability passed; automatic Split Tunnel Testbench skipped by design when the PR runner probe cannot authenticate
- manual CI run 25748155381 with `force_testbench=true`: Frontend Build passed; Rust Check (GitHub Windows) passed; Split Tunnel Testbench (Windows) passed
- Greptile reviewed latest head `1a498236427476da10672dd02c723c33565946b5`: confidence 5/5, safe to merge, no correctness issues remain
