### PR TITLE
[codex] Route bootstrap CDN IPs with Route Assist

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic, through the selected relay. Non-Roblox browser traffic still bypasses SwiftTunnel.
+SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic and the temporary CDN IPs resolved for those bootstrap hostnames, through the selected relay. Non-Roblox browser traffic still bypasses SwiftTunnel.
 
 Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
 

--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -8,9 +8,11 @@
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use log::{debug, info, warn};
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::fs;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
+use std::sync::{OnceLock, RwLock};
 use std::time::Duration;
 
 const MARKER_START: &str = "# SwiftTunnel Roblox Proxy - START";
@@ -23,6 +25,8 @@ const DNS_REPAIR_RESOLVERS: &[&str] = &[
     "https://1.1.1.1/dns-query",
     "https://8.8.8.8/resolve",
 ];
+
+static ACTIVE_BOOTSTRAP_IPS: OnceLock<RwLock<HashSet<Ipv4Addr>>> = OnceLock::new();
 
 /// Exact Roblox hostnames repaired when API tunneling is enabled.
 ///
@@ -81,9 +85,21 @@ struct DohJsonAnswer {
 /// Existing SwiftTunnel entries are removed first (idempotent).
 pub async fn apply_bootstrap_overrides() -> Result<(), String> {
     let overrides = resolve_bootstrap_overrides().await?;
+    let active_ips: HashSet<Ipv4Addr> = overrides.iter().map(|entry| entry.ip).collect();
+
     tokio::task::spawn_blocking(move || write_overrides(&overrides))
         .await
-        .map_err(|e| format!("Failed to join hosts repair task: {e}"))?
+        .map_err(|e| format!("Failed to join hosts repair task: {e}"))??;
+
+    set_active_bootstrap_ips(active_ips);
+    Ok(())
+}
+
+pub fn is_active_bootstrap_ip(ip: Ipv4Addr) -> bool {
+    active_bootstrap_ips()
+        .read()
+        .map(|ips| ips.contains(&ip))
+        .unwrap_or(false)
 }
 
 async fn resolve_bootstrap_overrides() -> Result<Vec<HostOverride>, String> {
@@ -228,6 +244,12 @@ fn write_overrides(overrides: &[HostOverride]) -> Result<(), String> {
 /// Synchronous version used from startup recovery and `Drop`.
 /// Call `remove_overrides_async` from async contexts.
 pub fn remove_overrides() -> Result<(), String> {
+    let result = remove_overrides_inner();
+    clear_active_bootstrap_ips();
+    result
+}
+
+fn remove_overrides_inner() -> Result<(), String> {
     let path = hosts_path();
 
     let content =
@@ -242,6 +264,34 @@ pub fn remove_overrides() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn active_bootstrap_ips() -> &'static RwLock<HashSet<Ipv4Addr>> {
+    ACTIVE_BOOTSTRAP_IPS.get_or_init(|| RwLock::new(HashSet::new()))
+}
+
+fn set_active_bootstrap_ips(ips: HashSet<Ipv4Addr>) {
+    match active_bootstrap_ips().write() {
+        Ok(mut active) => *active = ips,
+        Err(e) => warn!("Failed to publish Roblox bootstrap route IPs: {e}"),
+    }
+}
+
+fn clear_active_bootstrap_ips() {
+    match active_bootstrap_ips().write() {
+        Ok(mut active) => active.clear(),
+        Err(e) => warn!("Failed to clear Roblox bootstrap route IPs: {e}"),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn set_active_bootstrap_ips_for_test(ips: impl IntoIterator<Item = Ipv4Addr>) {
+    set_active_bootstrap_ips(ips.into_iter().collect());
+}
+
+#[cfg(test)]
+pub(crate) fn clear_active_bootstrap_ips_for_test() {
+    clear_active_bootstrap_ips();
 }
 
 /// Remove any SwiftTunnel Roblox Proxy entries without blocking a Tokio worker.
@@ -484,6 +534,20 @@ mod tests {
         assert!(block.contains("128.116.121.3 www.roblox.com"));
         assert!(block.contains(MARKER_END));
         assert!(!block.contains("127.66.0.1"));
+    }
+
+    #[test]
+    fn active_bootstrap_ips_are_exact_and_clearable() {
+        clear_active_bootstrap_ips_for_test();
+
+        let bootstrap_ip = Ipv4Addr::new(65, 9, 168, 80);
+        set_active_bootstrap_ips_for_test([bootstrap_ip]);
+
+        assert!(is_active_bootstrap_ip(bootstrap_ip));
+        assert!(!is_active_bootstrap_ip(Ipv4Addr::new(65, 9, 168, 81)));
+
+        clear_active_bootstrap_ips_for_test();
+        assert!(!is_active_bootstrap_ip(bootstrap_ip));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6877,10 +6877,11 @@ where
         let can_speculate_tcp_api = protocol == Protocol::Tcp && api_tunneling && has_tunnel_scope;
         let is_tcp_api_bootstrap_syn =
             can_speculate_tcp_api && is_tcp_initial_syn && matches!(dst_port, 80 | 443);
-        let is_roblox_http_dst = can_speculate_tcp_api
+        let is_route_assist_http_dst = can_speculate_tcp_api
             && is_tcp_initial_syn
             && matches!(dst_port, 80 | 443)
-            && super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling);
+            && (super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
+                || crate::roblox_proxy::hosts::is_active_bootstrap_ip(dst_ip));
         let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn {
             tcp_owner_lookup(src_ip, src_port)
         } else {
@@ -6890,11 +6891,12 @@ where
             tcp_api_bootstrap_owner
                 .map(|pid| tcp_owner_scope_match(pid, snapshot, &process_name_lookup))
                 .unwrap_or((false, false));
-        let tcp_api_bootstrap_owned_by_browser_roblox =
-            tcp_api_bootstrap_owned_by_browser && is_roblox_http_dst;
+        let tcp_api_bootstrap_owned_by_browser_route_assist =
+            tcp_api_bootstrap_owned_by_browser && is_route_assist_http_dst;
         let tcp_api_bootstrap_known_unrelated = tcp_api_bootstrap_owner
             .map(|_| {
-                !tcp_api_bootstrap_owned_by_tunnel && !tcp_api_bootstrap_owned_by_browser_roblox
+                !tcp_api_bootstrap_owned_by_tunnel
+                    && !tcp_api_bootstrap_owned_by_browser_route_assist
             })
             .unwrap_or(false);
         let tcp_api_bootstrap_allowed =
@@ -6902,7 +6904,7 @@ where
         let is_game_dst = if protocol == Protocol::Udp {
             super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
         } else {
-            is_roblox_http_dst && is_tcp_initial_syn && !tcp_api_bootstrap_known_unrelated
+            is_route_assist_http_dst && is_tcp_initial_syn && !tcp_api_bootstrap_known_unrelated
         };
         if is_game_dst || tcp_api_bootstrap_allowed {
             // Log speculative tunneling for debugging (first 20 times only)
@@ -6919,7 +6921,7 @@ where
                 });
                 if spec_count < 20 {
                     log::info!(
-                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (Roblox destination or API bootstrap, initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={}, owner_is_browser_roblox={})",
+                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (Roblox destination or active bootstrap repair IP, initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={}, owner_is_browser_route_assist={})",
                         src_ip,
                         src_port,
                         dst_ip,
@@ -6927,7 +6929,7 @@ where
                         is_tcp_initial_syn,
                         tcp_api_bootstrap_owner,
                         tcp_api_bootstrap_owned_by_tunnel,
-                        tcp_api_bootstrap_owned_by_browser_roblox
+                        tcp_api_bootstrap_owned_by_browser_route_assist
                     );
                 }
             } else {
@@ -7909,6 +7911,9 @@ mod tests {
     // Tests use AHashMap/AHashSet to match the production ProcessSnapshot types
     use ahash::AHashMap as HashMap;
     use ahash::AHashSet as HashSet;
+    use std::sync::Mutex;
+
+    static BOOTSTRAP_ROUTE_IP_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn build_ipv4_frame(
         protocol: u8,
@@ -11111,6 +11116,176 @@ mod tests {
             )
         );
         assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_allows_browser_owned_active_bootstrap_http_syn() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let bootstrap_cdn_ip = Ipv4Addr::new(184, 87, 193, 160);
+        let src_port = 40015;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+        let browser_pid = 9005;
+
+        crate::roblox_proxy::hosts::set_active_bootstrap_ips_for_test([bootstrap_cdn_ip]);
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, bootstrap_cdn_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(browser_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == browser_pid {
+                        Some("chrome.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_does_not_allow_browser_owned_inactive_bootstrap_http_syn() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let bootstrap_cdn_ip = Ipv4Addr::new(184, 87, 193, 160);
+        let src_port = 40016;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+        let browser_pid = 9006;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, bootstrap_cdn_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(browser_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == browser_pid {
+                        Some("chrome.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_does_not_allow_unrelated_owner_to_active_bootstrap_http_syn() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let bootstrap_cdn_ip = Ipv4Addr::new(184, 87, 193, 160);
+        let src_port = 40017;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+        let unrelated_pid = 9007;
+
+        crate::roblox_proxy::hosts::set_active_bootstrap_ips_for_test([bootstrap_cdn_ip]);
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, bootstrap_cdn_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(unrelated_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == unrelated_pid {
+                        Some("Discord.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.is_empty());
+
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route active Roblox bootstrap DNS repair IPs through Route Assist so `clientsettingscdn.roblox.com`/rbxcdn CDN answers do not escape locally
- keep the route bounded to exact temporary hosts-file repair IPs and clear it on cleanup
- add positive and negative tests for browser-owned active bootstrap CDN IPs, inactive CDN IPs, and unrelated owners

## Failure-mode plan
- Primary success: Roblox launch/API HTTP(S) for repaired bootstrap host IPs tunnels only while Route Assist is enabled and the repair set is active.
- Repairable/retryable: partial DNS-over-HTTPS repair still publishes only the hosts that resolved; cleanup clears the active route IP set.
- Fatal or diagnostic-only: Route Assist off, non-HTTP(S), no tunnel scope, inactive CDN IPs, and known unrelated process owners must not use this route.
- Structured signals: routing uses the exact bootstrap hostname allowlist via the existing repair resolver and the resulting IP set, not broad substring matching.
- Partial/race states: if hosts repair is skipped or fails, behavior stays unchanged; once cleanup runs, the temporary IP route set is cleared even if hosts cleanup reports an error.
- Tests: positive browser-owned active bootstrap CDN SYN, negative browser-owned inactive CDN SYN, negative unrelated-owner active CDN SYN, and exact active-IP set clearing.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p swifttunnel-core active_bootstrap_ips_are_exact_and_clearable -- --nocapture` hit the known macOS `windows-future` / `windows-core` mismatch before project tests (`IMarshal`, `marshaler`, `windows_threading::submit`)
- `cargo check -p swifttunnel-core --lib --target x86_64-pc-windows-msvc` on macOS reached the Windows target toolchain but failed in local C toolchain setup for `ring` (`assert.h` not found); GitHub Windows CI is the required compile/test proof
