### PR TITLE
Gate Route Assist TCP on captured handshakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 Only game traffic is optimized through SwiftTunnel. Discord, Spotify, Chrome — everything else uses your normal internet. No bandwidth wasted.
 
 ### 🧭 Roblox Route Assist
-Optional Roblox login/API HTTP(S) routing helps users bypass network bans and gives Roblox a better chance of placing sessions near the SwiftTunnel region they picked. Browser traffic is still scoped to Roblox destinations only; unrelated websites keep using the normal connection.
+Optional Roblox login/API HTTP(S) routing helps users bypass network bans and gives Roblox a better chance of placing sessions near the SwiftTunnel region they picked. Browser traffic is still scoped to Roblox destinations only; unrelated websites keep using the normal connection. TCP flows are routed only when SwiftTunnel captures the Roblox/bootstrap HTTPS handshake, so existing browser or Roblox connections are not moved into the relay halfway through.
 
 ### ⚡ Low Latency Gaming Servers
 27 gaming-optimized relays across 12 gaming regions. Each relay runs:
@@ -106,7 +106,7 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic and the temporary CDN IPs resolved for those bootstrap hostnames, through the selected relay. Non-Roblox browser traffic still bypasses SwiftTunnel.
+SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic and the temporary CDN IPs resolved for those bootstrap hostnames, through the selected relay. Route Assist TCP routing is handshake-gated so SwiftTunnel can clamp relay-owned flows before large HTTPS packets are exchanged; non-Roblox browser traffic and already-established TCP connections still bypass SwiftTunnel.
 
 Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
 

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6791,12 +6791,14 @@ where
     };
     let is_tcp_initial_syn =
         tcp_flags.is_some_and(|flags| (flags & 0x02) != 0 && (flags & 0x10) == 0);
+    let cache_key = (src_ip, src_port, protocol);
 
     // Phase 1: Check snapshot cache (fast path, O(1))
     //
     // IMPORTANT: This is process-based only. Destination-based speculative tunneling
     // is handled below so we can seed the inline cache for game-server hits.
-    if snapshot.should_tunnel(src_ip, src_port, protocol) {
+    let snapshot_tunnel_hit = snapshot.should_tunnel(src_ip, src_port, protocol);
+    if snapshot_tunnel_hit && !(protocol == Protocol::Tcp && api_tunneling) {
         SNAPSHOT_HITS.with(|c| c.set(c.get() + 1));
         let result =
             super::process_cache::is_likely_game_traffic(dst_port, protocol, api_tunneling);
@@ -6811,11 +6813,16 @@ where
         }
         return result;
     }
-    SNAPSHOT_MISSES.with(|c| c.set(c.get() + 1));
+    if snapshot_tunnel_hit {
+        // Process ownership alone is not a Route Assist TCP decision. The packet
+        // must still flow through the captured-SYN/inline-cache phases below so
+        // cache phase counters stay mutually exclusive.
+    } else {
+        SNAPSHOT_MISSES.with(|c| c.set(c.get() + 1));
+    }
 
     // Phase 2: Check per-worker inline cache (fast path, O(1))
     // Cache ONLY stores TRUE results (v0.9.25) - finding key means it's a tunnel app
-    let cache_key = (src_ip, src_port, protocol);
     if inline_cache.contains_key(&cache_key) {
         INLINE_HITS.with(|c| c.set(c.get() + 1));
         let result =
@@ -6835,8 +6842,13 @@ where
     // Phase 3: Port-level fallback for tunnel PIDs.
     // Handles cache misses caused by local IP representation drift while keeping
     // routing decision tied to known tunnel-owned ports.
+    //
+    // TCP is deliberately excluded here. Route Assist must see and MSS-clamp the
+    // SYN before it owns a TCP flow; otherwise pre-existing Roblox HTTPS
+    // connections can be half-moved into the relay and later dropped as
+    // oversized packets.
     let mut is_tunnel_app = false;
-    if (protocol == Protocol::Udp || (protocol == Protocol::Tcp && api_tunneling))
+    if protocol == Protocol::Udp
         && snapshot.should_tunnel_by_port_fallback(src_port, protocol, api_tunneling)
     {
         is_tunnel_app = true;
@@ -10577,7 +10589,9 @@ mod tests {
 
     #[test]
     fn test_tcp_tunneled_with_api_tunneling_enabled() {
-        // TCP from a Roblox process should be tunneled when api_tunneling is enabled
+        // TCP from a Roblox process is handshake-gated when api_tunneling is
+        // enabled. Existing connections whose SYN SwiftTunnel missed must not
+        // be pulled into the relay midstream, but captured SYNs should route.
         let src_ip = Ipv4Addr::new(192, 168, 1, 100);
         let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
         let src_port = 50000;
@@ -10613,14 +10627,25 @@ mod tests {
             false,
         ));
 
-        // With api_tunneling: TCP SHOULD be tunneled
+        // With api_tunneling: established TCP without a captured SYN should
+        // still bypass.
         inline_cache.clear();
-        assert!(should_route_to_vpn_with_inline_cache(
+        assert!(!should_route_to_vpn_with_inline_cache(
             &frame,
             &snapshot,
             &mut inline_cache,
             true,
         ));
+        assert!(inline_cache.is_empty());
+
+        let syn_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x02);
+        assert!(should_route_to_vpn_with_inline_cache(
+            &syn_frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
     }
 
     #[test]
@@ -11119,6 +11144,117 @@ mod tests {
     }
 
     #[test]
+    fn test_tcp_api_tunneling_allows_tunnel_owned_http_syn_for_mss_clamp() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let cdn_ip = Ipv4Addr::new(23, 61, 202, 142);
+        let src_port = 40018;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, cdn_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(tunnel_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == tunnel_pid {
+                        Some("RobloxPlayerBeta.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_captured_roblox_syn_allows_follow_on_packet() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let roblox_api_ip = Ipv4Addr::new(128, 116, 50, 3);
+        let src_port = 40019;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let syn_frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, roblox_api_ip, src_port, dst_port, 0x02);
+        let follow_on_frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, roblox_api_ip, src_port, dst_port, 0x18);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &syn_frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(tunnel_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == tunnel_pid {
+                        Some("RobloxPlayerBeta.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+        assert!(
+            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &follow_on_frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |_ip, _port| None,
+                |_pid| None,
+            )
+        );
+    }
+
+    #[test]
     fn test_tcp_api_tunneling_allows_browser_owned_active_bootstrap_http_syn() {
         let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
         crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
@@ -11495,9 +11631,10 @@ mod tests {
     }
 
     #[test]
-    fn test_tcp_port_fallback_tunnels_with_api_tunneling() {
-        // TCP still tunnels when we can tie the source port back to a Roblox-owned
-        // connection, even if the exact local IP tuple is stale.
+    fn test_tcp_port_fallback_does_not_tunnel_established_api_tcp_without_captured_syn() {
+        // TCP must not tunnel just because the owner table has a Roblox source
+        // port. If SwiftTunnel missed the SYN, the connection was negotiated
+        // outside the relay and may advertise an unsafe MSS for Route Assist.
         let cached_ip = Ipv4Addr::new(10, 10, 10, 10);
         let packet_ip = Ipv4Addr::new(10, 10, 10, 11);
         let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
@@ -11533,13 +11670,23 @@ mod tests {
         ));
 
         let mut cache_with_api: InlineCache = HashMap::new();
-        assert!(should_route_to_vpn_with_inline_cache(
+        assert!(!should_route_to_vpn_with_inline_cache(
             &frame,
             &snapshot,
             &mut cache_with_api,
             true,
         ));
-        assert!(cache_with_api.contains_key(&(packet_ip, src_port, Protocol::Tcp)));
+        assert!(cache_with_api.is_empty());
+
+        let exact_owner_frame = build_ipv4_frame(6, cached_ip, dst_ip, src_port, dst_port);
+        let mut exact_owner_cache: InlineCache = HashMap::new();
+        assert!(!should_route_to_vpn_with_inline_cache(
+            &exact_owner_frame,
+            &snapshot,
+            &mut exact_owner_cache,
+            true,
+        ));
+        assert!(exact_owner_cache.is_empty());
     }
 
     #[test]
@@ -11588,8 +11735,23 @@ mod tests {
         );
         let mut inline_cache: InlineCache = HashMap::new();
 
-        assert!(should_route_to_vpn_with_inline_cache(
+        assert!(!should_route_to_vpn_with_inline_cache(
             &frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(inline_cache.is_empty());
+
+        let syn_frame = build_ipv4_tcp_frame_with_flags(
+            Ipv4Addr::new(10, 0, 0, 99),
+            Ipv4Addr::new(128, 116, 50, 100),
+            roblox_port,
+            443,
+            0x02,
+        );
+        assert!(should_route_to_vpn_with_inline_cache(
+            &syn_frame,
             &snapshot,
             &mut inline_cache,
             true,

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -5119,17 +5119,17 @@ fn run_packet_reader(
             continue;
         }
 
+        // Load api_tunneling setting once per batch (cheap atomic load).
+        let api_tunneling = api_tunneling_enabled.load(Ordering::Relaxed);
+
         // Refresh process snapshot once per batch (cheap atomic load) so routing decisions
         // track new processes/connection tables without per-packet ArcSwap loads.
         let new_snapshot = process_cache.get_snapshot();
         if new_snapshot.version != snapshot_version {
             snapshot_version = new_snapshot.version;
-            inline_cache.clear();
+            prune_inline_cache_on_snapshot_refresh(&mut inline_cache, api_tunneling);
         }
         snapshot = new_snapshot;
-
-        // Load api_tunneling setting once per batch (cheap atomic load).
-        let api_tunneling = api_tunneling_enabled.load(Ordering::Relaxed);
 
         // Prepare passthrough queues
         passthrough_to_adapter = EthMRequest::new(b.physical_handle);
@@ -6569,6 +6569,18 @@ fn auto_routing_packet_action(
 type InlineCache = ahash::AHashMap<(Ipv4Addr, u16, Protocol), bool>;
 type FragmentKey = (Ipv4Addr, Ipv4Addr, u16, Protocol);
 
+fn prune_inline_cache_on_snapshot_refresh(inline_cache: &mut InlineCache, api_tunneling: bool) {
+    if !api_tunneling {
+        inline_cache.clear();
+        return;
+    }
+
+    // UDP ownership entries must track the newest process snapshot, but captured
+    // Route Assist TCP flows must survive owner-table refreshes after their SYN
+    // was MSS-clamped and relayed. FIN/RST packets evict TCP entries on close.
+    inline_cache.retain(|(_, _, protocol), _| *protocol == Protocol::Tcp);
+}
+
 fn process_name_in_tunnel_scope(name: &str, snapshot: &ProcessSnapshot) -> bool {
     let name_lower = name.to_lowercase();
     process_name_matches_any_tunnel_app(&name_lower, &snapshot.tunnel_apps)
@@ -6828,6 +6840,9 @@ where
         INLINE_HITS.with(|c| c.set(c.get() + 1));
         let result =
             super::process_cache::is_likely_game_traffic(dst_port, protocol, api_tunneling);
+        if protocol == Protocol::Tcp && tcp_flags.is_some_and(|flags| (flags & 0x05) != 0) {
+            inline_cache.remove(&cache_key);
+        }
         if protocol == Protocol::Udp && more_fragments {
             FRAGMENT_DECISIONS.with(|cache| {
                 let mut cache = cache.borrow_mut();
@@ -10203,6 +10218,42 @@ mod tests {
             &mut inline_cache,
             false,
         ));
+    }
+
+    #[test]
+    fn test_snapshot_refresh_keeps_tcp_inline_entries_and_clears_udp_when_api_tunneling() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let mut inline_cache: InlineCache = HashMap::new();
+        inline_cache.insert((src_ip, 40000, Protocol::Tcp), true);
+        inline_cache.insert((src_ip, 40001, Protocol::Udp), true);
+
+        prune_inline_cache_on_snapshot_refresh(&mut inline_cache, true);
+
+        assert!(inline_cache.contains_key(&(src_ip, 40000, Protocol::Tcp)));
+        assert!(!inline_cache.contains_key(&(src_ip, 40001, Protocol::Udp)));
+
+        prune_inline_cache_on_snapshot_refresh(&mut inline_cache, false);
+        assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_inline_cache_hit_evicts_fin_after_routing() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let src_port = 40000;
+        let dst_port = 443;
+        let snapshot = ProcessSnapshot::empty(HashSet::new());
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x11);
+        let mut inline_cache: InlineCache = HashMap::new();
+        inline_cache.insert((src_ip, src_port, Protocol::Tcp), true);
+
+        assert!(should_route_to_vpn_with_inline_cache(
+            &frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(!inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6813,13 +6813,14 @@ where
         }
         return result;
     }
-    if snapshot_tunnel_hit {
-        // Process ownership alone is not a Route Assist TCP decision. The packet
-        // must still flow through the captured-SYN/inline-cache phases below so
-        // cache phase counters stay mutually exclusive.
-    } else {
+    if !snapshot_tunnel_hit {
+        // Snapshot miss: process ownership was not established, so the remaining
+        // phases (inline cache, port fallback, speculative) own the counter.
         SNAPSHOT_MISSES.with(|c| c.set(c.get() + 1));
     }
+    // When snapshot_tunnel_hit is true for TCP+api_tunneling, the packet falls
+    // through to the captured-SYN/inline-cache phases so those counters stay
+    // mutually exclusive with SNAPSHOT_HITS.
 
     // Phase 2: Check per-worker inline cache (fast path, O(1))
     // Cache ONLY stores TRUE results (v0.9.25) - finding key means it's a tunnel app
@@ -6848,9 +6849,7 @@ where
     // connections can be half-moved into the relay and later dropped as
     // oversized packets.
     let mut is_tunnel_app = false;
-    if protocol == Protocol::Udp
-        && snapshot.should_tunnel_by_port_fallback(src_port, protocol, api_tunneling)
-    {
+    if protocol == Protocol::Udp && snapshot.should_tunnel_by_port_fallback(src_port, protocol) {
         is_tunnel_app = true;
         PORT_FALLBACK_HITS.with(|c| c.set(c.get() + 1));
     }

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6577,7 +6577,8 @@ fn prune_inline_cache_on_snapshot_refresh(inline_cache: &mut InlineCache, api_tu
 
     // UDP ownership entries must track the newest process snapshot, but captured
     // Route Assist TCP flows must survive owner-table refreshes after their SYN
-    // was MSS-clamped and relayed. FIN/RST packets evict TCP entries on close.
+    // was MSS-clamped and relayed. RST packets evict TCP entries immediately;
+    // FIN must stay cached so the final teardown ACK still uses the relay.
     inline_cache.retain(|(_, _, protocol), _| *protocol == Protocol::Tcp);
 }
 
@@ -6840,7 +6841,7 @@ where
         INLINE_HITS.with(|c| c.set(c.get() + 1));
         let result =
             super::process_cache::is_likely_game_traffic(dst_port, protocol, api_tunneling);
-        if protocol == Protocol::Tcp && tcp_flags.is_some_and(|flags| (flags & 0x05) != 0) {
+        if protocol == Protocol::Tcp && tcp_flags.is_some_and(|flags| (flags & 0x04) != 0) {
             inline_cache.remove(&cache_key);
         }
         if protocol == Protocol::Udp && more_fragments {
@@ -10237,18 +10238,47 @@ mod tests {
     }
 
     #[test]
-    fn test_tcp_inline_cache_hit_evicts_fin_after_routing() {
+    fn test_tcp_inline_cache_hit_keeps_fin_for_teardown_ack() {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
         let src_port = 40000;
         let dst_port = 443;
         let snapshot = ProcessSnapshot::empty(HashSet::new());
-        let frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x11);
+        let fin_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x11);
+        let ack_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x10);
         let mut inline_cache: InlineCache = HashMap::new();
         inline_cache.insert((src_ip, src_port, Protocol::Tcp), true);
 
         assert!(should_route_to_vpn_with_inline_cache(
-            &frame,
+            &fin_frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+
+        assert!(should_route_to_vpn_with_inline_cache(
+            &ack_frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+    }
+
+    #[test]
+    fn test_tcp_inline_cache_hit_evicts_rst_after_routing() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let src_port = 40000;
+        let dst_port = 443;
+        let snapshot = ProcessSnapshot::empty(HashSet::new());
+        let rst_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x14);
+        let mut inline_cache: InlineCache = HashMap::new();
+        inline_cache.insert((src_ip, src_port, Protocol::Tcp), true);
+
+        assert!(should_route_to_vpn_with_inline_cache(
+            &rst_frame,
             &snapshot,
             &mut inline_cache,
             true,

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6844,11 +6844,7 @@ where
     // Phase 2: Check per-worker inline cache (fast path, O(1))
     // Cache ONLY stores TRUE results (v0.9.25) - finding key means it's a tunnel app
     if inline_cache.contains_key(&cache_key) {
-        let recycled_tcp_syn = protocol == Protocol::Tcp
-            && is_tcp_initial_syn
-            && inline_cache
-                .get(&cache_key)
-                .is_some_and(|entry| *entry == InlineCacheEntry::FinSeen);
+        let recycled_tcp_syn = protocol == Protocol::Tcp && is_tcp_initial_syn;
         if recycled_tcp_syn {
             inline_cache.remove(&cache_key);
         } else {
@@ -10332,6 +10328,26 @@ mod tests {
         let syn_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x02);
         let mut inline_cache: InlineCache = HashMap::new();
         inline_cache.insert((src_ip, src_port, Protocol::Tcp), InlineCacheEntry::FinSeen);
+
+        assert!(!should_route_to_vpn_with_inline_cache(
+            &syn_frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(!inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+    }
+
+    #[test]
+    fn test_tcp_inline_cache_active_reclassifies_recycled_syn() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let dst_ip = Ipv4Addr::new(203, 0, 113, 20);
+        let src_port = 40000;
+        let dst_port = 443;
+        let snapshot = ProcessSnapshot::empty(HashSet::new());
+        let syn_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+        inline_cache.insert((src_ip, src_port, Protocol::Tcp), InlineCacheEntry::Active);
 
         assert!(!should_route_to_vpn_with_inline_cache(
             &syn_frame,

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6566,7 +6566,13 @@ fn auto_routing_packet_action(
 /// Per-worker inline cache for connection lookups
 /// This amortizes the expensive GetExtendedTcpTable syscall across multiple packets
 /// from the same connection. First packet: ~500μs, subsequent packets: <1μs
-type InlineCache = ahash::AHashMap<(Ipv4Addr, u16, Protocol), bool>;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InlineCacheEntry {
+    Active,
+    FinSeen,
+}
+
+type InlineCache = ahash::AHashMap<(Ipv4Addr, u16, Protocol), InlineCacheEntry>;
 type FragmentKey = (Ipv4Addr, Ipv4Addr, u16, Protocol);
 
 fn prune_inline_cache_on_snapshot_refresh(inline_cache: &mut InlineCache, api_tunneling: bool) {
@@ -6838,22 +6844,49 @@ where
     // Phase 2: Check per-worker inline cache (fast path, O(1))
     // Cache ONLY stores TRUE results (v0.9.25) - finding key means it's a tunnel app
     if inline_cache.contains_key(&cache_key) {
-        INLINE_HITS.with(|c| c.set(c.get() + 1));
-        let result =
-            super::process_cache::is_likely_game_traffic(dst_port, protocol, api_tunneling);
-        if protocol == Protocol::Tcp && tcp_flags.is_some_and(|flags| (flags & 0x04) != 0) {
+        let recycled_tcp_syn = protocol == Protocol::Tcp
+            && is_tcp_initial_syn
+            && inline_cache
+                .get(&cache_key)
+                .is_some_and(|entry| *entry == InlineCacheEntry::FinSeen);
+        if recycled_tcp_syn {
             inline_cache.remove(&cache_key);
-        }
-        if protocol == Protocol::Udp && more_fragments {
-            FRAGMENT_DECISIONS.with(|cache| {
-                let mut cache = cache.borrow_mut();
-                if cache.len() >= 4096 {
-                    cache.clear();
+        } else {
+            INLINE_HITS.with(|c| c.set(c.get() + 1));
+            let evict_after_route = if protocol == Protocol::Tcp {
+                let entry = inline_cache
+                    .get_mut(&cache_key)
+                    .expect("checked contains_key");
+                let flags = tcp_flags.unwrap_or(0);
+                if (flags & 0x04) != 0 {
+                    true
+                } else if *entry == InlineCacheEntry::FinSeen {
+                    flags == 0x10 || (flags & 0x01) != 0
+                } else if (flags & 0x01) != 0 {
+                    *entry = InlineCacheEntry::FinSeen;
+                    false
+                } else {
+                    false
                 }
-                cache.insert(fragment_key, result);
-            });
+            } else {
+                false
+            };
+            let result =
+                super::process_cache::is_likely_game_traffic(dst_port, protocol, api_tunneling);
+            if evict_after_route {
+                inline_cache.remove(&cache_key);
+            }
+            if protocol == Protocol::Udp && more_fragments {
+                FRAGMENT_DECISIONS.with(|cache| {
+                    let mut cache = cache.borrow_mut();
+                    if cache.len() >= 4096 {
+                        cache.clear();
+                    }
+                    cache.insert(fragment_key, result);
+                });
+            }
+            return result;
         }
-        return result;
     }
 
     // Phase 3: Port-level fallback for tunnel PIDs.
@@ -6884,7 +6917,7 @@ where
     // By only caching true results, we ensure that if a process wasn't found,
     // we keep trying on subsequent packets until it IS found.
     if is_tunnel_app && inline_cache.len() < 10000 {
-        inline_cache.insert(cache_key, true);
+        inline_cache.insert(cache_key, InlineCacheEntry::Active);
     }
 
     // Apply destination-based speculation if needed.
@@ -6987,7 +7020,7 @@ where
             if (protocol == Protocol::Udp || protocol == Protocol::Tcp)
                 && inline_cache.len() < 10000
             {
-                inline_cache.insert(cache_key, true);
+                inline_cache.insert(cache_key, InlineCacheEntry::Active);
             }
 
             true // Speculatively tunnel to game server
@@ -10211,7 +10244,7 @@ mod tests {
 
         let frame = build_ipv4_frame(17, src_ip, dst_ip, src_port, dst_port);
         let mut inline_cache: InlineCache = HashMap::new();
-        inline_cache.insert((src_ip, src_port, Protocol::Udp), true);
+        inline_cache.insert((src_ip, src_port, Protocol::Udp), InlineCacheEntry::Active);
 
         assert!(should_route_to_vpn_with_inline_cache(
             &frame,
@@ -10225,8 +10258,8 @@ mod tests {
     fn test_snapshot_refresh_keeps_tcp_inline_entries_and_clears_udp_when_api_tunneling() {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let mut inline_cache: InlineCache = HashMap::new();
-        inline_cache.insert((src_ip, 40000, Protocol::Tcp), true);
-        inline_cache.insert((src_ip, 40001, Protocol::Udp), true);
+        inline_cache.insert((src_ip, 40000, Protocol::Tcp), InlineCacheEntry::Active);
+        inline_cache.insert((src_ip, 40001, Protocol::Udp), InlineCacheEntry::Active);
 
         prune_inline_cache_on_snapshot_refresh(&mut inline_cache, true);
 
@@ -10247,7 +10280,7 @@ mod tests {
         let fin_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x11);
         let ack_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x10);
         let mut inline_cache: InlineCache = HashMap::new();
-        inline_cache.insert((src_ip, src_port, Protocol::Tcp), true);
+        inline_cache.insert((src_ip, src_port, Protocol::Tcp), InlineCacheEntry::Active);
 
         assert!(should_route_to_vpn_with_inline_cache(
             &fin_frame,
@@ -10255,7 +10288,10 @@ mod tests {
             &mut inline_cache,
             true,
         ));
-        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+        assert_eq!(
+            inline_cache.get(&(src_ip, src_port, Protocol::Tcp)),
+            Some(&InlineCacheEntry::FinSeen)
+        );
 
         assert!(should_route_to_vpn_with_inline_cache(
             &ack_frame,
@@ -10263,7 +10299,7 @@ mod tests {
             &mut inline_cache,
             true,
         ));
-        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+        assert!(!inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
     }
 
     #[test]
@@ -10275,10 +10311,30 @@ mod tests {
         let snapshot = ProcessSnapshot::empty(HashSet::new());
         let rst_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x14);
         let mut inline_cache: InlineCache = HashMap::new();
-        inline_cache.insert((src_ip, src_port, Protocol::Tcp), true);
+        inline_cache.insert((src_ip, src_port, Protocol::Tcp), InlineCacheEntry::Active);
 
         assert!(should_route_to_vpn_with_inline_cache(
             &rst_frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert!(!inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+    }
+
+    #[test]
+    fn test_tcp_inline_cache_fin_seen_reclassifies_recycled_syn() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let dst_ip = Ipv4Addr::new(203, 0, 113, 20);
+        let src_port = 40000;
+        let dst_port = 443;
+        let snapshot = ProcessSnapshot::empty(HashSet::new());
+        let syn_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+        inline_cache.insert((src_ip, src_port, Protocol::Tcp), InlineCacheEntry::FinSeen);
+
+        assert!(!should_route_to_vpn_with_inline_cache(
+            &syn_frame,
             &snapshot,
             &mut inline_cache,
             true,
@@ -10308,7 +10364,7 @@ mod tests {
 
         let frame = build_ipv4_frame(17, src_ip, dst_ip, src_port, dst_port);
         let mut inline_cache: InlineCache = HashMap::new();
-        inline_cache.insert((src_ip, src_port, Protocol::Udp), true);
+        inline_cache.insert((src_ip, src_port, Protocol::Udp), InlineCacheEntry::Active);
 
         assert!(!should_route_to_vpn_with_inline_cache(
             &frame,

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6857,7 +6857,11 @@ where
                 if (flags & 0x04) != 0 {
                     true
                 } else if *entry == InlineCacheEntry::FinSeen {
-                    flags == 0x10 || (flags & 0x01) != 0
+                    // Bare ACKs after a local FIN can still acknowledge
+                    // in-flight server data in a half-closed connection.
+                    // Keep routing until RST, a second FIN, or a future SYN
+                    // reclassifies a recycled port.
+                    (flags & 0x01) != 0
                 } else if (flags & 0x01) != 0 {
                     *entry = InlineCacheEntry::FinSeen;
                     false
@@ -6938,15 +6942,19 @@ where
             && matches!(dst_port, 80 | 443)
             && (super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
                 || crate::roblox_proxy::hosts::is_active_bootstrap_ip(dst_ip));
-        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn {
+        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn && !snapshot_tunnel_hit {
             tcp_owner_lookup(src_ip, src_port)
         } else {
             None
         };
         let (tcp_api_bootstrap_owned_by_tunnel, tcp_api_bootstrap_owned_by_browser) =
-            tcp_api_bootstrap_owner
-                .map(|pid| tcp_owner_scope_match(pid, snapshot, &process_name_lookup))
-                .unwrap_or((false, false));
+            if is_tcp_api_bootstrap_syn && snapshot_tunnel_hit {
+                (true, false)
+            } else {
+                tcp_api_bootstrap_owner
+                    .map(|pid| tcp_owner_scope_match(pid, snapshot, &process_name_lookup))
+                    .unwrap_or((false, false))
+            };
         let tcp_api_bootstrap_owned_by_browser_route_assist =
             tcp_api_bootstrap_owned_by_browser && is_route_assist_http_dst;
         let tcp_api_bootstrap_known_unrelated = tcp_api_bootstrap_owner
@@ -10267,7 +10275,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tcp_inline_cache_hit_keeps_fin_for_teardown_ack() {
+    fn test_tcp_inline_cache_hit_keeps_fin_seen_through_half_close_acks() {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
         let src_port = 40000;
@@ -10275,6 +10283,8 @@ mod tests {
         let snapshot = ProcessSnapshot::empty(HashSet::new());
         let fin_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x11);
         let ack_frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x10);
+        let second_fin_frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x11);
         let mut inline_cache: InlineCache = HashMap::new();
         inline_cache.insert((src_ip, src_port, Protocol::Tcp), InlineCacheEntry::Active);
 
@@ -10291,6 +10301,28 @@ mod tests {
 
         assert!(should_route_to_vpn_with_inline_cache(
             &ack_frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert_eq!(
+            inline_cache.get(&(src_ip, src_port, Protocol::Tcp)),
+            Some(&InlineCacheEntry::FinSeen)
+        );
+
+        assert!(should_route_to_vpn_with_inline_cache(
+            &ack_frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+        ));
+        assert_eq!(
+            inline_cache.get(&(src_ip, src_port, Protocol::Tcp)),
+            Some(&InlineCacheEntry::FinSeen)
+        );
+
+        assert!(should_route_to_vpn_with_inline_cache(
+            &second_fin_frame,
             &snapshot,
             &mut inline_cache,
             true,
@@ -10928,6 +10960,45 @@ mod tests {
                     None
                 }
             },
+        ));
+        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_snapshot_syn_skips_owner_lookup() {
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let src_port = 40001;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+
+        let mut connections = HashMap::new();
+        connections.insert(
+            ConnectionKey::new(src_ip, src_port, Protocol::Tcp),
+            tunnel_pid,
+        );
+        let snapshot = ProcessSnapshot {
+            connections,
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, dst_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(should_route_to_vpn_with_inline_cache_and_tcp_owner_lookup(
+            &frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+            |_ip, _port| panic!("snapshot-owned SYN should not call tcp_owner_lookup"),
         ));
         assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
     }

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -345,6 +345,7 @@ impl ProcessSnapshot {
     /// TCP Route Assist is intentionally excluded: the packet router must capture
     /// and MSS-clamp the SYN before owning a TCP flow, so TCP port ownership is
     /// metadata for handshake/speculation checks rather than a routing fallback.
+    /// Do not relax this without proving established TCP flows stay bypassed.
     #[inline]
     pub fn should_tunnel_by_port_fallback(
         &self,

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -347,12 +347,7 @@ impl ProcessSnapshot {
     /// metadata for handshake/speculation checks rather than a routing fallback.
     /// Do not relax this without proving established TCP flows stay bypassed.
     #[inline]
-    pub fn should_tunnel_by_port_fallback(
-        &self,
-        local_port: u16,
-        protocol: Protocol,
-        _api_tunneling: bool,
-    ) -> bool {
+    pub fn should_tunnel_by_port_fallback(&self, local_port: u16, protocol: Protocol) -> bool {
         match protocol {
             Protocol::Udp => self.tunnel_udp_ports.contains(&local_port),
             Protocol::Tcp => false,
@@ -1303,8 +1298,8 @@ mod tests {
         cache.update(connections, pid_names);
         let snap = cache.get_snapshot();
 
-        assert!(snap.should_tunnel_by_port_fallback(55000, Protocol::Udp, false));
-        assert!(!snap.should_tunnel_by_port_fallback(55001, Protocol::Udp, false));
+        assert!(snap.should_tunnel_by_port_fallback(55000, Protocol::Udp));
+        assert!(!snap.should_tunnel_by_port_fallback(55001, Protocol::Udp));
     }
 
     #[test]
@@ -1322,7 +1317,7 @@ mod tests {
         cache.update(connections, pid_names);
         let snap = cache.get_snapshot();
 
-        assert!(!snap.should_tunnel_by_port_fallback(56000, Protocol::Udp, false));
+        assert!(!snap.should_tunnel_by_port_fallback(56000, Protocol::Udp));
     }
 
     #[test]
@@ -1423,10 +1418,9 @@ mod tests {
         // TCP ownership is still published for Route Assist handshake checks,
         // but port fallback routing remains UDP-only.
         assert!(snap.tunnel_tcp_ports.contains(&55000));
-        assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Tcp, true));
-        assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Tcp, false));
+        assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Tcp));
         // UDP port fallback is unchanged regardless of api_tunneling
-        assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Udp, false));
+        assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Udp));
     }
 
     #[test]
@@ -1484,7 +1478,7 @@ mod tests {
         cache.register_udp_port_immediate(55000);
         let first_snapshot = cache.get_snapshot();
         let first_version = first_snapshot.version;
-        assert!(first_snapshot.should_tunnel_by_port_fallback(55000, Protocol::Udp, false));
+        assert!(first_snapshot.should_tunnel_by_port_fallback(55000, Protocol::Udp));
         drop(first_snapshot);
 
         cache.register_udp_port_immediate(55000);
@@ -1518,7 +1512,7 @@ mod tests {
 
         assert!(first_snapshot.tunnel_tcp_ports.contains(&443));
         assert!(first_snapshot.tunnel_tcp_ports.contains(&50000));
-        assert!(!first_snapshot.should_tunnel_by_port_fallback(443, Protocol::Tcp, false));
+        assert!(!first_snapshot.should_tunnel_by_port_fallback(443, Protocol::Tcp));
         drop(first_snapshot);
 
         // Calling with the same set should not force another snapshot rebuild.

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -336,21 +336,25 @@ impl ProcessSnapshot {
         self.is_tunnel_connection(local_ip, local_port, protocol)
     }
 
-    /// Fallback check for tunnel ownership by source port.
+    /// UDP fallback check for tunnel ownership by source port.
     ///
     /// This is a miss-path helper used when exact `(ip, port, protocol)` cache lookup
     /// fails but we still want to recover tunnel routing for packets emitted by a
     /// known tunnel app that may have shifted local IP representation.
+    ///
+    /// TCP Route Assist is intentionally excluded: the packet router must capture
+    /// and MSS-clamp the SYN before owning a TCP flow, so TCP port ownership is
+    /// metadata for handshake/speculation checks rather than a routing fallback.
     #[inline]
     pub fn should_tunnel_by_port_fallback(
         &self,
         local_port: u16,
         protocol: Protocol,
-        api_tunneling: bool,
+        _api_tunneling: bool,
     ) -> bool {
         match protocol {
             Protocol::Udp => self.tunnel_udp_ports.contains(&local_port),
-            Protocol::Tcp => api_tunneling && self.tunnel_tcp_ports.contains(&local_port),
+            Protocol::Tcp => false,
         }
     }
 
@@ -1401,7 +1405,7 @@ mod tests {
     }
 
     #[test]
-    fn test_should_tunnel_by_port_fallback_tcp_with_api_tunneling() {
+    fn test_should_tunnel_by_port_fallback_rejects_tcp_even_with_api_tunneling() {
         let cache = LockFreeProcessCache::new(vec!["roblox".to_string()]);
 
         let mut connections = HashMap::new();
@@ -1415,9 +1419,10 @@ mod tests {
         cache.update(connections, pid_names);
         let snap = cache.get_snapshot();
 
-        // TCP port fallback should work when api_tunneling is enabled
-        assert!(snap.should_tunnel_by_port_fallback(55000, Protocol::Tcp, true));
-        // TCP port fallback should NOT work when api_tunneling is disabled
+        // TCP ownership is still published for Route Assist handshake checks,
+        // but port fallback routing remains UDP-only.
+        assert!(snap.tunnel_tcp_ports.contains(&55000));
+        assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Tcp, true));
         assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Tcp, false));
         // UDP port fallback is unchanged regardless of api_tunneling
         assert!(!snap.should_tunnel_by_port_fallback(55000, Protocol::Udp, false));
@@ -1510,8 +1515,8 @@ mod tests {
         let first_snapshot = cache.get_snapshot();
         let first_version = first_snapshot.version;
 
-        assert!(first_snapshot.should_tunnel_by_port_fallback(443, Protocol::Tcp, true));
-        assert!(first_snapshot.should_tunnel_by_port_fallback(50000, Protocol::Tcp, true));
+        assert!(first_snapshot.tunnel_tcp_ports.contains(&443));
+        assert!(first_snapshot.tunnel_tcp_ports.contains(&50000));
         assert!(!first_snapshot.should_tunnel_by_port_fallback(443, Protocol::Tcp, false));
         drop(first_snapshot);
 
@@ -1530,8 +1535,8 @@ mod tests {
         cache.update(connections, pid_names);
 
         let updated = cache.get_snapshot();
-        assert!(updated.should_tunnel_by_port_fallback(443, Protocol::Tcp, true));
-        assert!(updated.should_tunnel_by_port_fallback(50000, Protocol::Tcp, true));
+        assert!(updated.tunnel_tcp_ports.contains(&443));
+        assert!(updated.tunnel_tcp_ports.contains(&50000));
     }
 
     #[test]
@@ -1549,8 +1554,8 @@ mod tests {
 
         let snap = cache.get_snapshot();
         assert!(snap.should_tunnel(Ipv4Addr::new(10, 0, 0, 20), 53000, Protocol::Tcp));
-        assert!(snap.should_tunnel_by_port_fallback(443, Protocol::Tcp, true));
-        assert!(snap.should_tunnel_by_port_fallback(53000, Protocol::Tcp, true));
+        assert!(snap.tunnel_tcp_ports.contains(&443));
+        assert!(snap.tunnel_tcp_ports.contains(&53000));
     }
 
     #[test]
@@ -1563,11 +1568,7 @@ mod tests {
             &[53000],
             Duration::from_secs(30),
         );
-        assert!(
-            cache
-                .get_snapshot()
-                .should_tunnel_by_port_fallback(53000, Protocol::Tcp, true)
-        );
+        assert!(cache.get_snapshot().tunnel_tcp_ports.contains(&53000));
 
         cache.update_with_recent_tcp_ports(
             HashMap::new(),
@@ -1575,11 +1576,7 @@ mod tests {
             &[],
             Duration::from_secs(30),
         );
-        assert!(
-            cache
-                .get_snapshot()
-                .should_tunnel_by_port_fallback(53000, Protocol::Tcp, true)
-        );
+        assert!(cache.get_snapshot().tunnel_tcp_ports.contains(&53000));
 
         std::thread::sleep(Duration::from_millis(2));
         cache.update_with_recent_tcp_ports(
@@ -1588,10 +1585,6 @@ mod tests {
             &[],
             Duration::from_millis(1),
         );
-        assert!(
-            !cache
-                .get_snapshot()
-                .should_tunnel_by_port_fallback(53000, Protocol::Tcp, true)
-        );
+        assert!(!cache.get_snapshot().tunnel_tcp_ports.contains(&53000));
     }
 }


### PR DESCRIPTION
## Summary
- gate Route Assist TCP to captured SYNs so established Roblox HTTPS flows are not moved into the relay midstream without MSS clamp
- preserve captured Roblox/browser HTTP(S) SYN routing and follow-on inline-cache routing
- reclassify recycled TCP SYNs before cache hits so silent connection deaths cannot misroute a reused source port
- keep half-closed TCP flows routed through bare ACKs while still evicting on RST, second FIN, or recycled SYN reclassification
- skip redundant TCP owner-table lookups for snapshot-owned Route Assist SYNs
- make TCP port ownership metadata-only for fallback routing and keep cache phase counters exclusive
- document the Route Assist TCP handshake guardrail

## Testing
- cargo fmt --all -- --check
- git diff --check
- Windows testbench: cargo test -p swifttunnel-core --lib (641 passed, 3 ignored)
- GitHub Actions: Frontend Build, Rust Check (GitHub Windows), Split Tunnel Testbench Availability

## Failure-mode plan
Primary success is that Route Assist only owns TCP flows whose SYN SwiftTunnel captured and can MSS-clamp before relay forwarding. Repairable/routable cases are captured Roblox/browser HTTP(S) SYNs to Roblox/API/bootstrap paths and Roblox-owned HTTP(S) SYNs; existing TCP flows without captured SYNs bypass. Fatal routing cases include unrelated known owners, non-HTTP TCP, and recycled source ports that no longer belong to a captured connection. Signals are TCP flags, owner lookup, exact Roblox ranges, and active bootstrap IPs rather than dialog text. Partial-success behavior is to leave missed established flows untouched, seed captured flows into the inline cache for follow-on packets, route teardown and half-close packets long enough to close cleanly, and force any later SYN with the same key through reclassification.