### PR TITLE
fix(vpn): surface fatal networking failure modes instead of stalling silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # This job shares the testbench runner workspace with release.yml.
+          # GitHub-backed caches do not help release tags, so preserve the
+          # runner-local Cargo outputs for the next release run.
+          clean: false
+
+      - name: Clean workspace but keep local Cargo outputs
+        shell: powershell
+        run: |
+          git reset --hard HEAD
+          git clean -ffdx -e target/ -e swifttunnel-desktop/src-tauri/target/
+          $bundleDirs = @(
+            "target/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/release/bundle"
+          )
+          Remove-Item -Path $bundleDirs -Recurse -Force -ErrorAction SilentlyContinue
 
       - name: Ensure Git Bash
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,23 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag != '' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+          # Self-hosted testbench runner: keep local build caches available so
+          # the next step can preserve Cargo's target/ directory. GitHub-backed
+          # caches are tag-scoped here and miss across release tags.
+          clean: false
+
+      - name: Clean workspace but keep local Cargo outputs
+        shell: powershell
+        run: |
+          # actions/checkout clean=true would delete target/ before cargo can
+          # reuse it. Do the clean ourselves so only compiler outputs survive.
+          git reset --hard HEAD
+          git clean -ffdx -e target/ -e swifttunnel-desktop/src-tauri/target/
+          $bundleDirs = @(
+            "target/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/release/bundle"
+          )
+          Remove-Item -Path $bundleDirs -Recurse -Force -ErrorAction SilentlyContinue
 
       - name: Ensure Git Bash
         shell: powershell
@@ -192,8 +209,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
-          cache-dependency-path: swifttunnel-desktop/package-lock.json
+          # No cache: npm. Self-hosted runner keeps the npm download cache at
+          # %LOCALAPPDATA%\npm-cache between runs, so the GitHub-backed cache
+          # would just be redundant churn (and tag-scoped, so it never hits).
 
       - name: Enforce version consistency
         shell: powershell
@@ -266,13 +284,11 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache Rust build outputs
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            . -> target
-          cache-on-failure: true
-          save-if: true
+      # No GitHub-backed Rust cache. Tag-triggered runs are scoped to their
+      # own ref, so each tag would always miss caches saved by prior tags.
+      # Instead, the controlled clean step above preserves compiler outputs
+      # in target/ on the testbench runner while removing stale packaged
+      # bundles before the release upload step.
 
       - name: Install frontend dependencies
         working-directory: swifttunnel-desktop

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Built-in performance optimizations:
 - **FPS Unlocker** — Remove the 60 FPS cap
 - **Network Tweaks** — Optimize TCP/UDP settings, DNS, and adapter config
 - **System Boosts** — Process priority, timer resolution, memory management
-- **Roblox FFlags** — Ultraboost writes every valid Roblox `version-*` folder and re-applies saved flags on startup so Roblox updates do not drop the settings.
+- **Roblox FFlags** — Ultraboost writes every valid Roblox `version-*` folder with curated allowlisted FPS flags, cleans up retired SwiftTunnel flags such as high-DPI sharpness overrides, and re-applies saved flags on startup so Roblox updates do not drop the settings.
 
 ### 🔒 Lightweight & Safe
 - No kernel drivers required for basic operation
@@ -180,6 +180,7 @@ Notes:
 - The manual `Announce Release` workflow can resend the Discord announcement for an existing tag without rebuilding or republishing the app.
 - `SWIFTTUNNEL_UPDATE_MANIFEST_PRIVATE_KEY` should be an Ed25519 private key (PEM), and `SWIFTTUNNEL_UPDATE_MANIFEST_PUBLIC_KEY_B64` should be the matching raw 32-byte public key encoded in base64.
 - Windows CI and release packaging run on the self-hosted `testbench` GitHub runner with the `swifttunnel-app` label so GitHub uses the same Windows environment we already trust for real builds.
+- Release packaging does not use GitHub-backed npm or Rust caches. Tag-scoped release runs would miss those caches; instead, the self-hosted runner keeps npm's local download cache and preserves Cargo compiler outputs between runs while removing stale packaged bundles and cleaning the rest of the workspace.
 - A scheduled GitHub reconciliation workflow dispatches the normal GitHub `Release` workflow if the newest GitHub semver tag is missing its release entry.
 
 ### GitHub Cutover Notes

--- a/Windows-testbench/run_split_tunnel_integration_test.ps1
+++ b/Windows-testbench/run_split_tunnel_integration_test.ps1
@@ -11,7 +11,10 @@ param(
     [int]$UdpCount,
     [int]$UdpPayloadBytes,
     [string]$TcpTarget,
-    [int]$TcpCount
+    [int]$TcpCount,
+    [string]$HttpsGetUrl,
+    [string]$TestExe,
+    [switch]$SkipManualProcessRegister
 )
 
 $ErrorActionPreference = "Stop"
@@ -36,6 +39,9 @@ if ($UdpCount) { $argsList += @("--udp-count", $UdpCount) }
 if ($UdpPayloadBytes) { $argsList += @("--udp-payload-bytes", $UdpPayloadBytes) }
 if ($TcpTarget) { $argsList += @("--tcp-target", $TcpTarget) }
 if ($TcpCount) { $argsList += @("--tcp-count", $TcpCount) }
+if ($HttpsGetUrl) { $argsList += @("--https-get-url", $HttpsGetUrl) }
+if ($TestExe) { $argsList += @("--test-exe", $TestExe) }
+if ($SkipManualProcessRegister) { $argsList += "--skip-manual-process-register" }
 
 & ".\target\release\split_tunnel_integration_test.exe" @argsList
 exit $LASTEXITCODE

--- a/swifttunnel-core/src/bin/ip_checker.rs
+++ b/swifttunnel-core/src/bin/ip_checker.rs
@@ -1,9 +1,10 @@
 mod testbench_shared;
 
 use testbench_shared::{
-    DEFAULT_TCP_PROBE_COUNT, DEFAULT_TCP_PROBE_TARGET, DEFAULT_UDP_ECHO_PAYLOAD_BYTES,
-    DEFAULT_UDP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS, DEFAULT_UDP_PROBE_TARGET,
-    get_public_ip, init_logging, run_tcp_probe, run_udp_echo_probe, run_udp_probe,
+    DEFAULT_HTTPS_PROBE_URL, DEFAULT_TCP_PROBE_COUNT, DEFAULT_TCP_PROBE_TARGET,
+    DEFAULT_UDP_ECHO_PAYLOAD_BYTES, DEFAULT_UDP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS,
+    DEFAULT_UDP_PROBE_TARGET, get_public_ip, init_logging, run_https_get_probe, run_tcp_probe,
+    run_udp_echo_probe, run_udp_probe,
 };
 
 fn print_usage() {
@@ -21,6 +22,10 @@ fn print_usage() {
     println!(
         "  ip_checker.exe --tcp-probe [--target {}] [--count {}] [--startup-delay-ms {}] [--port-file path]",
         DEFAULT_TCP_PROBE_TARGET, DEFAULT_TCP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS
+    );
+    println!(
+        "  ip_checker.exe --https-get [--url {}] [--startup-delay-ms {}]",
+        DEFAULT_HTTPS_PROBE_URL, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS
     );
 }
 
@@ -274,6 +279,57 @@ fn main() {
             std::process::exit(1);
         }
         println!("TCP probe complete: target={} count={}", target, count);
+        return;
+    }
+
+    if args.iter().any(|arg| arg == "--https-get") {
+        let mut url = DEFAULT_HTTPS_PROBE_URL.to_string();
+        let mut startup_delay_ms = DEFAULT_UDP_PROBE_STARTUP_DELAY_MS;
+        let mut idx = 0usize;
+
+        while idx < args.len() {
+            match args[idx].as_str() {
+                "--https-get" => idx += 1,
+                "--url" => {
+                    idx += 1;
+                    let Some(value) = args.get(idx) else {
+                        eprintln!("Missing value for --url");
+                        std::process::exit(2);
+                    };
+                    url = value.clone();
+                    idx += 1;
+                }
+                "--startup-delay-ms" => {
+                    idx += 1;
+                    let Some(value) = args.get(idx) else {
+                        eprintln!("Missing value for --startup-delay-ms");
+                        std::process::exit(2);
+                    };
+                    match value.parse::<u64>() {
+                        Ok(parsed) => startup_delay_ms = parsed,
+                        Err(_) => {
+                            eprintln!("Invalid integer for --startup-delay-ms: {}", value);
+                            std::process::exit(2);
+                        }
+                    }
+                    idx += 1;
+                }
+                other => {
+                    eprintln!("Unknown argument: {}", other);
+                    std::process::exit(2);
+                }
+            }
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build tokio runtime");
+        if let Err(err) = runtime.block_on(run_https_get_probe(&url, startup_delay_ms)) {
+            eprintln!("HTTPS GET probe failed: {}", err);
+            std::process::exit(1);
+        }
+        println!("HTTPS GET probe complete: url={}", url);
         return;
     }
 

--- a/swifttunnel-core/src/bin/split_tunnel_integration_test.rs
+++ b/swifttunnel-core/src/bin/split_tunnel_integration_test.rs
@@ -1,17 +1,17 @@
 mod testbench_shared;
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Child, Command};
 use std::time::Duration;
 
 use swifttunnel_core::settings::load_settings;
 use swifttunnel_core::vpn::{SplitTunnelDiagnostics, VpnConnection};
 use testbench_shared::{
-    DEFAULT_TCP_PROBE_COUNT, DEFAULT_TCP_PROBE_TARGET, DEFAULT_UDP_ECHO_PAYLOAD_BYTES,
-    DEFAULT_UDP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS, DEFAULT_UDP_PROBE_TARGET,
-    connect_vpn, get_public_ip, init_logging, parse_common_cli_options, print_diagnostics,
-    print_preflight_summary, resolve_binding_preference, resolve_enable_api_tunneling,
-    resolve_region, resolve_test_exe,
+    DEFAULT_HTTPS_PROBE_URL, DEFAULT_TCP_PROBE_COUNT, DEFAULT_TCP_PROBE_TARGET,
+    DEFAULT_UDP_ECHO_PAYLOAD_BYTES, DEFAULT_UDP_PROBE_COUNT, DEFAULT_UDP_PROBE_STARTUP_DELAY_MS,
+    DEFAULT_UDP_PROBE_TARGET, connect_vpn, get_public_ip, init_logging, parse_common_cli_options,
+    print_diagnostics, print_preflight_summary, resolve_binding_preference,
+    resolve_enable_api_tunneling, resolve_probe_process_name, resolve_region, resolve_test_exe,
 };
 
 fn print_usage() {
@@ -37,8 +37,10 @@ fn print_usage() {
     println!("  SWIFTTUNNEL_TEST_REGION");
     println!("  SWIFTTUNNEL_TEST_ADAPTER_GUID");
     println!("  SWIFTTUNNEL_TEST_TCP_TARGET");
+    println!("  SWIFTTUNNEL_TEST_HTTPS_GET_URL");
     println!("  SWIFTTUNNEL_TEST_CUSTOM_RELAY");
     println!("  SWIFTTUNNEL_TEST_ENABLE_API_TUNNELING");
+    println!("  --skip-manual-process-register");
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -136,6 +138,7 @@ async fn run_connected_checks(
     if !test_exe.exists() {
         return Err(format!("test executable not found: {}", test_exe.display()));
     }
+    let probe_process_name = resolve_probe_process_name(options);
 
     let udp_target = options
         .udp_target
@@ -196,21 +199,36 @@ async fn run_connected_checks(
             &port_file_arg,
         ]);
     }
-    let child = command
+    let mut child = command
         .spawn()
         .map_err(|e| format!("failed to spawn probe executable: {}", e))?;
 
     let child_pid = child.id();
     println!("Probe helper PID: {}", child_pid);
-    vpn.register_tunnel_process(child_pid, "ip_checker.exe")
-        .await
-        .map_err(|e| format!("failed to register probe process for tunneling: {}", e))?;
+    if options.skip_manual_process_register {
+        println!(
+            "Skipping manual probe process registration for {}; relying on process watcher",
+            probe_process_name
+        );
+    } else {
+        register_probe_process_or_stop(vpn, &mut child, &probe_process_name, "probe").await?;
+    }
 
-    let local_port = wait_for_probe_port(&port_file)?;
+    let local_port = match wait_for_probe_port(&port_file) {
+        Ok(port) => port,
+        Err(e) => {
+            stop_probe_child(&mut child, "probe port wait");
+            return Err(e);
+        }
+    };
     println!("Probe helper local UDP port: {}", local_port);
-    vpn.register_tunnel_udp_port(local_port)
-        .await
-        .map_err(|e| format!("failed to register probe UDP port for tunneling: {}", e))?;
+    if let Err(e) = vpn.register_tunnel_udp_port(local_port).await {
+        stop_probe_child(&mut child, "probe UDP port registration");
+        return Err(format!(
+            "failed to register probe UDP port for tunneling: {}",
+            e
+        ));
+    }
 
     let output = child
         .wait_with_output()
@@ -244,6 +262,7 @@ async fn run_connected_checks(
 
     if api_tunneling_enabled {
         run_tcp_api_probe_check(vpn, options, &after).await?;
+        run_https_api_probe_check(vpn, options).await?;
     } else {
         println!("Skipping TCP/API probe because API tunneling is disabled");
     }
@@ -257,6 +276,7 @@ async fn run_tcp_api_probe_check(
     before: &SplitTunnelDiagnostics,
 ) -> Result<(), String> {
     let test_exe = resolve_test_exe(options)?;
+    let probe_process_name = resolve_probe_process_name(options);
     let startup_delay_ms = DEFAULT_UDP_PROBE_STARTUP_DELAY_MS.to_string();
     let port_file = std::env::temp_dir().join(format!(
         "swifttunnel-probe-tcp-port-{}-{}.txt",
@@ -281,7 +301,7 @@ async fn run_tcp_api_probe_check(
         tcp_target,
         tcp_count
     );
-    let child = Command::new(&test_exe)
+    let mut child = Command::new(&test_exe)
         .args([
             "--tcp-probe",
             "--target",
@@ -298,11 +318,22 @@ async fn run_tcp_api_probe_check(
 
     let child_pid = child.id();
     println!("TCP probe helper PID: {}", child_pid);
-    vpn.register_tunnel_process(child_pid, "ip_checker.exe")
-        .await
-        .map_err(|e| format!("failed to register TCP probe process for tunneling: {}", e))?;
+    if options.skip_manual_process_register {
+        println!(
+            "Skipping manual TCP probe process registration for {}; relying on process watcher",
+            probe_process_name
+        );
+    } else {
+        register_probe_process_or_stop(vpn, &mut child, &probe_process_name, "TCP probe").await?;
+    }
 
-    let local_port = wait_for_probe_port(&port_file)?;
+    let local_port = match wait_for_probe_port(&port_file) {
+        Ok(port) => port,
+        Err(e) => {
+            stop_probe_child(&mut child, "TCP probe port wait");
+            return Err(e);
+        }
+    };
     println!("TCP probe helper local port: {}", local_port);
 
     let output = child
@@ -336,6 +367,109 @@ async fn run_tcp_api_probe_check(
     }
 
     Ok(())
+}
+
+async fn run_https_api_probe_check(
+    vpn: &mut VpnConnection,
+    options: &testbench_shared::CommonCliOptions,
+) -> Result<(), String> {
+    let before = vpn
+        .get_split_tunnel_diagnostics()
+        .ok_or_else(|| "missing split tunnel diagnostics before HTTPS probe".to_string())?;
+    let test_exe = resolve_test_exe(options)?;
+    let probe_process_name = resolve_probe_process_name(options);
+    let startup_delay_ms = DEFAULT_UDP_PROBE_STARTUP_DELAY_MS.to_string();
+    let url = options
+        .https_get_url
+        .clone()
+        .or_else(|| std::env::var("SWIFTTUNNEL_TEST_HTTPS_GET_URL").ok())
+        .unwrap_or_else(|| DEFAULT_HTTPS_PROBE_URL.to_string());
+
+    println!(
+        "Running tunneled HTTPS/API probe via {} to {}",
+        test_exe.display(),
+        url
+    );
+    let mut child = Command::new(&test_exe)
+        .args([
+            "--https-get",
+            "--url",
+            &url,
+            "--startup-delay-ms",
+            &startup_delay_ms,
+        ])
+        .spawn()
+        .map_err(|e| format!("failed to spawn HTTPS probe executable: {}", e))?;
+
+    let child_pid = child.id();
+    println!("HTTPS probe helper PID: {}", child_pid);
+    if options.skip_manual_process_register {
+        println!(
+            "Skipping manual HTTPS probe process registration for {}; relying on process watcher",
+            probe_process_name
+        );
+    } else {
+        register_probe_process_or_stop(vpn, &mut child, &probe_process_name, "HTTPS probe").await?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("failed to wait for HTTPS probe executable: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "HTTPS probe executable failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    if !output.stdout.is_empty() {
+        println!("{}", String::from_utf8_lossy(&output.stdout).trim());
+    }
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let after = vpn
+        .get_split_tunnel_diagnostics()
+        .ok_or_else(|| "missing split tunnel diagnostics after HTTPS probe".to_string())?;
+    print_diagnostics(&after);
+
+    if after.packets_tunneled <= before.packets_tunneled {
+        return Err(format!(
+            "expected HTTPS/API probe to increase tunneled packet counter (before={}, after={})",
+            before.packets_tunneled, after.packets_tunneled
+        ));
+    }
+
+    Ok(())
+}
+
+async fn register_probe_process_or_stop(
+    vpn: &mut VpnConnection,
+    child: &mut Child,
+    process_name: &str,
+    label: &str,
+) -> Result<(), String> {
+    if let Err(e) = vpn.register_tunnel_process(child.id(), process_name).await {
+        stop_probe_child(child, label);
+        return Err(format!(
+            "failed to register {} process for tunneling: {}",
+            label, e
+        ));
+    }
+    Ok(())
+}
+
+fn stop_probe_child(child: &mut Child, label: &str) {
+    if let Err(e) = child.kill() {
+        eprintln!(
+            "Failed to kill {} child process {}: {}",
+            label,
+            child.id(),
+            e
+        );
+    }
+    let _ = child.wait();
 }
 
 fn wait_for_probe_port(path: &Path) -> Result<u16, String> {

--- a/swifttunnel-core/src/bin/testbench_shared/mod.rs
+++ b/swifttunnel-core/src/bin/testbench_shared/mod.rs
@@ -17,6 +17,8 @@ pub const DEFAULT_UDP_ECHO_PAYLOAD_BYTES: usize = 1200;
 pub const DEFAULT_UDP_PROBE_STARTUP_DELAY_MS: u64 = 1500;
 pub const DEFAULT_TCP_PROBE_TARGET: &str = "www.roblox.com:80";
 pub const DEFAULT_TCP_PROBE_COUNT: usize = 5;
+pub const DEFAULT_HTTPS_PROBE_URL: &str =
+    "https://clientsettingscdn.roblox.com/v2/settings/application/PCDesktopClient";
 
 #[derive(Debug, Clone, Default)]
 pub struct CommonCliOptions {
@@ -32,8 +34,10 @@ pub struct CommonCliOptions {
     pub udp_payload_bytes: Option<usize>,
     pub tcp_target: Option<String>,
     pub tcp_count: Option<usize>,
+    pub https_get_url: Option<String>,
     pub custom_relay_server: Option<String>,
     pub enable_api_tunneling: bool,
+    pub skip_manual_process_register: bool,
 }
 
 pub fn init_logging() {
@@ -89,8 +93,10 @@ pub fn parse_common_cli_options(args: &[String]) -> Result<CommonCliOptions, Str
                     .map_err(|_| format!("Invalid integer for {}: {}", flag, raw))?;
                 opts.tcp_count = Some(count);
             }
+            "--https-get-url" => opts.https_get_url = Some(next(flag, &mut idx)?),
             "--custom-relay" => opts.custom_relay_server = Some(next(flag, &mut idx)?),
             "--enable-api-tunneling" => opts.enable_api_tunneling = true,
+            "--skip-manual-process-register" => opts.skip_manual_process_register = true,
             "--help" | "-h" => return Err("help".to_string()),
             other => return Err(format!("Unknown argument: {}", other)),
         }
@@ -262,6 +268,16 @@ pub fn resolve_test_exe(opts: &CommonCliOptions) -> Result<PathBuf, String> {
         return Err("Current executable has no parent directory".to_string());
     };
     Ok(dir.join("ip_checker.exe"))
+}
+
+pub fn resolve_probe_process_name(opts: &CommonCliOptions) -> String {
+    opts.test_exe
+        .as_ref()
+        .and_then(|path| path.file_name())
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("ip_checker.exe")
+        .to_string()
 }
 
 pub fn get_public_ip() -> Result<String, String> {
@@ -550,6 +566,50 @@ pub fn run_tcp_probe(
     Ok(())
 }
 
+pub async fn run_https_get_probe(url: &str, startup_delay_ms: u64) -> Result<(), String> {
+    // Give the parent process time to register the helper PID before any TCP
+    // SYN is emitted.
+    tokio::time::sleep(Duration::from_millis(startup_delay_ms)).await;
+
+    let response = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .user_agent("SwiftTunnel-Testbench/1.0")
+        .build()
+        .map_err(|e| format!("Failed to build HTTPS probe client: {}", e))?
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("HTTPS GET '{}' failed: {}", url, e))?;
+
+    let status = response.status();
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("HTTPS GET '{}' response read failed: {}", url, e))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "HTTPS GET '{}' returned {} ({} bytes)",
+            url,
+            status,
+            bytes.len()
+        ));
+    }
+
+    if bytes.is_empty() {
+        return Err(format!("HTTPS GET '{}' returned an empty response", url));
+    }
+
+    println!(
+        "HTTPS GET probe response summary: url={} status={} response_bytes={}",
+        url,
+        status,
+        bytes.len()
+    );
+
+    Ok(())
+}
+
 pub async fn connect_vpn(
     vpn: &mut VpnConnection,
     opts: &CommonCliOptions,
@@ -560,10 +620,19 @@ pub async fn connect_vpn(
     let region = resolve_region(opts);
     let available_servers = load_available_servers().await?;
 
+    let mut tunnel_apps = vec!["ip_checker.exe".to_string()];
+    let probe_process_name = resolve_probe_process_name(opts);
+    if !tunnel_apps
+        .iter()
+        .any(|app| app.eq_ignore_ascii_case(&probe_process_name))
+    {
+        tunnel_apps.push(probe_process_name);
+    }
+
     vpn.connect(
         &access_token,
         &region,
-        vec!["ip_checker.exe".to_string()],
+        tunnel_apps,
         resolve_custom_relay_server(opts, settings),
         false,
         settings.config.network_settings.gaming_qos,

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -723,7 +723,7 @@ impl RobloxOptimizer {
     //  ULTRABOOST FFLAGS
     // ═══════════════════════════════════════════════════════════════════════════════
 
-    /// All allowlisted performance FFlags applied by Ultraboost
+    /// Allowlisted performance FFlags applied by Ultraboost.
     const ULTRABOOST_FFLAGS: &[(&str, &str)] = &[
         ("FFlagHandleAltEnterFullscreenManually", "False"),
         ("FFlagDebugGraphicsPreferD3D11", "True"),
@@ -735,7 +735,6 @@ impl RobloxOptimizer {
         ("FIntFRMMinGrassDistance", "0"),
         ("FIntFRMMaxGrassDistance", "0"),
         ("FIntGrassMovementReducedMotionFactor", "0"),
-        ("DFFlagDisableDPIScale", "True"),
     ];
 
     /// FFlag used by Bloxstrap-family bootstrappers for the framerate limiter.
@@ -749,6 +748,12 @@ impl RobloxOptimizer {
         "FFlagDisablePostFx",
         "FIntDebugTextureManagerSkipMips",
     ];
+
+    /// Former SwiftTunnel UltraBoost entries that should be removed from
+    /// existing ClientAppSettings. `DFFlagDisableDPIScale` is a valid Roblox
+    /// client flag, but it favors sharper high-DPI rendering over maximum FPS
+    /// so it is no longer written by Ultraboost.
+    const REMOVED_ULTRABOOST_FFLAGS: &[&str] = &["DFFlagDisableDPIScale"];
 
     /// Known Bloxstrap-family persistent ClientSettings locations under LOCALAPPDATA.
     ///
@@ -1023,9 +1028,9 @@ impl RobloxOptimizer {
     }
 
     /// Apply FFlag optimizations to ClientAppSettings.json
-    /// When ultraboost is enabled, writes all allowlisted performance FFlags.
+    /// When ultraboost is enabled, writes curated allowlisted performance FFlags.
     /// When FPS unlock is enabled, writes the bootstrapper-compatible FPS FFlag.
-    /// Always cleans up old blocked FFlags from previous versions.
+    /// Always cleans up old blocked or retired FFlags from previous versions.
     fn apply_client_fflags(&self, config: &RobloxSettingsConfig) -> Result<FFlagApplyOutcome> {
         let should_write_fflags = config.ultraboost || config.unlock_fps;
         let client_settings_paths = Self::get_client_settings_paths(should_write_fflags)?;
@@ -1146,8 +1151,11 @@ impl RobloxOptimizer {
 
         let mut settings = Self::read_client_app_settings(&settings_path)?;
 
-        // Always clean up old blocked FFlags from previous versions
+        // Always clean up old blocked or retired FFlags from previous versions
         for key in Self::LEGACY_BLOCKED_FFLAGS {
+            settings.remove(*key);
+        }
+        for key in Self::REMOVED_ULTRABOOST_FFLAGS {
             settings.remove(*key);
         }
 
@@ -1244,6 +1252,9 @@ impl RobloxOptimizer {
 
                 // Remove old blocked FFlags (legacy cleanup)
                 for key in Self::LEGACY_BLOCKED_FFLAGS {
+                    settings.remove(*key);
+                }
+                for key in Self::REMOVED_ULTRABOOST_FFLAGS {
                     settings.remove(*key);
                 }
 
@@ -2034,6 +2045,47 @@ mod tests {
     }
 
     #[test]
+    fn fflag_apply_removes_retired_ultraboost_flags_when_enabled() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_retired_ultraboost");
+        let _ = fs::remove_dir_all(&dir);
+        let version = dir.join("Roblox").join("Versions").join("version-active");
+        let client_settings = version.join("ClientSettings");
+        fs::create_dir_all(&client_settings).unwrap();
+        fs::write(version.join("RobloxPlayerBeta.exe"), "").unwrap();
+        fs::write(
+            client_settings.join("ClientAppSettings.json"),
+            r#"{
+  "DFFlagDisableDPIScale": "True",
+  "FStringUserOwnedFlag": "keep-me"
+}"#,
+        )
+        .unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let config = RobloxSettingsConfig {
+            ultraboost: true,
+            ..Default::default()
+        };
+
+        opt.apply_client_fflags_for_local_app_data(&config, &dir)
+            .unwrap();
+
+        let content = fs::read_to_string(client_settings.join("ClientAppSettings.json")).unwrap();
+        let settings: HashMap<String, serde_json::Value> = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            settings.get("FFlagDebugGraphicsPreferD3D11"),
+            Some(&serde_json::json!("True"))
+        );
+        assert!(!settings.contains_key("DFFlagDisableDPIScale"));
+        assert_eq!(
+            settings.get("FStringUserOwnedFlag"),
+            Some(&serde_json::json!("keep-me"))
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn fflag_apply_ignores_version_like_folder_without_player_exe() {
         let dir = std::env::temp_dir().join("roblox_opt_test_fflag_ignore_nearmiss");
         let _ = fs::remove_dir_all(&dir);
@@ -2378,8 +2430,8 @@ mod tests {
     fn ultraboost_fflags_count() {
         assert_eq!(
             RobloxOptimizer::ULTRABOOST_FFLAGS.len(),
-            11,
-            "Expected 11 ultraboost FFlags"
+            10,
+            "Expected 10 ultraboost FFlags"
         );
     }
 
@@ -2393,15 +2445,27 @@ mod tests {
     }
 
     #[test]
+    fn removed_ultraboost_fflags_count() {
+        assert_eq!(
+            RobloxOptimizer::REMOVED_ULTRABOOST_FFLAGS.len(),
+            1,
+            "Expected 1 retired ultraboost FFlag"
+        );
+    }
+
+    #[test]
     fn ultraboost_and_legacy_fflags_are_disjoint() {
         let ultraboost_keys: Vec<&str> = RobloxOptimizer::ULTRABOOST_FFLAGS
             .iter()
             .map(|(k, _)| *k)
             .collect();
-        for legacy_key in RobloxOptimizer::LEGACY_BLOCKED_FFLAGS {
+        for legacy_key in RobloxOptimizer::LEGACY_BLOCKED_FFLAGS
+            .iter()
+            .chain(RobloxOptimizer::REMOVED_ULTRABOOST_FFLAGS.iter())
+        {
             assert!(
                 !ultraboost_keys.contains(legacy_key),
-                "Legacy key '{}' should not appear in ultraboost FFlags",
+                "Cleaned-up key '{}' should not appear in ultraboost FFlags",
                 legacy_key
             );
         }

--- a/swifttunnel-core/src/structs.rs
+++ b/swifttunnel-core/src/structs.rs
@@ -113,7 +113,7 @@ pub struct RobloxSettingsConfig {
     pub window_height: u32,
     #[serde(default = "default_roblox_window_fullscreen")]
     pub window_fullscreen: bool,
-    /// Ultraboost: applies all allowlisted performance FFlags for maximum FPS
+    /// Ultraboost: applies curated allowlisted performance FFlags for maximum FPS
     #[serde(default)]
     pub ultraboost: bool,
 }
@@ -459,8 +459,8 @@ pub mod boost_info {
         id: "ultraboost",
         title: "Ultraboost",
         short_desc: "Max performance FFlags",
-        long_desc: "Applies all Roblox-allowlisted performance FFlags for maximum FPS. Disables shadows, post-processing, grass, DPI scaling, and forces D3D11 with lowest texture and render quality. Significant visual reduction for maximum frame rates.",
-        impact: "+20-40% FPS",
+        long_desc: "Applies curated Roblox-allowlisted performance FFlags for maximum FPS. Forces D3D11 with minimum texture, render quality, anti-aliasing, sky, and grass settings while avoiding high-DPI sharpness flags that can cost frames.",
+        impact: "Maximum FPS preset",
         risk_level: RiskLevel::Safe,
         requires_admin: false,
     };

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -7,6 +7,7 @@
 //! - Connection state tracking
 
 use super::local_connectivity::LocalConnectivity;
+use super::parallel_interceptor::WorkerPanicCause;
 use super::parallel_interceptor::{
     AdapterBindingPreference, QueueOverflowMode, ThroughputStats,
     is_point_to_point_default_route_context,
@@ -69,6 +70,13 @@ const CONNECT_FAIL_AUTH_REQUIRED: &str = "ST_CONNECT_AUTH_REQUIRED";
 const CONNECT_FAIL_POLICY_UNAVAILABLE: &str = "ST_CONNECT_POLICY_UNAVAILABLE";
 const CONNECT_FAIL_REGION_UNAVAILABLE: &str = "ST_CONNECT_REGION_UNAVAILABLE";
 
+/// Relay UDP port used *only* as a last-resort fallback when the resolved
+/// server list carried no relay candidate (and no custom relay is configured)
+/// to derive a port from. Normal connects use the per-relay `relay_port`
+/// advertised by `/api/vpn/servers`; reaching this constant means the server
+/// list was empty or malformed, which `setup_split_tunnel` logs as a warning.
+const FALLBACK_RELAY_PORT: u16 = 51821;
+
 static HANDSHAKE_TIMEOUT_EVENTS: AtomicU64 = AtomicU64::new(0);
 static CANDIDATE_EXHAUSTED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static PREFLIGHT_ENFORCED_EVENTS: AtomicU64 = AtomicU64::new(0);
@@ -112,6 +120,20 @@ fn classify_relay_health(
 ) -> RelayHealthAction {
     use super::udp_relay::RelayHealthState;
 
+    if sender_panicked {
+        // The relay sender thread panicked or hit an unrecoverable send error.
+        // Every outbound game packet is silently dropped for the rest of this
+        // session, so the connection is effectively dead. Prefer this
+        // structured sender-failure signal even if relay health has also raced
+        // to Dead, so teardown records the primary failure instead of a generic
+        // relay-dead label.
+        return RelayHealthAction::Fatal {
+            error_message: "Relay connection failed - SwiftTunnel stopped the session because the outbound relay path failed. Please reconnect."
+                .to_string(),
+            cleanup_reason: "relay_sender_panicked",
+        };
+    }
+
     if health == RelayHealthState::Dead {
         // The relay-dead heuristic also fires when the user's own machine
         // loses internet (Wi-Fi blip, sleep/resume, ISP outage): keepalives
@@ -133,12 +155,6 @@ fn classify_relay_health(
         };
     }
 
-    if sender_panicked {
-        return RelayHealthAction::Continue {
-            relay_status: Some("panicked".to_string()),
-        };
-    }
-
     match health {
         RelayHealthState::Stale => RelayHealthAction::Continue {
             relay_status: Some("stale".to_string()),
@@ -147,6 +163,35 @@ fn classify_relay_health(
             RelayHealthAction::Continue { relay_status: None }
         }
         RelayHealthState::Dead => unreachable!("handled above"),
+    }
+}
+
+/// Maps a `WorkerPanicCause` to the user-facing error message and the
+/// teardown `cleanup_reason` marker. Pulled out as a pure function so the
+/// UI-contract wording is unit-testable.
+///
+/// `ReaderHandleLost` MUST keep wording that matches `isDriverMissing()` in
+/// swifttunnel-desktop/src/components/connect/connectState.ts — that helper
+/// substring-matches "split tunnel driver not available" AND "windows packet
+/// filter driver" (case-insensitive) to render the install-driver CTA.
+/// `InternalThreadFailed` MUST NOT contain those substrings: a panicked
+/// reader/inbound thread is an internal bug, not a missing driver, so the UI
+/// should offer a plain reconnect instead of a misleading reinstall prompt.
+fn worker_panic_error(cause: WorkerPanicCause) -> (String, &'static str) {
+    match cause {
+        WorkerPanicCause::ReaderHandleLost => (
+            "Split tunnel driver not available — the Windows Packet Filter driver lost \
+             its adapter handle and could not recover. Please reconnect, or reinstall \
+             the driver."
+                .to_string(),
+            "workers_panicked_recovery",
+        ),
+        WorkerPanicCause::InternalThreadFailed => (
+            "SwiftTunnel stopped the session because an internal networking thread failed \
+             unexpectedly. Please reconnect."
+                .to_string(),
+            "worker_thread_failed_recovery",
+        ),
     }
 }
 
@@ -1225,23 +1270,34 @@ impl VpnConnection {
             selected_relay_region = server_region.clone();
             *addr
         } else {
-            // No custom relay = use resolved server endpoint, forcing relay port 51821.
+            // No custom relay AND no relay candidate from the server list.
+            // This should not happen on a healthy connect — `/api/vpn/servers`
+            // carries a `relay_port` per relay — so we fall back to the
+            // resolved server endpoint with `FALLBACK_RELAY_PORT` and log it
+            // loudly rather than silently guessing a port.
+            log::warn!(
+                "V3: no relay candidate resolved; falling back to {} with hardcoded port {}",
+                config.endpoint,
+                FALLBACK_RELAY_PORT
+            );
             if let Ok(addr) = config.endpoint.parse::<SocketAddr>() {
-                SocketAddr::new(addr.ip(), 51821)
+                SocketAddr::new(addr.ip(), FALLBACK_RELAY_PORT)
             } else if let Ok(ip) = config.endpoint.parse::<std::net::IpAddr>() {
-                SocketAddr::new(ip, 51821)
+                SocketAddr::new(ip, FALLBACK_RELAY_PORT)
             } else {
                 let vpn_ip = config
                     .endpoint
                     .split(':')
                     .next()
                     .unwrap_or(&config.endpoint);
-                format!("{}:51821", vpn_ip).parse().map_err(|e| {
-                    VpnError::SplitTunnelSetupFailed(format!(
-                        "Invalid VPN server IP for relay: {}",
-                        e
-                    ))
-                })?
+                format!("{}:{}", vpn_ip, FALLBACK_RELAY_PORT)
+                    .parse()
+                    .map_err(|e| {
+                        VpnError::SplitTunnelSetupFailed(format!(
+                            "Invalid VPN server IP for relay: {}",
+                            e
+                        ))
+                    })?
             }
         };
 
@@ -1858,10 +1914,10 @@ impl VpnConnection {
             log::info!("V3: Currently tunneling: {:?}", running);
         }
 
-        // Capture the interceptor's panic flag before the driver moves into an
-        // Arc<Mutex<_>> — the monitor task needs lock-free access to poll it
-        // alongside relay_health and sender_panicked.
-        let workers_panicked_for_monitor = driver.workers_panicked_arc();
+        // Capture the interceptor's panic-cause flag before the driver moves
+        // into an Arc<Mutex<_>> — the monitor task needs lock-free access to
+        // poll it alongside relay_health and sender_panicked.
+        let workers_panic_cause_for_monitor = driver.workers_panic_cause_arc();
         let driver = Arc::new(Mutex::new(driver));
         self.split_tunnel = Some(Arc::clone(&driver));
 
@@ -1921,7 +1977,7 @@ impl VpnConnection {
         let auto_router_for_monitor = self.auto_router.clone();
         let process_performance_for_monitor = self.process_performance_manager.clone();
         let relay_health_monitor = relay_for_health;
-        let workers_panicked_monitor = workers_panicked_for_monitor;
+        let workers_panic_cause_monitor = workers_panic_cause_for_monitor;
 
         tokio::spawn(async move {
             log::info!("V3: Process monitor started");
@@ -2225,38 +2281,32 @@ impl VpnConnection {
                         {
                             let health = relay_health_monitor.relay_health();
 
-                            // `workers_panicked` means the split-tunnel reader
-                            // thread exhausted its rebind budget (see
-                            // `READER_MAX_REBINDS` in parallel_interceptor.rs)
-                            // or the V3 inbound receiver panicked — in either
-                            // case, zero packets will ever flow again in this
-                            // session. Previously we only dimmed `relay_status`
-                            // and the UI kept showing a green check. Now we
-                            // transition out of Connected so the UI can offer
-                            // reconnect + reinstall-driver CTAs.
-                            let workers_panicked = workers_panicked_monitor
+                            // A non-zero `workers_panic_cause` means a
+                            // split-tunnel thread failed and zero packets will
+                            // ever flow again in this session. The two causes
+                            // (see `WorkerPanicCause`) get distinct,
+                            // actionable error strings via `worker_panic_error`
+                            // — driver-handle loss renders the reinstall-driver
+                            // CTA, an internal thread panic renders a plain
+                            // reconnect. Previously both collapsed into one
+                            // "reinstall driver" message and the UI kept
+                            // showing a green check until then.
+                            let worker_panic_cause = workers_panic_cause_monitor
                                 .as_ref()
-                                .map(|f| f.load(Ordering::Acquire))
-                                .unwrap_or(false);
+                                .and_then(|f| {
+                                    WorkerPanicCause::from_u8(f.load(Ordering::Acquire))
+                                });
 
-                            if workers_panicked {
+                            if let Some(cause) = worker_panic_cause {
+                                let (error_message, cleanup_reason) =
+                                    worker_panic_error(cause);
                                 let transitioned = state_handle.send_if_modified(|state| {
                                     if matches!(*state, ConnectionState::Connected { .. }) {
                                         log::error!(
-                                            "V3: Split-tunnel reader could not recover — transitioning Connected → Error"
+                                            "V3: split-tunnel worker failure ({:?}) — transitioning Connected → Error",
+                                            cause
                                         );
-                                        // Wording MUST match `isDriverMissing()` in
-                                        // swifttunnel-desktop/src/components/connect/connectState.ts
-                                        // so the UI renders the install-driver CTA instead of plain
-                                        // text. That helper substring-matches on
-                                        // "split tunnel driver not available" AND
-                                        // "windows packet filter driver" (case-insensitive).
-                                        *state = ConnectionState::Error(
-                                            "Split tunnel driver not available — the Windows Packet Filter driver lost \
-                                             its adapter handle and could not recover. Please reconnect, or reinstall \
-                                             the driver."
-                                                .to_string(),
-                                        );
+                                        *state = ConnectionState::Error(error_message.clone());
                                         true
                                     } else {
                                         false
@@ -2289,7 +2339,7 @@ impl VpnConnection {
                                     }
                                     if let Some(ref manager) = process_performance_for_monitor {
                                         let mut guard = manager.lock().await;
-                                        guard.cleanup_all("workers_panicked_recovery");
+                                        guard.cleanup_all(cleanup_reason);
                                     }
                                     break;
                                 }
@@ -2889,6 +2939,123 @@ mod tests {
         );
 
         assert_eq!(action, RelayHealthAction::Continue { relay_status: None });
+    }
+
+    #[test]
+    fn test_sender_panicked_is_fatal_even_when_relay_health_looks_ok() {
+        // A panicked relay sender thread drops every outbound packet, but the
+        // keepalive bookkeeping that escalates `relay_health` to `Dead` lags
+        // ~60s behind. The monitor must tear the session down immediately on
+        // the `sender_panicked` signal instead of waiting for that timeout.
+        for health in [
+            super::super::udp_relay::RelayHealthState::Healthy,
+            super::super::udp_relay::RelayHealthState::NoTrafficYet,
+            super::super::udp_relay::RelayHealthState::Stale,
+        ] {
+            let action = classify_relay_health(health, true, LocalConnectivity::Unknown);
+            match action {
+                RelayHealthAction::Fatal {
+                    error_message,
+                    cleanup_reason,
+                } => {
+                    assert!(
+                        error_message.contains("outbound relay path failed"),
+                        "expected sender-panic message, got: {error_message}"
+                    );
+                    assert_eq!(cleanup_reason, "relay_sender_panicked");
+                }
+                RelayHealthAction::Continue { .. } => {
+                    panic!("a panicked sender must not remain connected (health={health:?})")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_sender_panicked_keeps_cleanup_reason_when_relay_also_dead() {
+        // Positive race fallback for W1: if the sender failure and relay-dead
+        // heuristic are both visible in the same monitor tick, preserve the
+        // structured sender-failure cleanup reason instead of masking it as a
+        // generic dead relay.
+        let action = classify_relay_health(
+            super::super::udp_relay::RelayHealthState::Dead,
+            true,
+            LocalConnectivity::Reachable,
+        );
+
+        match action {
+            RelayHealthAction::Fatal {
+                error_message,
+                cleanup_reason,
+            } => {
+                assert!(error_message.contains("outbound relay path failed"));
+                assert_eq!(cleanup_reason, "relay_sender_panicked");
+            }
+            RelayHealthAction::Continue { .. } => {
+                panic!("a panicked sender must not remain connected even when relay is dead")
+            }
+        }
+    }
+
+    #[test]
+    fn test_healthy_relay_without_sender_panic_stays_connected() {
+        // Negative companion to the test above: the fatal path must fire only
+        // for the actual `sender_panicked` signal, not for an otherwise
+        // healthy relay. Guards against the W1 fix over-triggering.
+        let action = classify_relay_health(
+            super::super::udp_relay::RelayHealthState::Healthy,
+            false,
+            LocalConnectivity::Unknown,
+        );
+        assert_eq!(action, RelayHealthAction::Continue { relay_status: None });
+    }
+
+    #[test]
+    fn test_worker_panic_error_reader_handle_lost_matches_driver_missing_ui_contract() {
+        // `isDriverMissing()` in connectState.ts substring-matches BOTH
+        // phrases (case-insensitive) to render the reinstall-driver CTA.
+        let (message, cleanup_reason) = worker_panic_error(WorkerPanicCause::ReaderHandleLost);
+        let lower = message.to_lowercase();
+        assert!(
+            lower.contains("split tunnel driver not available"),
+            "ReaderHandleLost message must trip isDriverMissing(): {message}"
+        );
+        assert!(
+            lower.contains("windows packet filter driver"),
+            "ReaderHandleLost message must trip isDriverMissing(): {message}"
+        );
+        assert_eq!(cleanup_reason, "workers_panicked_recovery");
+    }
+
+    #[test]
+    fn test_worker_panic_error_internal_thread_failed_avoids_driver_missing_ui_contract() {
+        // An internal thread panic is NOT a missing driver — the message must
+        // NOT trip `isDriverMissing()`, so the UI offers a plain reconnect
+        // instead of a misleading reinstall-driver prompt.
+        let (message, cleanup_reason) = worker_panic_error(WorkerPanicCause::InternalThreadFailed);
+        let lower = message.to_lowercase();
+        assert!(
+            !lower.contains("split tunnel driver not available"),
+            "InternalThreadFailed message must not trip isDriverMissing(): {message}"
+        );
+        assert!(
+            !lower.contains("windows packet filter driver"),
+            "InternalThreadFailed message must not trip isDriverMissing(): {message}"
+        );
+        assert_eq!(cleanup_reason, "worker_thread_failed_recovery");
+    }
+
+    #[test]
+    fn test_worker_panic_cause_u8_round_trips() {
+        for cause in [
+            WorkerPanicCause::ReaderHandleLost,
+            WorkerPanicCause::InternalThreadFailed,
+        ] {
+            assert_eq!(WorkerPanicCause::from_u8(cause.as_u8()), Some(cause));
+        }
+        // 0 is the "still running" sentinel and must never decode to a cause.
+        assert_eq!(WorkerPanicCause::from_u8(0), None);
+        assert_eq!(WorkerPanicCause::from_u8(99), None);
     }
 
     /// Default relay health for tests where the relay-health gate isn't

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -48,7 +48,7 @@ use std::net::Ipv4Addr;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -94,6 +94,53 @@ const REBIND_BACKOFFS: [Duration; READER_MAX_REBINDS as usize] = [
     Duration::from_millis(500),
     Duration::from_secs(2),
 ];
+
+/// Why the split-tunnel interceptor's internal threads stopped, surfaced to
+/// the connection monitor so it can pick an actionable error message instead
+/// of collapsing distinct failures into one string.
+///
+/// Stored in an `AtomicU8` (`workers_panic_cause`); a value of `0` means the
+/// threads are still running. The two variants map to the two things the user
+/// can actually do about it:
+///
+/// - `ReaderHandleLost` — the packet reader could not acquire or hold its NDIS
+///   adapter handle (rebind budget exhausted, initial acquire failed, a
+///   route-change restart failed, or the reader thread had to be abandoned on
+///   a join timeout). This is the driver-handle-loss class; the UI should
+///   offer the reinstall-driver CTA.
+/// - `InternalThreadFailed` — the packet reader thread or the V3 inbound
+///   receiver thread panicked, or the inbound receiver returned a fatal error.
+///   The driver is fine; this is an internal bug, so the UI should offer a
+///   plain reconnect rather than a misleading "reinstall driver" prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerPanicCause {
+    ReaderHandleLost,
+    InternalThreadFailed,
+}
+
+impl WorkerPanicCause {
+    pub fn as_u8(self) -> u8 {
+        match self {
+            WorkerPanicCause::ReaderHandleLost => 1,
+            WorkerPanicCause::InternalThreadFailed => 2,
+        }
+    }
+
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(WorkerPanicCause::ReaderHandleLost),
+            2 => Some(WorkerPanicCause::InternalThreadFailed),
+            _ => None,
+        }
+    }
+}
+
+/// Records the first worker-panic cause to occur this session. First write
+/// wins: a later generic teardown (e.g. the reader join timeout in `stop()`)
+/// must not clobber the specific cause the failing thread already reported.
+fn record_worker_panic_cause(flag: &AtomicU8, cause: WorkerPanicCause) {
+    let _ = flag.compare_exchange(0, cause.as_u8(), Ordering::AcqRel, Ordering::Acquire);
+}
 
 /// TCP owner-table refresh cadence while API tunneling is active and a tunnel
 /// process is present. Teleport/API HTTPS flows can be brief, so the normal
@@ -854,10 +901,11 @@ pub struct ParallelInterceptor {
     relay_ctx: Option<Arc<super::udp_relay::UdpRelay>>,
     /// Inbound receiver thread handle (reads from UdpRelay)
     inbound_receiver_handle: Option<JoinHandle<()>>,
-    /// Set to true if any internal thread (inbound receiver, reader, workers)
-    /// panics. The connection state machine polls this so a worker panic surfaces
-    /// as a real error instead of a silently frozen tunnel.
-    workers_panicked: Arc<AtomicBool>,
+    /// Set to a non-zero `WorkerPanicCause` discriminant if any internal thread
+    /// (inbound receiver, reader, workers) panics or loses its adapter handle.
+    /// The connection state machine polls this so a worker failure surfaces as
+    /// a real, *cause-specific* error instead of a silently frozen tunnel.
+    workers_panic_cause: Arc<AtomicU8>,
     /// Detected game server IPs (for notification purposes)
     detected_game_servers: Arc<parking_lot::RwLock<std::collections::HashSet<std::net::Ipv4Addr>>>,
     /// Flag to trigger immediate cache refresh (set by ETW when game process detected)
@@ -933,7 +981,7 @@ impl ParallelInterceptor {
             throughput_stats: ThroughputStats::default(),
             relay_ctx: None,
             inbound_receiver_handle: None,
-            workers_panicked: Arc::new(AtomicBool::new(false)),
+            workers_panic_cause: Arc::new(AtomicU8::new(0)),
             detected_game_servers: Arc::new(parking_lot::RwLock::new(
                 std::collections::HashSet::new(),
             )),
@@ -3932,15 +3980,15 @@ impl ParallelInterceptor {
         self.disable_ipv6()?;
 
         self.stop_flag.store(false, Ordering::Release);
-        // Reset the panic flag alongside stop_flag. `workers_panicked` is
-        // written `true` by the reader/inbound-receiver threads on panic or
-        // budget exhaustion, and is never cleared. Without this reset, a
+        // Reset the panic cause alongside stop_flag. `workers_panic_cause` is
+        // written by the reader/inbound-receiver threads on panic or budget
+        // exhaustion, and is never cleared on its own. Without this reset, a
         // subsequent `stop()`+`start()` on the same `ParallelInterceptor`
         // (e.g. via `maybe_rebind_on_default_route_change`) would start with
-        // the flag already asserted, and the next monitor tick would
+        // the cause already asserted, and the next monitor tick would
         // immediately transition the freshly-restarted session
         // Connected→Error.
-        self.workers_panicked.store(false, Ordering::Release);
+        self.workers_panic_cause.store(0, Ordering::Release);
         self.active = true;
 
         // Create channels for workers
@@ -4025,14 +4073,16 @@ impl ParallelInterceptor {
                 VpnError::SplitTunnel("Physical adapter name not set".to_string())
             })?);
 
-        let reader_panicked_flag = Arc::clone(&self.workers_panicked);
+        let reader_panic_cause_flag = Arc::clone(&self.workers_panic_cause);
         self.reader_handle = Some(thread::spawn(move || {
             // Wrap in catch_unwind so we can distinguish graceful shutdown
             // (stop_flag set by disconnect or a sibling thread) from a reader
             // failure. The reader's L3 error branch already sets stop_flag to
-            // propagate shutdown to other threads, so we also set
-            // workers_panicked here so the connection monitor can surface the
-            // failure instead of treating it as a clean disconnect.
+            // propagate shutdown to other threads, so we also record the
+            // panic cause here so the connection monitor can surface the
+            // failure instead of treating it as a clean disconnect. A reader
+            // *error* return is the driver-handle-loss class (rebind budget
+            // exhausted / acquire failed); a reader *panic* is an internal bug.
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 run_packet_reader(
                     physical_idx,
@@ -4055,10 +4105,16 @@ impl ParallelInterceptor {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
                     log::error!("Packet reader error: {}", e);
-                    reader_panicked_flag.store(true, Ordering::Release);
+                    record_worker_panic_cause(
+                        &reader_panic_cause_flag,
+                        WorkerPanicCause::ReaderHandleLost,
+                    );
                 }
                 Err(panic_payload) => {
-                    reader_panicked_flag.store(true, Ordering::Release);
+                    record_worker_panic_cause(
+                        &reader_panic_cause_flag,
+                        WorkerPanicCause::InternalThreadFailed,
+                    );
                     let msg = if let Some(s) = panic_payload.downcast_ref::<&'static str>() {
                         (*s).to_string()
                     } else if let Some(s) = panic_payload.downcast_ref::<String>() {
@@ -4078,26 +4134,36 @@ impl ParallelInterceptor {
                     let relay = Arc::clone(relay_ctx);
                     let inbound_stop = Arc::clone(&self.stop_flag);
                     let throughput = self.throughput_stats.clone();
-                    let panicked_flag = Arc::clone(&self.workers_panicked);
+                    let panic_cause_flag = Arc::clone(&self.workers_panic_cause);
 
                     self.inbound_receiver_handle = Some(thread::spawn(move || {
-                        // Wrap in catch_unwind so a panic surfaces via workers_panicked
-                        // instead of silently halting the injection path — otherwise the
-                        // tunnel appears "connected" with zero throughput.
+                        // Wrap in catch_unwind so a panic surfaces via
+                        // workers_panic_cause instead of silently halting the
+                        // injection path — otherwise the tunnel appears
+                        // "connected" with zero throughput. Both a fatal error
+                        // return and a panic are the InternalThreadFailed class:
+                        // the NDIS adapter handle is still valid, the injection
+                        // thread itself died.
                         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                             run_v3_inbound_receiver(relay, config, inbound_stop, throughput)
                         }));
                         match result {
                             Ok(Ok(())) => {}
                             Ok(Err(e)) => {
-                                panicked_flag.store(true, Ordering::Release);
+                                record_worker_panic_cause(
+                                    &panic_cause_flag,
+                                    WorkerPanicCause::InternalThreadFailed,
+                                );
                                 log::error!(
                                     "V3 inbound receiver exited fatally — injection halted: {}",
                                     e
                                 );
                             }
                             Err(panic_payload) => {
-                                panicked_flag.store(true, Ordering::Release);
+                                record_worker_panic_cause(
+                                    &panic_cause_flag,
+                                    WorkerPanicCause::InternalThreadFailed,
+                                );
                                 let msg =
                                     if let Some(s) = panic_payload.downcast_ref::<&'static str>() {
                                         (*s).to_string()
@@ -4140,7 +4206,15 @@ impl ParallelInterceptor {
         // Wait for threads with timeout to prevent hanging on stuck threads
         if let Some(handle) = self.reader_handle.take() {
             if !join_with_timeout(handle, "Reader") {
-                self.workers_panicked.store(true, Ordering::Release);
+                // The reader thread is wedged inside ndisapi and had to be
+                // abandoned — its adapter handle is effectively lost. First
+                // write wins, so if the reader already reported its own cause
+                // (panic / budget exhaustion) before getting stuck, that
+                // more-specific cause is preserved.
+                record_worker_panic_cause(
+                    &self.workers_panic_cause,
+                    WorkerPanicCause::ReaderHandleLost,
+                );
                 super::split_tunnel::SplitTunnelDriver::cleanup_stale_state();
             }
         }
@@ -4358,7 +4432,12 @@ impl ParallelInterceptor {
         }
 
         if let Err(e) = self.start() {
-            self.workers_panicked.store(true, Ordering::Release);
+            // Restart after a route change failed to re-acquire the adapter —
+            // driver-handle-loss class.
+            record_worker_panic_cause(
+                &self.workers_panic_cause,
+                WorkerPanicCause::ReaderHandleLost,
+            );
             return Err(e);
         }
         if let (Some(old_name), Some(new_name)) = (
@@ -4406,14 +4485,20 @@ impl ParallelInterceptor {
     /// this so a worker failure surfaces as a user-visible error instead of a
     /// silent stall.
     pub fn workers_panicked(&self) -> bool {
-        self.workers_panicked.load(Ordering::Acquire)
+        self.workers_panic_cause.load(Ordering::Acquire) != 0
     }
 
-    /// Returns a clone of the internal `workers_panicked` flag so async tasks
+    /// Returns the specific cause of the worker failure, if one has occurred.
+    pub fn workers_panic_cause(&self) -> Option<WorkerPanicCause> {
+        WorkerPanicCause::from_u8(self.workers_panic_cause.load(Ordering::Acquire))
+    }
+
+    /// Returns a clone of the internal `workers_panic_cause` flag so async tasks
     /// (e.g. the connection monitor in `connection.rs`) can observe it without
-    /// holding a reference to this interceptor.
-    pub fn workers_panicked_arc(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.workers_panicked)
+    /// holding a reference to this interceptor. Decode with
+    /// [`WorkerPanicCause::from_u8`].
+    pub fn workers_panic_cause_arc(&self) -> Arc<AtomicU8> {
+        Arc::clone(&self.workers_panic_cause)
     }
 
     /// Get snapshot for external use

--- a/swifttunnel-core/src/vpn/split_tunnel.rs
+++ b/swifttunnel-core/src/vpn/split_tunnel.rs
@@ -25,7 +25,7 @@ use crate::utils::normalize_guid_ascii_lowercase;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::time::{Duration, Instant};
 
 const DRIVER_READY_POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -299,13 +299,14 @@ impl SplitTunnelDriver {
         }
     }
 
-    /// Returns a handle to the interceptor's `workers_panicked` flag so
+    /// Returns a handle to the interceptor's `workers_panic_cause` flag so
     /// long-lived async monitors can observe reader/inbound-receiver failures
-    /// without holding a reference to the driver.
-    pub fn workers_panicked_arc(&self) -> Option<Arc<AtomicBool>> {
+    /// (and their specific cause) without holding a reference to the driver.
+    /// Decode the loaded `u8` with `WorkerPanicCause::from_u8`.
+    pub fn workers_panic_cause_arc(&self) -> Option<Arc<AtomicU8>> {
         self.parallel_interceptor
             .as_ref()
-            .map(|i| i.workers_panicked_arc())
+            .map(|i| i.workers_panic_cause_arc())
     }
 
     pub fn set_queue_overflow_mode(&mut self, mode: QueueOverflowMode) {

--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -421,7 +421,7 @@ export function BoostTab() {
         )}
         <SettingRow
           title="Ultraboost"
-          desc="All allowlisted performance FFlags (+20-40% FPS)"
+          desc="Curated FPS-focused Roblox FFlags"
           enabled={draft.roblox_settings.ultraboost}
           onChange={(v) => updateRblxOpt({ ultraboost: v })}
         />


### PR DESCRIPTION
## Summary

Fixes three failure-mode gaps in the split-tunnel / relay stack where a **fatal condition left the UI showing a green "Connected" check over a dead tunnel**. Came out of a quality audit of the networking code.

### W1 — sender-thread panic is now fatal immediately
`classify_relay_health` treated `sender_panicked` as a `Continue` (a cosmetic `"panicked"` relay status). A panicked relay sender thread silently drops **all** outbound game traffic, but the connection stayed nominally "Connected" for **up to ~60s** until the keepalive path escalated `relay_health` to `Dead`. It now returns `Fatal` with a `relay_sender_panicked` cleanup reason — consistent with how `workers_panicked` already tears the session down.

### W2 — hardcoded `:51821` relay-port fallback
The "no relay candidate resolved" branch in `setup_split_tunnel` hardcoded port `51821` in three places. Per the relay-protocol docs, clients must use the per-relay `relay_port` from `/api/vpn/servers`. Reaching this branch means the server list was empty/malformed — now a named `FALLBACK_RELAY_PORT` constant with a `log::warn!` so it's observable instead of a silent magic number.

### W3 — `workers_panicked` split into distinct causes
One `AtomicBool` collapsed three unrelated failures (reader adapter-handle loss / rebind-budget exhaustion vs. an internal thread panic) into a single "reinstall driver" error string. Replaced with an `AtomicU8` `WorkerPanicCause`:
- `ReaderHandleLost` → keeps the driver-missing wording that `isDriverMissing()` in `connectState.ts` substring-matches (renders the reinstall-driver CTA)
- `InternalThreadFailed` → plain reconnect message — a code panic in the reader/inbound thread is **not** fixed by reinstalling the driver

The monitor maps the cause through the new pure, unit-tested `worker_panic_error` helper. First-write-wins (`compare_exchange`) so a later generic teardown can't clobber the specific cause.

## Tests
- `test_sender_panicked_is_fatal_even_when_relay_health_looks_ok` — across Healthy/NoTrafficYet/Stale
- `test_healthy_relay_without_sender_panic_stays_connected` — negative test, guards against over-triggering
- `test_worker_panic_error_reader_handle_lost_matches_driver_missing_ui_contract`
- `test_worker_panic_error_internal_thread_failed_avoids_driver_missing_ui_contract`
- `test_worker_panic_cause_u8_round_trips`

## Notes
- Touches Windows-only paths; **not yet verified on the testbench VM** — relying on CI for the Windows build.
- Per request, this PR also **bundles pre-existing in-progress work** that was already in the working tree (testbench/CI workflow tweaks, `process_cache` DNS port-53 bypass). Those are unrelated to the failure-mode fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)