### PR TITLE
Fix networking recovery and relay selection safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Built-in performance optimizations:
 - Banned accounts are blocked in-app and trigger best-effort cleanup of saved VPN, Roblox, network, and system boosts.
 
 ### 🌍 Auto Region Detection
-Starts on the lowest-latency region from the in-app ping test, then resolves detected Roblox game-server IPs through SwiftTunnel's IPinfo-backed web resolver. Manual server pins stay respected and still complete the relay-ticket handshake, drained relays are excluded through `/api/vpn/servers`, stale lookups cannot switch after a newer game-server IP, and live ping-test refreshes keep Auto Route's server choices current while connected.
+Starts on the lowest-latency region from the in-app ping test, then resolves detected Roblox game-server IPs through SwiftTunnel's IPinfo-backed web resolver. Manual server pins stay respected and still complete the relay-ticket handshake, drained relays are excluded through `/api/vpn/servers`, stale lookups cannot switch after a newer game-server IP, and live ping-test refreshes keep Auto Route's server choices current while connected. The desktop client only switches on a non-low-confidence structured resolver region id and does not fall back to a hardcoded local Roblox-region table when the resolver fails, returns low confidence, or returns only raw location text.
 
 ---
 
@@ -108,7 +108,11 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 
 SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic and the temporary CDN IPs resolved for those bootstrap hostnames, through the selected relay. Route Assist TCP routing is handshake-gated so SwiftTunnel can clamp relay-owned flows before large HTTPS packets are exchanged; non-Roblox browser traffic and already-established TCP connections still bypass SwiftTunnel.
 
-Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
+Roblox detection and restart/boost helpers cover the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible and is never force-killed for boost restart because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
+
+Custom relay endpoints are tester-only. The desktop command checks the refreshed in-memory profile before honoring `custom_relay_server`, and tester custom relays still perform the relay-ticket policy request so bans and revocation are enforced before the user-supplied endpoint is used.
+
+Loopback, link-local, multicast, broadcast, and unspecified destinations are never sent through the relay even if a tunnel-eligible process owns the socket. Auto Route also records a degraded event when a forced server pin is unavailable and the client falls back to another relay in the target region.
 
 
 ## Building

--- a/swifttunnel-core/src/firewall_fixer.rs
+++ b/swifttunnel-core/src/firewall_fixer.rs
@@ -3,11 +3,10 @@ use crate::structs::*;
 use log::{info, warn};
 use std::path::PathBuf;
 
-const ROBLOX_EXECUTABLES: [&str; 4] = [
+const ROBLOX_EXECUTABLES: [&str; 3] = [
     "RobloxPlayerBeta.exe",
     "RobloxStudioBeta.exe",
     "RobloxCrashHandler.exe",
-    "Windows10Universal.exe",
 ];
 
 const FIREWALL_RULE_PREFIX: &str = "SwiftTunnel - Roblox";
@@ -307,6 +306,11 @@ fn find_roblox_executables() -> Vec<(String, PathBuf)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn roblox_firewall_executables_exclude_generic_uwp_host() {
+        assert!(!ROBLOX_EXECUTABLES.contains(&"Windows10Universal.exe"));
+    }
 
     #[test]
     fn firewall_fixer_default_not_applied() {

--- a/swifttunnel-core/src/geolocation.rs
+++ b/swifttunnel-core/src/geolocation.rs
@@ -522,6 +522,17 @@ fn resolve_api_response(
         .or_else(|| api_region.as_ref().map(|r| r.display_name().to_string()))
         .unwrap_or_else(|| "Unknown".to_string());
     let confidence = response.confidence.as_deref().unwrap_or("unknown");
+    if confidence.eq_ignore_ascii_case("low") {
+        log::warn!(
+            "Geo lookup: SwiftTunnel resolver returned low confidence for {}; keeping current relay [location={}, provider={:?}, roblox_region={:?}, swifttunnel_region={:?}]",
+            ip,
+            location,
+            response.provider,
+            response.roblox_region_id,
+            response.swifttunnel_region_id
+        );
+        return None;
+    }
 
     if let Some(region) = api_region {
         log::info!(
@@ -552,7 +563,8 @@ fn resolve_api_response(
 ///
 /// Uses the SwiftTunnel web resolver. The resolver is IPinfo-primary and owns
 /// the provider token/cache/overrides. Auto-routing only receives a region when
-/// the resolver returns a recognized structured region id.
+/// the resolver returns a recognized structured region id with non-low
+/// confidence; it does not invent a local fallback from raw city/state text.
 pub async fn lookup_game_server_region(ip: Ipv4Addr) -> Option<(RobloxRegion, String)> {
     resolve_api_response(ip, resolve_game_server_region_from_api(ip).await)
 }
@@ -804,29 +816,26 @@ mod tests {
     }
 
     #[test]
-    fn test_low_confidence_resolver_uses_structured_region_without_local_override() {
+    fn test_low_confidence_resolver_returns_none_without_local_override() {
         let response = GameServerRegionResponse {
             provider: Some("ipinfo".to_string()),
             location: Some(GameServerRegionLocation {
-                city: None,
-                region: None,
+                city: Some("Dallas".to_string()),
+                region: Some("Texas".to_string()),
                 country: Some("US".to_string()),
                 loc: None,
             }),
-            roblox_region_id: Some("us-east".to_string()),
-            swifttunnel_region_id: Some("us-east".to_string()),
+            roblox_region_id: Some("us-west".to_string()),
+            swifttunnel_region_id: Some("us-west".to_string()),
             confidence: Some("low".to_string()),
         };
 
         let resolved = resolve_api_response(Ipv4Addr::new(128, 116, 55, 10), Some(response));
-        assert_eq!(
-            resolved,
-            Some((RobloxRegion::UsEast, "US East".to_string()))
-        );
+        assert_eq!(resolved, None);
     }
 
     #[test]
-    fn test_resolver_failure_returns_none_without_local_fallback() {
+    fn test_resolver_failure_returns_none_without_hardcoded_fallback() {
         let resolved = resolve_api_response(Ipv4Addr::new(128, 116, 95, 10), None);
         assert_eq!(resolved, None);
     }

--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -7,11 +7,10 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 const LEGACY_ROBLOX_PRIORITY_POLICY: &str = "RobloxPriority";
-const ROBLOX_QOS_EXECUTABLES: [&str; 4] = [
+const ROBLOX_QOS_EXECUTABLES: [&str; 3] = [
     "RobloxPlayerBeta.exe",
     "RobloxStudioBeta.exe",
     "RobloxCrashHandler.exe",
-    "Windows10Universal.exe",
 ];
 const RELAY_QOS_EXECUTABLES: [&str; 2] = ["SwiftTunnel.exe", "swifttunnel-desktop.exe"];
 const NETWORK_SYSTEM_PROFILE_KEY: &str =

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -636,7 +636,7 @@ impl RobloxOptimizer {
 
     /// Check whether a Roblox client process is currently running.
     pub fn is_roblox_running(&self) -> bool {
-        let process_names = ["RobloxPlayerBeta.exe", "Windows10Universal.exe"];
+        let process_names = roblox_process_restart_names();
 
         process_names.iter().any(|process_name| {
             hidden_command("tasklist")
@@ -652,7 +652,7 @@ impl RobloxOptimizer {
 
     /// Force-close running Roblox client processes.
     pub fn close_running_instances(&self) -> Result<()> {
-        let process_names = ["RobloxPlayerBeta.exe", "Windows10Universal.exe"];
+        let process_names = roblox_process_restart_names();
 
         for process_name in process_names {
             let output = hidden_command("taskkill")
@@ -1331,6 +1331,25 @@ impl RobloxOptimizer {
     }
 }
 
+fn roblox_process_restart_names() -> &'static [&'static str] {
+    &["RobloxPlayerBeta.exe"]
+}
+
+#[cfg(test)]
+mod restart_process_tests {
+    use super::*;
+
+    #[test]
+    fn restart_kill_list_excludes_generic_uwp_host() {
+        assert!(!roblox_process_restart_names().contains(&"Windows10Universal.exe"));
+    }
+
+    #[test]
+    fn restart_kill_list_still_targets_win32_player() {
+        assert!(roblox_process_restart_names().contains(&"RobloxPlayerBeta.exe"));
+    }
+}
+
 impl Default for RobloxOptimizer {
     fn default() -> Self {
         Self::new()
@@ -1776,10 +1795,8 @@ mod tests {
         opt.apply_client_fflags_for_local_app_data(&config, &dir)
             .unwrap();
 
-        let content =
-            fs::read_to_string(client_settings.join("ClientAppSettings.json")).unwrap();
-        let settings: HashMap<String, serde_json::Value> =
-            serde_json::from_str(&content).unwrap();
+        let content = fs::read_to_string(client_settings.join("ClientAppSettings.json")).unwrap();
+        let settings: HashMap<String, serde_json::Value> = serde_json::from_str(&content).unwrap();
         assert!(
             !settings.contains_key(RobloxOptimizer::FPS_UNLOCK_FFLAG),
             "retired FPS scheduler flag must be stripped on apply"

--- a/swifttunnel-core/src/vpn/auto_routing.rs
+++ b/swifttunnel-core/src/vpn/auto_routing.rs
@@ -503,6 +503,11 @@ impl AutoRouter {
             .cloned()
             .expect("candidates checked as non-empty");
 
+        if current_st_region == resolved_region && current_relay_addr == Some(resolved_addr) {
+            *self.current_game_region.write() = Some(game_region.clone());
+            return None;
+        }
+
         if let Some(pinned) = pinned_server.filter(|_| forced_fallback_degraded) {
             let mut log = self.event_log.write();
             log.push_back(AutoRoutingEvent {
@@ -519,14 +524,6 @@ impl AutoRouter {
             if log.len() > MAX_EVENT_LOG_ENTRIES {
                 log.pop_front();
             }
-        }
-
-        if candidates.len() == 1
-            && current_st_region == resolved_region
-            && current_relay_addr == Some(resolved_addr)
-        {
-            *self.current_game_region.write() = Some(game_region.clone());
-            return None;
         }
 
         Some((resolved_region, resolved_addr))
@@ -857,7 +854,7 @@ mod tests {
 
         let router = AutoRouter::new(true, "singapore");
         router.set_available_servers(make_servers());
-        router.set_current_relay("54.255.205.216:51821".parse().unwrap(), "singapore");
+        router.set_current_relay("3.111.230.152:51821".parse().unwrap(), "mumbai");
         router.set_forced_servers(HashMap::from([(
             "singapore".to_string(),
             "singapore-99".to_string(),
@@ -876,6 +873,26 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].kind, AutoRoutingEventKind::ForcedFallbackDegraded);
         assert!(events[0].reason.contains("singapore-99 unavailable"));
+    }
+
+    #[test]
+    fn test_forced_server_unavailable_noops_without_degraded_spam() {
+        use std::collections::HashMap;
+
+        let router = AutoRouter::new(true, "singapore");
+        router.set_available_servers(make_servers());
+        router.set_current_relay("54.255.205.216:51821".parse().unwrap(), "singapore");
+        router.set_forced_servers(HashMap::from([(
+            "singapore".to_string(),
+            "singapore-99".to_string(),
+        )]));
+
+        assert!(
+            router
+                .get_best_server_for_region(&RobloxRegion::Singapore)
+                .is_none()
+        );
+        assert!(router.recent_events(1).is_empty());
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/auto_routing.rs
+++ b/swifttunnel-core/src/vpn/auto_routing.rs
@@ -503,7 +503,10 @@ impl AutoRouter {
             .cloned()
             .expect("candidates checked as non-empty");
 
-        if current_st_region == resolved_region && current_relay_addr == Some(resolved_addr) {
+        if forced_fallback_degraded
+            && current_st_region == resolved_region
+            && current_relay_addr == Some(resolved_addr)
+        {
             *self.current_game_region.write() = Some(game_region.clone());
             return None;
         }
@@ -524,6 +527,14 @@ impl AutoRouter {
             if log.len() > MAX_EVENT_LOG_ENTRIES {
                 log.pop_front();
             }
+        }
+
+        if candidates.len() == 1
+            && current_st_region == resolved_region
+            && current_relay_addr == Some(resolved_addr)
+        {
+            *self.current_game_region.write() = Some(game_region.clone());
+            return None;
         }
 
         Some((resolved_region, resolved_addr))

--- a/swifttunnel-core/src/vpn/auto_routing.rs
+++ b/swifttunnel-core/src/vpn/auto_routing.rs
@@ -83,11 +83,19 @@ pub struct AutoRouter {
 /// An auto-routing event for the UI log
 #[derive(Debug, Clone)]
 pub struct AutoRoutingEvent {
+    pub kind: AutoRoutingEventKind,
     pub timestamp: Instant,
     pub from_region: String,
     pub to_region: String,
     pub game_server_region: String,
     pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoRoutingEventKind {
+    RelaySwitch,
+    Bypass,
+    ForcedFallbackDegraded,
 }
 
 /// Result of evaluating a game server IP for auto-routing
@@ -444,6 +452,7 @@ impl AutoRouter {
             // Log the bypass event
             let mut log = self.event_log.write();
             log.push_back(AutoRoutingEvent {
+                kind: AutoRoutingEventKind::Bypass,
                 timestamp: Instant::now(),
                 from_region: self.current_st_region.read().clone(),
                 to_region: "BYPASS".to_string(),
@@ -472,6 +481,11 @@ impl AutoRouter {
         let servers = self.available_servers.read();
         let current_st_region = self.current_st_region.read().clone();
         let current_relay_addr = *self.current_relay_addr.read();
+        let forced_fallback_degraded = pinned_server.is_some_and(|pinned| {
+            !servers
+                .iter()
+                .any(|(server_region, _, _)| server_region == pinned)
+        });
         let candidates =
             super::connection::relay_candidates_for_region(best_st_region, &servers, pinned_server);
         if candidates.is_empty() {
@@ -488,6 +502,24 @@ impl AutoRouter {
             .min_by_key(|(_, _, latency_ms)| latency_ms.unwrap_or(u32::MAX))
             .cloned()
             .expect("candidates checked as non-empty");
+
+        if let Some(pinned) = pinned_server.filter(|_| forced_fallback_degraded) {
+            let mut log = self.event_log.write();
+            log.push_back(AutoRoutingEvent {
+                kind: AutoRoutingEventKind::ForcedFallbackDegraded,
+                timestamp: Instant::now(),
+                from_region: current_st_region.clone(),
+                to_region: resolved_region.clone(),
+                game_server_region: game_region.display_name().to_string(),
+                reason: format!(
+                    "Pinned server {} unavailable - using {} instead",
+                    pinned, resolved_region
+                ),
+            });
+            if log.len() > MAX_EVENT_LOG_ENTRIES {
+                log.pop_front();
+            }
+        }
 
         if candidates.len() == 1
             && current_st_region == resolved_region
@@ -600,6 +632,7 @@ impl AutoRouter {
         };
 
         let event = AutoRoutingEvent {
+            kind: AutoRoutingEventKind::RelaySwitch,
             timestamp: now,
             from_region: from_region.to_string(),
             to_region: to_region.to_string(),
@@ -816,6 +849,33 @@ mod tests {
                 "203.0.113.2:51821".parse::<SocketAddr>().unwrap()
             ))
         );
+    }
+
+    #[test]
+    fn test_forced_server_unavailable_records_degraded_fallback() {
+        use std::collections::HashMap;
+
+        let router = AutoRouter::new(true, "singapore");
+        router.set_available_servers(make_servers());
+        router.set_current_relay("54.255.205.216:51821".parse().unwrap(), "singapore");
+        router.set_forced_servers(HashMap::from([(
+            "singapore".to_string(),
+            "singapore-99".to_string(),
+        )]));
+
+        let best = router.get_best_server_for_region(&RobloxRegion::Singapore);
+        assert_eq!(
+            best,
+            Some((
+                "singapore".to_string(),
+                "54.255.205.216:51821".parse::<SocketAddr>().unwrap()
+            ))
+        );
+
+        let events = router.recent_events(1);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, AutoRoutingEventKind::ForcedFallbackDegraded);
+        assert!(events[0].reason.contains("singapore-99 unavailable"));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -1269,7 +1269,7 @@ impl VpnConnection {
             let _ = driver.close();
             return Err(VpnError::ConfigFetch(format!(
                 "Selected region '{}' has no available relay candidate",
-                region
+                config.region
             )));
         };
 

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -70,13 +70,6 @@ const CONNECT_FAIL_AUTH_REQUIRED: &str = "ST_CONNECT_AUTH_REQUIRED";
 const CONNECT_FAIL_POLICY_UNAVAILABLE: &str = "ST_CONNECT_POLICY_UNAVAILABLE";
 const CONNECT_FAIL_REGION_UNAVAILABLE: &str = "ST_CONNECT_REGION_UNAVAILABLE";
 
-/// Relay UDP port used *only* as a last-resort fallback when the resolved
-/// server list carried no relay candidate (and no custom relay is configured)
-/// to derive a port from. Normal connects use the per-relay `relay_port`
-/// advertised by `/api/vpn/servers`; reaching this constant means the server
-/// list was empty or malformed, which `setup_split_tunnel` logs as a warning.
-const FALLBACK_RELAY_PORT: u16 = 51821;
-
 static HANDSHAKE_TIMEOUT_EVENTS: AtomicU64 = AtomicU64::new(0);
 static CANDIDATE_EXHAUSTED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static PREFLIGHT_ENFORCED_EVENTS: AtomicU64 = AtomicU64::new(0);
@@ -843,6 +836,8 @@ pub struct VpnConnection {
     auto_router: Option<Arc<super::auto_routing::AutoRouter>>,
     /// Background task that performs async auto-routing IP lookups.
     auto_lookup_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Background task that monitors process cache, relay health, and recovery.
+    process_monitor_handle: Option<tokio::task::JoinHandle<()>>,
     /// Per-process game performance tuning manager (Windows-only behavior).
     process_performance_manager: Option<Arc<Mutex<GameProcessPerformanceManager>>>,
     /// Tracks whether this connection wrote the temporary Roblox bootstrap hosts repair.
@@ -860,6 +855,7 @@ impl VpnConnection {
             etw_watcher: None,
             auto_router: None,
             auto_lookup_handle: None,
+            process_monitor_handle: None,
             process_performance_manager: None,
             bootstrap_dns_repair_applied: false,
         }
@@ -1270,35 +1266,11 @@ impl VpnConnection {
             selected_relay_region = server_region.clone();
             *addr
         } else {
-            // No custom relay AND no relay candidate from the server list.
-            // This should not happen on a healthy connect — `/api/vpn/servers`
-            // carries a `relay_port` per relay — so we fall back to the
-            // resolved server endpoint with `FALLBACK_RELAY_PORT` and log it
-            // loudly rather than silently guessing a port.
-            log::warn!(
-                "V3: no relay candidate resolved; falling back to {} with hardcoded port {}",
-                config.endpoint,
-                FALLBACK_RELAY_PORT
-            );
-            if let Ok(addr) = config.endpoint.parse::<SocketAddr>() {
-                SocketAddr::new(addr.ip(), FALLBACK_RELAY_PORT)
-            } else if let Ok(ip) = config.endpoint.parse::<std::net::IpAddr>() {
-                SocketAddr::new(ip, FALLBACK_RELAY_PORT)
-            } else {
-                let vpn_ip = config
-                    .endpoint
-                    .split(':')
-                    .next()
-                    .unwrap_or(&config.endpoint);
-                format!("{}:{}", vpn_ip, FALLBACK_RELAY_PORT)
-                    .parse()
-                    .map_err(|e| {
-                        VpnError::SplitTunnelSetupFailed(format!(
-                            "Invalid VPN server IP for relay: {}",
-                            e
-                        ))
-                    })?
-            }
+            let _ = driver.close();
+            return Err(VpnError::ConfigFetch(format!(
+                "Selected region '{}' has no available relay candidate",
+                region
+            )));
         };
 
         log::info!("V3: Creating UDP relay to {}", relay_addr);
@@ -1326,14 +1298,41 @@ impl VpnConnection {
         };
 
         let mut relay_auth_mode = if custom_relay_server.is_some() {
-            "custom_legacy".to_string()
+            "custom_policy_pending".to_string()
         } else {
             "legacy_fallback".to_string()
         };
         let mut queue_full_mode = RelayQueueFullMode::Bypass;
 
         if custom_relay_server.is_some() {
-            log::warn!("V3: Custom relay enabled, skipping authenticated relay ticket bootstrap");
+            let auth_client = AuthClient::new();
+            let session_id_hex = relay.session_id_hex();
+            match auth_client
+                .get_relay_ticket(access_token, &config.region, &session_id_hex)
+                .await
+            {
+                Ok(ticket) => {
+                    queue_full_mode = ticket.queue_full_mode();
+                    relay_auth_mode = "custom_policy_checked".to_string();
+                    log::warn!(
+                        "V3: Custom relay enabled after relay-ticket policy check; relay auth handshake is skipped because the endpoint is user supplied"
+                    );
+                }
+                Err(e) => {
+                    if let Some(reason) = relay_ticket_ban_reason(&e) {
+                        log::warn!(
+                            "V3: Custom relay policy check rejected because the current account is banned"
+                        );
+                        let _ = driver.close();
+                        return Err(VpnError::UserBanned(reason));
+                    }
+                    let _ = driver.close();
+                    return Err(VpnError::Connection(format!(
+                        "Custom relay policy check failed: {}",
+                        e
+                    )));
+                }
+            }
         } else {
             let auth_client = AuthClient::new();
             let session_id_hex = relay.session_id_hex();
@@ -1971,15 +1970,15 @@ impl VpnConnection {
         }
 
         // Start process monitor (event-driven ETW + periodic refresh)
-        self.process_monitor_stop.store(false, Ordering::SeqCst);
-        let stop_flag = Arc::clone(&self.process_monitor_stop);
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        self.process_monitor_stop = Arc::clone(&stop_flag);
         let state_handle = Arc::clone(&self.state);
         let auto_router_for_monitor = self.auto_router.clone();
         let process_performance_for_monitor = self.process_performance_manager.clone();
         let relay_health_monitor = relay_for_health;
         let workers_panic_cause_monitor = workers_panic_cause_for_monitor;
 
-        tokio::spawn(async move {
+        let process_monitor_handle = tokio::spawn(async move {
             log::info!("V3: Process monitor started");
             // Match previous behavior: first periodic refresh occurs after the interval.
             let first_tick =
@@ -2426,6 +2425,7 @@ impl VpnConnection {
 
             log::info!("V3: Process monitor stopped");
         });
+        self.process_monitor_handle = Some(process_monitor_handle);
 
         log::info!("V3 split tunnel configured - game traffic relayed via UDP");
         Ok((running, relay_auth_mode, selected_relay_region, relay_addr))
@@ -2473,6 +2473,14 @@ impl VpnConnection {
         if let Some(handle) = self.auto_lookup_handle.take() {
             handle.abort();
             let _ = handle.await;
+        }
+
+        if let Some(handle) = self.process_monitor_handle.take() {
+            match tokio::time::timeout(Duration::from_millis(750), handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => log::warn!("Process monitor task join failed: {}", e),
+                Err(_) => log::warn!("Process monitor did not stop within 750ms"),
+            }
         }
 
         if let Some(manager) = self.process_performance_manager.take() {

--- a/swifttunnel-core/src/vpn/ipv6_recovery.rs
+++ b/swifttunnel-core/src/vpn/ipv6_recovery.rs
@@ -85,10 +85,7 @@ impl Ipv6Marker {
             exit 1
         }}
 
-        if ($deleteExit -ne 0 -and $showText -notmatch 'No rules match') {{
-            Write-Error ('Could not verify IPv6 block firewall rule removal. Delete exit=' + $deleteExit + '. Delete output: ' + $deleteText + '. Show output: ' + $showText)
-            exit 1
-        }}
+        Write-Output ('IPv6 block firewall rule absent after restore. Delete exit=' + $deleteExit + '. Delete output: ' + $deleteText + '. Show output: ' + $showText)
         "#,
                 IPV6_BLOCK_RULE_NAME
             ),
@@ -378,13 +375,15 @@ fn restore_firewall_rule_marker(adapter_name: &str) -> bool {
         return false;
     }
 
-    let show_text = format!(
-        "{}{}",
-        String::from_utf8_lossy(&show_output.stdout),
-        String::from_utf8_lossy(&show_output.stderr)
-    );
-
-    if !delete_output.status.success() && !show_text.contains("No rules match") {
+    if !firewall_rule_absent_after_restore(
+        delete_output.status.success(),
+        show_output.status.success(),
+    ) {
+        let show_text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&show_output.stdout),
+            String::from_utf8_lossy(&show_output.stderr)
+        );
         log::warn!(
             "Could not verify IPv6 block firewall rule removal for adapter {}: {}",
             adapter_name,
@@ -398,6 +397,10 @@ fn restore_firewall_rule_marker(adapter_name: &str) -> bool {
         adapter_name
     );
     true
+}
+
+fn firewall_rule_absent_after_restore(_delete_success: bool, show_success: bool) -> bool {
+    !show_success
 }
 
 fn restore_ipv6_for_marker(marker: &Ipv6Marker) -> bool {
@@ -498,6 +501,15 @@ mod tests {
         assert!(cmd.contains("netsh.exe advfirewall firewall delete rule"));
         assert!(cmd.contains("netsh.exe advfirewall firewall show rule"));
         assert!(cmd.contains("exit 1"));
+        assert!(!cmd.contains("No rules match"));
+    }
+
+    #[test]
+    fn firewall_rule_restore_uses_show_status_not_localized_text() {
+        assert!(firewall_rule_absent_after_restore(false, false));
+        assert!(firewall_rule_absent_after_restore(true, false));
+        assert!(!firewall_rule_absent_after_restore(true, true));
+        assert!(!firewall_rule_absent_after_restore(false, true));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/ipv6_recovery.rs
+++ b/swifttunnel-core/src/vpn/ipv6_recovery.rs
@@ -356,18 +356,32 @@ fn restore_firewall_rule_marker(adapter_name: &str) -> bool {
         }
     };
 
-    let show_output = crate::hidden_command("netsh")
-        .args(["advfirewall", "firewall", "show", "rule", name_arg.as_str()])
+    let probe_script = build_firewall_rule_probe_script(IPV6_BLOCK_RULE_NAME);
+    let probe_output = crate::hidden_command("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &probe_script])
         .output();
-    let show_output = match show_output {
-        Ok(output) => output,
+    let (probe_result, probe_text) = match probe_output {
+        Ok(output) => {
+            let probe_text = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            (
+                firewall_rule_probe_from_exit_code(output.status.code()),
+                probe_text,
+            )
+        }
         Err(e) => {
-            log::error!("Failed to verify IPv6 firewall restore with netsh: {}", e);
-            return false;
+            log::warn!(
+                "Failed to verify IPv6 firewall restore with PowerShell: {}",
+                e
+            );
+            (FirewallRuleProbe::ProbeFailed, e.to_string())
         }
     };
 
-    if show_output.status.success() {
+    if probe_result == FirewallRuleProbe::Present {
         log::warn!(
             "IPv6 block firewall rule still exists after delete attempt for adapter {}",
             adapter_name
@@ -375,19 +389,19 @@ fn restore_firewall_rule_marker(adapter_name: &str) -> bool {
         return false;
     }
 
-    if !firewall_rule_absent_after_restore(
-        delete_output.status.success(),
-        show_output.status.success(),
-    ) {
-        let show_text = format!(
+    if !firewall_rule_restored(delete_output.status.success(), probe_result) {
+        let delete_text = format!(
             "{}{}",
-            String::from_utf8_lossy(&show_output.stdout),
-            String::from_utf8_lossy(&show_output.stderr)
+            String::from_utf8_lossy(&delete_output.stdout),
+            String::from_utf8_lossy(&delete_output.stderr)
         );
         log::warn!(
-            "Could not verify IPv6 block firewall rule removal for adapter {}: {}",
+            "Could not verify IPv6 block firewall rule removal for adapter {}: delete_ok={} probe={:?} delete='{}' probe='{}'",
             adapter_name,
-            show_text.trim()
+            delete_output.status.success(),
+            probe_result,
+            delete_text.trim(),
+            probe_text.trim()
         );
         return false;
     }
@@ -399,8 +413,41 @@ fn restore_firewall_rule_marker(adapter_name: &str) -> bool {
     true
 }
 
-fn firewall_rule_absent_after_restore(_delete_success: bool, show_success: bool) -> bool {
-    !show_success
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FirewallRuleProbe {
+    Present,
+    Absent,
+    ProbeFailed,
+}
+
+fn build_firewall_rule_probe_script(rule_name: &str) -> String {
+    format!(
+        r#"
+        $rule = Get-NetFirewallRule -DisplayName '{}' -ErrorAction SilentlyContinue
+        if ($null -eq $rule) {{
+            exit 2
+        }}
+        exit 0
+        "#,
+        rule_name.replace('\'', "''")
+    )
+}
+
+fn firewall_rule_probe_from_exit_code(code: Option<i32>) -> FirewallRuleProbe {
+    match code {
+        Some(0) => FirewallRuleProbe::Present,
+        Some(2) => FirewallRuleProbe::Absent,
+        _ => FirewallRuleProbe::ProbeFailed,
+    }
+}
+
+fn firewall_rule_restored(delete_success: bool, probe: FirewallRuleProbe) -> bool {
+    match (delete_success, probe) {
+        (_, FirewallRuleProbe::Present) => false,
+        (true, _) => true,
+        (false, FirewallRuleProbe::Absent) => true,
+        (false, FirewallRuleProbe::ProbeFailed) => false,
+    }
 }
 
 fn restore_ipv6_for_marker(marker: &Ipv6Marker) -> bool {
@@ -505,11 +552,24 @@ mod tests {
     }
 
     #[test]
-    fn firewall_rule_restore_uses_show_status_not_localized_text() {
-        assert!(firewall_rule_absent_after_restore(false, false));
-        assert!(firewall_rule_absent_after_restore(true, false));
-        assert!(!firewall_rule_absent_after_restore(true, true));
-        assert!(!firewall_rule_absent_after_restore(false, true));
+    fn firewall_rule_restore_uses_structured_probe_outcome() {
+        assert!(firewall_rule_restored(true, FirewallRuleProbe::Absent));
+        assert!(firewall_rule_restored(true, FirewallRuleProbe::ProbeFailed));
+        assert!(firewall_rule_restored(false, FirewallRuleProbe::Absent));
+        assert!(!firewall_rule_restored(true, FirewallRuleProbe::Present));
+        assert!(!firewall_rule_restored(false, FirewallRuleProbe::Present));
+        assert!(!firewall_rule_restored(
+            false,
+            FirewallRuleProbe::ProbeFailed
+        ));
+        assert_eq!(
+            firewall_rule_probe_from_exit_code(Some(2)),
+            FirewallRuleProbe::Absent
+        );
+        assert_eq!(
+            firewall_rule_probe_from_exit_code(Some(1)),
+            FirewallRuleProbe::ProbeFailed
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -10216,10 +10216,7 @@ mod tests {
             std::net::IpAddr::V4(ip) => ip,
             std::net::IpAddr::V6(_) => panic!("test expects IPv4 localhost"),
         };
-        let dst_ip = match server_addr.ip() {
-            std::net::IpAddr::V4(ip) => ip,
-            std::net::IpAddr::V6(_) => panic!("test expects IPv4 localhost"),
-        };
+        let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
         let src_port = src_addr.port();
         let dst_port = server_addr.port();
 

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -4202,6 +4202,11 @@ impl ParallelInterceptor {
 
         log::info!("Stopping parallel interceptor...");
         self.stop_flag.store(true, Ordering::Release);
+        let (lock, cvar) = &*self.refresh_condvar;
+        if let Ok(mut signaled) = lock.lock() {
+            *signaled = true;
+            cvar.notify_all();
+        }
 
         // Wait for threads with timeout to prevent hanging on stuck threads
         if let Some(handle) = self.reader_handle.take() {
@@ -4630,6 +4635,17 @@ fn inject_inbound_packet(
         );
         return None;
     }
+    let version = ip_packet[0] >> 4;
+    let ihl = ((ip_packet[0] & 0x0F) as usize) * 4;
+    if version != 4 || ihl < 20 || ip_packet.len() < ihl {
+        log::warn!(
+            "inject_inbound_packet: invalid IPv4 header (version={}, ihl={}, len={})",
+            version,
+            ihl,
+            ip_packet.len()
+        );
+        return None;
+    }
 
     // Log first 10 packets for debugging
     if packet_count < 10 {
@@ -4762,16 +4778,16 @@ fn forward_tunneled_packet_from_reader(
         return ReaderTunnelAction::BypassPhysical;
     }
 
-    let forward_result = if ip_packet.len() >= 20 {
+    let forward_result = if ip_packet.len() > MAX_PACKET_SIZE {
+        log_super_segment_truncation_sampled(ip_packet.len());
+        Ok(super::udp_relay::RelaySendOutcome::Oversize)
+    } else if ip_packet.len() >= 20 {
         PACKET_BUFFER.with(|buf| {
             let mut fix_buf = buf.borrow_mut();
-            if ip_packet.len() > MAX_PACKET_SIZE {
-                log_super_segment_truncation_sampled(ip_packet.len());
-            }
-            let pkt_len = ip_packet.len().min(MAX_PACKET_SIZE);
+            let pkt_len = ip_packet.len();
             fix_buf[..pkt_len].copy_from_slice(&ip_packet[..pkt_len]);
             clamp_tcp_mss_for_relay(&mut fix_buf[..pkt_len], relay.max_inner_packet_len());
-            fix_packet_checksums(&mut fix_buf[..pkt_len]);
+            let _ = fix_packet_checksums(&mut fix_buf[..pkt_len]);
             relay.forward_outbound_fast(&fix_buf[..pkt_len])
         })
     } else {
@@ -5603,19 +5619,19 @@ fn run_packet_worker(
                         );
                     }
 
-                    let forward_result = if ip_packet.len() >= 20 {
+                    let forward_result = if ip_packet.len() > MAX_PACKET_SIZE {
+                        log_super_segment_truncation_sampled(ip_packet.len());
+                        Ok(super::udp_relay::RelaySendOutcome::Oversize)
+                    } else if ip_packet.len() >= 20 {
                         PACKET_BUFFER.with(|buf| {
                             let mut fix_buf = buf.borrow_mut();
-                            if ip_packet.len() > MAX_PACKET_SIZE {
-                                log_super_segment_truncation_sampled(ip_packet.len());
-                            }
-                            let pkt_len = ip_packet.len().min(MAX_PACKET_SIZE);
+                            let pkt_len = ip_packet.len();
                             fix_buf[..pkt_len].copy_from_slice(&ip_packet[..pkt_len]);
                             clamp_tcp_mss_for_relay(
                                 &mut fix_buf[..pkt_len],
                                 relay.max_inner_packet_len(),
                             );
-                            fix_packet_checksums(&mut fix_buf[..pkt_len]);
+                            let _ = fix_packet_checksums(&mut fix_buf[..pkt_len]);
                             relay.forward_outbound(&fix_buf[..pkt_len])
                         })
                     } else {
@@ -6853,6 +6869,10 @@ where
         data[ip_start + 19],
     );
 
+    if super::process_cache::is_non_tunnelable_dst(dst_ip) {
+        return false;
+    }
+
     let fragment_bits = u16::from_be_bytes([data[ip_start + 6], data[ip_start + 7]]);
     let more_fragments = (fragment_bits & 0x2000) != 0;
     let fragment_offset = fragment_bits & 0x1FFF;
@@ -7681,6 +7701,7 @@ fn clamp_tcp_mss_for_relay(packet: &mut [u8], max_inner_packet_len: usize) -> bo
 
 /// Fix checksums in an IP packet (modifies packet in place)
 /// Returns true if checksums were fixed
+#[must_use]
 fn fix_packet_checksums(packet: &mut [u8]) -> bool {
     if packet.len() < 20 {
         return false;

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -172,6 +172,17 @@ pub fn is_likely_game_traffic(dst_port: u16, protocol: Protocol, api_tunneling: 
     }
 }
 
+/// Destinations that must never be sent through the relay, even when the
+/// owning process is tunnel-eligible.
+#[inline(always)]
+pub fn is_non_tunnelable_dst(dst_ip: Ipv4Addr) -> bool {
+    dst_ip.is_unspecified()
+        || dst_ip.is_loopback()
+        || dst_ip.is_link_local()
+        || dst_ip.is_multicast()
+        || dst_ip.is_broadcast()
+}
+
 /// Check if destination is any known game server (extensible for future games)
 #[inline(always)]
 pub fn is_game_server(
@@ -1338,6 +1349,20 @@ mod tests {
         // should still tunnel.
         assert!(is_likely_game_traffic(3478, Protocol::Udp, false));
         assert!(is_likely_game_traffic(443, Protocol::Tcp, true));
+    }
+
+    #[test]
+    fn test_non_tunnelable_destinations_are_filtered() {
+        for ip in [
+            Ipv4Addr::new(0, 0, 0, 0),
+            Ipv4Addr::new(127, 0, 0, 1),
+            Ipv4Addr::new(169, 254, 1, 1),
+            Ipv4Addr::new(224, 0, 0, 251),
+            Ipv4Addr::new(255, 255, 255, 255),
+        ] {
+            assert!(is_non_tunnelable_dst(ip), "{ip} should bypass");
+        }
+        assert!(!is_non_tunnelable_dst(Ipv4Addr::new(128, 116, 50, 10)));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/udp_relay.rs
+++ b/swifttunnel-core/src/vpn/udp_relay.rs
@@ -1781,6 +1781,8 @@ impl UdpRelay {
             .store(RelayHealthState::NoTrafficYet as u8, Ordering::Relaxed);
         self.unanswered_keepalives.store(0, Ordering::Relaxed);
         self.inject_error_streak.store(0, Ordering::Relaxed);
+        self.send_unreachable_streak.store(0, Ordering::Relaxed);
+        self.send_failure_streak.store(0, Ordering::Relaxed);
         *self.last_receive_time.lock() = None;
         *self.first_outbound_time.lock() = None;
         log::info!(
@@ -2576,6 +2578,19 @@ mod tests {
         relay.switch_relay("127.0.0.1:51822".parse().unwrap());
 
         assert_eq!(relay.inject_error_streak(), 0);
+        assert_eq!(relay.relay_health(), RelayHealthState::NoTrafficYet);
+    }
+
+    #[test]
+    fn test_send_failure_streaks_reset_on_relay_switch() {
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        relay.send_unreachable_streak.store(2, Ordering::Relaxed);
+        relay.send_failure_streak.store(4, Ordering::Relaxed);
+
+        relay.switch_relay("127.0.0.1:51822".parse().unwrap());
+
+        assert_eq!(relay.send_unreachable_streak(), 0);
+        assert_eq!(relay.send_failure_streak(), 0);
         assert_eq!(relay.relay_health(), RelayHealthState::NoTrafficYet);
     }
 

--- a/swifttunnel-core/src/vpn/wfp_block.rs
+++ b/swifttunnel-core/src/vpn/wfp_block.rs
@@ -503,10 +503,17 @@ pub fn unblock_process_by_path(image_path: &str) -> Result<(), String> {
     if let Some(filter_id) = state.active_filters.get(&key).copied() {
         unsafe {
             let result = FwpmFilterDeleteById0(state.engine_handle, filter_id);
-            if result == 0 || result == FWP_E_FILTER_NOT_FOUND_CODE {
+            if result == 0 {
                 state.active_filters.remove(&key);
                 log::info!(
                     "WFP block filter removed for {} (filter_id={})",
+                    image_path,
+                    filter_id
+                );
+            } else if result == FWP_E_FILTER_NOT_FOUND_CODE {
+                state.active_filters.remove(&key);
+                log::info!(
+                    "WFP block filter already absent for {} (filter_id={}); removed local tracking entry",
                     image_path,
                     filter_id
                 );

--- a/swifttunnel-core/src/vpn/wfp_block.rs
+++ b/swifttunnel-core/src/vpn/wfp_block.rs
@@ -500,20 +500,21 @@ pub fn unblock_process_by_path(image_path: &str) -> Result<(), String> {
 
     let key = image_path.to_lowercase();
 
-    if let Some(filter_id) = state.active_filters.remove(&key) {
+    if let Some(filter_id) = state.active_filters.get(&key).copied() {
         unsafe {
             let result = FwpmFilterDeleteById0(state.engine_handle, filter_id);
-            if result != 0 {
-                log::warn!(
-                    "Failed to remove block filter for '{}': 0x{:08x}",
-                    image_path,
-                    result
-                );
-            } else {
+            if result == 0 || result == FWP_E_FILTER_NOT_FOUND_CODE {
+                state.active_filters.remove(&key);
                 log::info!(
                     "WFP block filter removed for {} (filter_id={})",
                     image_path,
                     filter_id
+                );
+            } else {
+                log::warn!(
+                    "Failed to remove block filter for '{}': 0x{:08x}",
+                    image_path,
+                    result
                 );
             }
         }

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -222,6 +222,17 @@ fn vpn_error_is_user_banned(error: &VpnError) -> bool {
     matches!(error, VpnError::UserBanned(_))
 }
 
+fn validate_custom_relay_access(custom_relay: Option<&str>, is_tester: bool) -> Result<(), String> {
+    if custom_relay.is_some() && !is_tester {
+        return Err(
+            "Custom relay servers are only available to tester accounts. Clear the custom relay setting and connect again."
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
 async fn emit_ban_cleanup(app: &AppHandle, state: &AppState) {
     let emitted = crate::commands::auth::apply_ban_cleanup(app, state).await;
     if !emitted {
@@ -441,16 +452,21 @@ pub async fn vpn_connect(
     }
 
     // Get access token
-    let access_token = {
+    let (access_token, is_tester) = {
         let auth = state.auth_manager.lock().await;
         match auth.get_access_token().await {
-            Ok(token) => token,
+            Ok(token) => {
+                let is_tester = auth.get_user().map(|user| user.is_tester).unwrap_or(false);
+                (token, is_tester)
+            }
             Err(e) => {
                 drop(auth);
                 return Err(handle_connect_auth_error(&app, &state, e).await);
             }
         }
     };
+
+    validate_custom_relay_access(custom_relay.as_deref(), is_tester)?;
 
     let mut vpn = state.vpn_connection.lock().await;
     let connect_result = tokio::time::timeout(
@@ -1012,6 +1028,13 @@ mod tests {
         assert!(!vpn_error_is_user_banned(&VpnError::Connection(
             "Account banned appears in unrelated text".to_string()
         )));
+    }
+
+    #[test]
+    fn custom_relay_requires_tester_profile() {
+        assert!(validate_custom_relay_access(Some("relay.example.com:51821"), false).is_err());
+        assert!(validate_custom_relay_access(Some("relay.example.com:51821"), true).is_ok());
+        assert!(validate_custom_relay_access(None, false).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove hardcoded relay fallback behavior and require structured, non-low-confidence resolver regions for Auto Route
- make custom relays tester-only with relay-ticket policy checks, add degraded forced-server events, and reset relay send failure streaks on switch
- prevent non-tunnelable local/multicast traffic from being relayed, avoid killing the generic UWP host during Roblox boost restart, and harden recovery cleanup paths

## Tests
- npm test -- --run
- npx tsc --noEmit
- npm run build
- cargo fmt --check
- cargo test -p swifttunnel-core test_forced_server_unavailable_records_degraded_fallback --lib (blocked on macOS by known windows-future/windows-core mismatch before tests compile)
