### PR TITLE
Fix WinpkFilter ARM64 probe startup compatibility

### DIFF
--- a/swifttunnel-core/src/vpn/winpkfilter.rs
+++ b/swifttunnel-core/src/vpn/winpkfilter.rs
@@ -125,7 +125,7 @@ pub fn validate_msi_file(path: &Path, pkg: &WinpkFilterMsiPackage) -> Result<(),
 pub fn detect_native_arch() -> WinpkFilterMsiArch {
     use windows::Win32::System::SystemInformation::IMAGE_FILE_MACHINE_ARM64;
     use windows::Win32::System::Threading::{
-        GetCurrentProcess, GetMachineTypeAttributes, IsWow64Process2, KernelEnabled, UserEnabled,
+        GetCurrentProcess, IsWow64Process2, KernelEnabled, UserEnabled,
     };
 
     let mut process_machine: windows::Win32::System::SystemInformation::IMAGE_FILE_MACHINE =
@@ -153,17 +153,102 @@ pub fn detect_native_arch() -> WinpkFilterMsiArch {
 
     // Fallback for older/blocked IsWow64Process2 paths. On Windows-on-ARM64,
     // GetMachineTypeAttributes reports whether ARM64 code is supported by the
-    // current host, without relying on localized environment variables.
-    unsafe {
-        if let Ok(attrs) = GetMachineTypeAttributes(IMAGE_FILE_MACHINE_ARM64.0) {
-            if (attrs & (UserEnabled | KernelEnabled)).0 != 0 {
-                return WinpkFilterMsiArch::Arm64;
+    // current host, without relying on localized environment variables. Resolve
+    // it dynamically because older Windows builds do not export this symbol; a
+    // static import prevents the process from reaching main with 0xC0000139.
+    if let Some(api) = machine_type_attributes_api() {
+        unsafe {
+            let mut attrs = Default::default();
+            if (api.get_machine_type_attributes)(IMAGE_FILE_MACHINE_ARM64.0, &mut attrs).is_ok() {
+                if (attrs & (UserEnabled | KernelEnabled)).0 != 0 {
+                    return WinpkFilterMsiArch::Arm64;
+                }
             }
         }
     }
 
     // Fallback: PROCESSOR_ARCHITECTURE env var.
     if let Ok(arch) = std::env::var("PROCESSOR_ARCHITECTURE") {
+        if arch.eq_ignore_ascii_case("ARM64") {
+            return WinpkFilterMsiArch::Arm64;
+        }
+    }
+
+    WinpkFilterMsiArch::X64
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy)]
+struct MachineTypeAttributesApi {
+    get_machine_type_attributes: unsafe extern "system" fn(
+        u16,
+        *mut windows::Win32::System::Threading::MACHINE_ATTRIBUTES,
+    ) -> windows::core::HRESULT,
+}
+
+#[cfg(windows)]
+fn machine_type_attributes_api() -> Option<MachineTypeAttributesApi> {
+    static API: std::sync::OnceLock<Option<MachineTypeAttributesApi>> = std::sync::OnceLock::new();
+    *API.get_or_init(load_machine_type_attributes_api)
+}
+
+#[cfg(windows)]
+fn load_machine_type_attributes_api() -> Option<MachineTypeAttributesApi> {
+    let address = kernel32_proc_address(b"GetMachineTypeAttributes\0")?;
+    let api = unsafe {
+        MachineTypeAttributesApi {
+            get_machine_type_attributes: std::mem::transmute(address),
+        }
+    };
+    Some(api)
+}
+
+#[cfg(windows)]
+unsafe extern "system" {
+    fn GetModuleHandleW(lpmodulename: *const u16) -> isize;
+    fn GetProcAddress(hmodule: isize, lpprocname: *const u8) -> *const std::ffi::c_void;
+}
+
+#[cfg(windows)]
+fn kernel32_proc_address(symbol: &'static [u8]) -> Option<*const std::ffi::c_void> {
+    let module_name: Vec<u16> = "kernel32.dll"
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let module = unsafe { GetModuleHandleW(module_name.as_ptr()) };
+    if module == 0 {
+        return None;
+    }
+
+    let address = unsafe { GetProcAddress(module, symbol.as_ptr()) };
+    if address.is_null() {
+        None
+    } else {
+        Some(address)
+    }
+}
+
+#[cfg(test)]
+fn detect_native_arch_from_signals(
+    is_wow64_native_machine: Option<u16>,
+    machine_attrs: Option<u32>,
+    processor_architecture: Option<&str>,
+) -> WinpkFilterMsiArch {
+    if let Some(native_machine) = is_wow64_native_machine {
+        if native_machine == 0xAA64 {
+            return WinpkFilterMsiArch::Arm64;
+        }
+        return WinpkFilterMsiArch::X64;
+    }
+
+    if let Some(attrs) = machine_attrs {
+        if attrs != 0 {
+            return WinpkFilterMsiArch::Arm64;
+        }
+    }
+
+    if let Some(arch) = processor_architecture {
         if arch.eq_ignore_ascii_case("ARM64") {
             return WinpkFilterMsiArch::Arm64;
         }
@@ -1000,6 +1085,38 @@ Provider Name:      NDISAPI
             arch == WinpkFilterMsiArch::X64 || arch == WinpkFilterMsiArch::Arm64,
             "unexpected arch: {:?}",
             arch
+        );
+    }
+
+    #[test]
+    fn detect_native_arch_signal_priority_uses_structured_results() {
+        assert_eq!(
+            detect_native_arch_from_signals(Some(0xAA64), None, None),
+            WinpkFilterMsiArch::Arm64
+        );
+        assert_eq!(
+            detect_native_arch_from_signals(Some(0x8664), Some(1), Some("ARM64")),
+            WinpkFilterMsiArch::X64
+        );
+        assert_eq!(
+            detect_native_arch_from_signals(None, Some(1), Some("AMD64")),
+            WinpkFilterMsiArch::Arm64
+        );
+    }
+
+    #[test]
+    fn detect_native_arch_signal_fallback_treats_missing_optional_api_as_x64() {
+        assert_eq!(
+            detect_native_arch_from_signals(None, None, Some("ARM64")),
+            WinpkFilterMsiArch::Arm64
+        );
+        assert_eq!(
+            detect_native_arch_from_signals(None, None, Some("AMD64")),
+            WinpkFilterMsiArch::X64
+        );
+        assert_eq!(
+            detect_native_arch_from_signals(None, None, None),
+            WinpkFilterMsiArch::X64
         );
     }
 

--- a/swifttunnel-core/src/vpn/winpkfilter.rs
+++ b/swifttunnel-core/src/vpn/winpkfilter.rs
@@ -205,6 +205,8 @@ fn load_machine_type_attributes_api() -> Option<MachineTypeAttributesApi> {
 
 #[cfg(windows)]
 unsafe extern "system" {
+    // Keep these raw imports narrow so GetMachineTypeAttributes stays optional
+    // at load time on older Windows builds that do not export it.
     fn GetModuleHandleW(lpmodulename: *const u16) -> isize;
     fn GetProcAddress(hmodule: isize, lpprocname: *const u8) -> *const std::ffi::c_void;
 }
@@ -218,11 +220,15 @@ fn kernel32_proc_address(symbol: &'static [u8]) -> Option<*const std::ffi::c_voi
 
     let module = unsafe { GetModuleHandleW(module_name.as_ptr()) };
     if module == 0 {
+        log::debug!("kernel32.dll was not loaded while resolving optional Win32 API");
         return None;
     }
 
     let address = unsafe { GetProcAddress(module, symbol.as_ptr()) };
     if address.is_null() {
+        let symbol_name = std::str::from_utf8(symbol.strip_suffix(&[0]).unwrap_or(symbol))
+            .unwrap_or("<non-utf8>");
+        log::debug!("optional Win32 API {symbol_name} is unavailable; falling back");
         None
     } else {
         Some(address)
@@ -243,7 +249,9 @@ fn detect_native_arch_from_signals(
     }
 
     if let Some(attrs) = machine_attrs {
-        if attrs != 0 {
+        const USER_ENABLED: u32 = 1;
+        const KERNEL_ENABLED: u32 = 2;
+        if (attrs & (USER_ENABLED | KERNEL_ENABLED)) != 0 {
             return WinpkFilterMsiArch::Arm64;
         }
     }
@@ -1101,6 +1109,10 @@ Provider Name:      NDISAPI
         assert_eq!(
             detect_native_arch_from_signals(None, Some(1), Some("AMD64")),
             WinpkFilterMsiArch::Arm64
+        );
+        assert_eq!(
+            detect_native_arch_from_signals(None, Some(4), Some("AMD64")),
+            WinpkFilterMsiArch::X64
         );
     }
 


### PR DESCRIPTION
## Summary
- load `GetMachineTypeAttributes` dynamically instead of statically importing it from `kernel32.dll`
- keep `IsWow64Process2` as the primary structured architecture signal
- add focused tests for architecture signal priority and missing optional API fallback

## Failure-mode plan
- Primary success: Windows binaries that link the VPN module must load and reach `main()` on the Windows testbench OS.
- Secondary success: ARM64 driver selection can still use `GetMachineTypeAttributes` when that API exists, but missing exports must not cause process startup failure.
- Repairable/diagnostic: a missing optional `GetMachineTypeAttributes` export is diagnostic-only and falls through to the next probe.
- Fatal: inability to load the process itself was the regression; this change removes the load-time dependency.
- Structured signals: `IsWow64Process2` and dynamically resolved `GetMachineTypeAttributes` remain structured signals. `PROCESSOR_ARCHITECTURE` is only the final fallback.
- Partial success: if optional probes fail, x64 remains the conservative default unless the environment explicitly says ARM64.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `npm test -- --run`
- `npx tsc --noEmit`
- `npm run build`
- Windows testbench: `cargo build -p swifttunnel-core --release --bin split_tunnel_integration_test --bin ip_checker`
- Windows testbench: `split_tunnel_integration_test.exe --help` exits `0` and prints usage instead of failing before `main()`
- Windows testbench: full split-tunnel integration harness passed with UDP, TCP, and HTTPS probes

## Notes
- `cargo test -p swifttunnel-core detect_native_arch_signal --lib` is blocked locally on macOS by the known `windows-future` / `windows-core` mismatch before crate tests run. Windows testbench is the authoritative gate for this Windows-specific path.
