### PR TITLE
[codex] Verify PC boost application state

### DIFF
--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -334,6 +334,24 @@ impl SystemOptimizer {
         }
     }
 
+    fn power_plan_from_guid(guid: &str) -> Option<PowerPlan> {
+        if guid.eq_ignore_ascii_case(BALANCED_POWER_PLAN_GUID) {
+            Some(PowerPlan::Balanced)
+        } else if guid.eq_ignore_ascii_case(HIGH_PERFORMANCE_POWER_PLAN_GUID) {
+            Some(PowerPlan::HighPerformance)
+        } else if guid.eq_ignore_ascii_case(ULTIMATE_POWER_PLAN_GUID) {
+            Some(PowerPlan::Ultimate)
+        } else if guid.eq_ignore_ascii_case(SWIFTTUNNEL_POWER_PLAN_GUID) {
+            Some(PowerPlan::SwiftTunnel)
+        } else {
+            None
+        }
+    }
+
+    fn active_power_plan() -> Option<PowerPlan> {
+        Self::active_power_plan_guid().and_then(|guid| Self::power_plan_from_guid(&guid))
+    }
+
     fn active_power_plan_guid() -> Option<String> {
         let output = hidden_command("powercfg")
             .args(["/GETACTIVESCHEME"])
@@ -636,6 +654,7 @@ impl SystemOptimizer {
     }
 
     /// Apply all system optimizations
+    #[deprecated(note = "Use apply_optimizations_checked so verified applied_config is preserved")]
     pub fn apply_optimizations(
         &mut self,
         config: &SystemOptimizationConfig,
@@ -726,8 +745,20 @@ impl SystemOptimizer {
         }
 
         if let Err(e) = self.set_power_plan(&config.power_plan) {
-            applied_config.power_plan = PowerPlan::Balanced;
-            warnings.push(format!("Power plan did not verify: {}", e));
+            if let Some(active_power_plan) = Self::active_power_plan() {
+                applied_config.power_plan = active_power_plan;
+                warnings.push(format!(
+                    "Power plan did not verify: {}; active plan read back as {:?}",
+                    e, active_power_plan
+                ));
+            } else {
+                applied_config.power_plan =
+                    config.previous_power_plan.unwrap_or(PowerPlan::Balanced);
+                warnings.push(format!(
+                    "Power plan did not verify and the active plan could not be mapped to a SwiftTunnel option: {}",
+                    e
+                ));
+            }
         }
 
         // Tier 1 (Safe) Boosts
@@ -1268,6 +1299,38 @@ mod tests {
         assert_eq!(
             SystemOptimizer::power_plan_guid(&PowerPlan::SwiftTunnel),
             SWIFTTUNNEL_POWER_PLAN_GUID
+        );
+    }
+
+    #[test]
+    fn power_plan_from_guid_maps_known_plan_guids() {
+        assert_eq!(
+            SystemOptimizer::power_plan_from_guid(BALANCED_POWER_PLAN_GUID),
+            Some(PowerPlan::Balanced)
+        );
+        assert_eq!(
+            SystemOptimizer::power_plan_from_guid(HIGH_PERFORMANCE_POWER_PLAN_GUID),
+            Some(PowerPlan::HighPerformance)
+        );
+        assert_eq!(
+            SystemOptimizer::power_plan_from_guid(ULTIMATE_POWER_PLAN_GUID),
+            Some(PowerPlan::Ultimate)
+        );
+        assert_eq!(
+            SystemOptimizer::power_plan_from_guid(SWIFTTUNNEL_POWER_PLAN_GUID),
+            Some(PowerPlan::SwiftTunnel)
+        );
+    }
+
+    #[test]
+    fn power_plan_from_guid_rejects_unknown_or_similar_guid() {
+        assert_eq!(
+            SystemOptimizer::power_plan_from_guid("44444444-4444-4444-4444-444444444453"),
+            None
+        );
+        assert_eq!(
+            SystemOptimizer::power_plan_from_guid("not-a-real-guid"),
+            None
         );
     }
 

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -56,6 +56,20 @@ struct MmcssSnapshot {
     system_responsiveness: Option<u32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistryWrite<'a> {
+    Dword {
+        key_path: &'a str,
+        value_name: &'a str,
+        value: u32,
+    },
+    String {
+        key_path: &'a str,
+        value_name: &'a str,
+        value: &'a str,
+    },
+}
+
 pub struct SystemOptimizer {
     original_priority: Option<u32>,
     timer_resolution_active: bool,
@@ -282,6 +296,40 @@ impl SystemOptimizer {
         if let Err(e) = Self::try_set_registry_string(key_path, value_name, value) {
             warn!("{}", e);
         }
+    }
+
+    fn apply_registry_write(write: RegistryWrite<'_>) -> Result<()> {
+        match write {
+            RegistryWrite::Dword {
+                key_path,
+                value_name,
+                value,
+            } => Self::try_set_registry_dword(key_path, value_name, value),
+            RegistryWrite::String {
+                key_path,
+                value_name,
+                value,
+            } => Self::try_set_registry_string(key_path, value_name, value),
+        }
+    }
+
+    fn apply_registry_writes_with_rollback<'a, F, R>(
+        writes: &[RegistryWrite<'a>],
+        mut apply: F,
+        rollback: R,
+    ) -> Result<()>
+    where
+        F: FnMut(RegistryWrite<'a>) -> Result<()>,
+        R: FnOnce(),
+    {
+        for write in writes.iter().copied() {
+            if let Err(e) = apply(write) {
+                rollback();
+                return Err(e);
+            }
+        }
+
+        Ok(())
     }
 
     fn restore_registry_dword(key_path: &str, value_name: &str, snapshot: Option<u32>) {
@@ -586,6 +634,23 @@ impl SystemOptimizer {
         matches!(installed, Some(false))
     }
 
+    fn capture_mmcss_snapshot() -> MmcssSnapshot {
+        MmcssSnapshot {
+            scheduling_category: Self::query_registry_string(
+                MMCSS_GAMES_KEY,
+                "Scheduling Category",
+            ),
+            sfio_priority: Self::query_registry_string(MMCSS_GAMES_KEY, "SFIO Priority"),
+            background_only: Self::query_registry_string(MMCSS_GAMES_KEY, "Background Only"),
+            priority: Self::query_registry_dword(MMCSS_GAMES_KEY, "Priority"),
+            clock_rate: Self::query_registry_dword(MMCSS_GAMES_KEY, "Clock Rate"),
+            system_responsiveness: Self::query_registry_dword(
+                MMCSS_SYSTEM_PROFILE_KEY,
+                "SystemResponsiveness",
+            ),
+        }
+    }
+
     fn capture_system_state_snapshots(&mut self, config: &SystemOptimizationConfig) {
         if config.disable_game_bar {
             Self::capture_dword_snapshot(&mut self.game_bar_snapshot, GAME_BAR_KEY, GAME_BAR_VALUE);
@@ -613,20 +678,7 @@ impl SystemOptimizer {
         }
 
         if config.mmcss_gaming_profile && self.mmcss_snapshot.is_none() {
-            self.mmcss_snapshot = Some(MmcssSnapshot {
-                scheduling_category: Self::query_registry_string(
-                    MMCSS_GAMES_KEY,
-                    "Scheduling Category",
-                ),
-                sfio_priority: Self::query_registry_string(MMCSS_GAMES_KEY, "SFIO Priority"),
-                background_only: Self::query_registry_string(MMCSS_GAMES_KEY, "Background Only"),
-                priority: Self::query_registry_dword(MMCSS_GAMES_KEY, "Priority"),
-                clock_rate: Self::query_registry_dword(MMCSS_GAMES_KEY, "Clock Rate"),
-                system_responsiveness: Self::query_registry_dword(
-                    MMCSS_SYSTEM_PROFILE_KEY,
-                    "SystemResponsiveness",
-                ),
-            });
+            self.mmcss_snapshot = Some(Self::capture_mmcss_snapshot());
         }
 
         if !matches!(config.power_plan, PowerPlan::Balanced)
@@ -951,56 +1003,51 @@ impl SystemOptimizer {
 
     /// Apply MMCSS (Multimedia Class Scheduler Service) gaming profile
     /// This boosts priority for game processes via the Windows scheduler
-    pub fn apply_mmcss_profile(&self) -> Result<()> {
+    pub fn apply_mmcss_profile(&mut self) -> Result<()> {
         info!("Applying MMCSS gaming profile");
+        let rollback_snapshot = self
+            .mmcss_snapshot
+            .clone()
+            .unwrap_or_else(Self::capture_mmcss_snapshot);
 
-        // Set MMCSS gaming profile registry keys
-        let mmcss_keys = [
-            (
-                r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games",
-                "Scheduling Category",
-                "High",
-            ),
-            (
-                r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games",
-                "SFIO Priority",
-                "High",
-            ),
-            (
-                r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games",
-                "Background Only",
-                "False",
-            ),
+        let mmcss_writes = [
+            RegistryWrite::String {
+                key_path: MMCSS_GAMES_KEY,
+                value_name: "Scheduling Category",
+                value: "High",
+            },
+            RegistryWrite::String {
+                key_path: MMCSS_GAMES_KEY,
+                value_name: "SFIO Priority",
+                value: "High",
+            },
+            RegistryWrite::String {
+                key_path: MMCSS_GAMES_KEY,
+                value_name: "Background Only",
+                value: "False",
+            },
+            RegistryWrite::Dword {
+                key_path: MMCSS_GAMES_KEY,
+                value_name: "Priority",
+                value: 6,
+            },
+            RegistryWrite::Dword {
+                key_path: MMCSS_GAMES_KEY,
+                value_name: "Clock Rate",
+                value: 10000,
+            },
+            RegistryWrite::Dword {
+                key_path: MMCSS_SYSTEM_PROFILE_KEY,
+                value_name: "SystemResponsiveness",
+                value: 0,
+            },
         ];
 
-        for (key_path, value_name, value_data) in mmcss_keys.iter() {
-            Self::try_set_registry_string(key_path, value_name, value_data)?;
-        }
-
-        // Set DWORD values separately
-        let dword_keys = [
-            (
-                r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games",
-                "Priority",
-                "6",
-            ),
-            (
-                r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games",
-                "Clock Rate",
-                "10000",
-            ),
-            (
-                r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile",
-                "SystemResponsiveness",
-                "0",
-            ),
-        ];
-
-        for (key_path, value_name, value_data) in dword_keys.iter() {
-            if let Ok(value) = value_data.parse::<u32>() {
-                Self::try_set_registry_dword(key_path, value_name, value)?;
-            }
-        }
+        Self::apply_registry_writes_with_rollback(
+            &mmcss_writes,
+            Self::apply_registry_write,
+            || Self::restore_mmcss_snapshot(rollback_snapshot.clone()),
+        )?;
 
         info!("MMCSS gaming profile applied");
         Ok(())
@@ -1025,19 +1072,44 @@ impl SystemOptimizer {
     }
 
     /// Enable Windows Game Mode for resource prioritization
-    pub fn enable_game_mode(&self) -> Result<()> {
+    pub fn enable_game_mode(&mut self) -> Result<()> {
         info!("Enabling Windows Game Mode");
+        let rollback_allow_auto = self.game_mode_allow_auto_snapshot.unwrap_or_else(|| {
+            Self::query_registry_dword(GAME_MODE_KEY, GAME_MODE_ALLOW_AUTO_VALUE)
+        });
+        let rollback_enabled = self
+            .game_mode_enabled_snapshot
+            .unwrap_or_else(|| Self::query_registry_dword(GAME_MODE_KEY, GAME_MODE_ENABLED_VALUE));
 
-        let game_mode_keys = [
-            (GAME_MODE_KEY, GAME_MODE_ALLOW_AUTO_VALUE, "1"),
-            (GAME_MODE_KEY, GAME_MODE_ENABLED_VALUE, "1"),
+        let game_mode_writes = [
+            RegistryWrite::Dword {
+                key_path: GAME_MODE_KEY,
+                value_name: GAME_MODE_ALLOW_AUTO_VALUE,
+                value: 1,
+            },
+            RegistryWrite::Dword {
+                key_path: GAME_MODE_KEY,
+                value_name: GAME_MODE_ENABLED_VALUE,
+                value: 1,
+            },
         ];
 
-        for (key_path, value_name, value_data) in game_mode_keys.iter() {
-            if let Ok(value) = value_data.parse::<u32>() {
-                Self::try_set_registry_dword(key_path, value_name, value)?;
-            }
-        }
+        Self::apply_registry_writes_with_rollback(
+            &game_mode_writes,
+            Self::apply_registry_write,
+            || {
+                Self::restore_registry_dword(
+                    GAME_MODE_KEY,
+                    GAME_MODE_ENABLED_VALUE,
+                    rollback_enabled,
+                );
+                Self::restore_registry_dword(
+                    GAME_MODE_KEY,
+                    GAME_MODE_ALLOW_AUTO_VALUE,
+                    rollback_allow_auto,
+                );
+            },
+        )?;
 
         info!("Windows Game Mode enabled");
         Ok(())
@@ -1403,6 +1475,69 @@ mod tests {
                 .iter()
                 .any(|warning| warning.contains("no CPU cores were selected"))
         );
+    }
+
+    #[test]
+    fn registry_write_plan_rolls_back_after_a_partial_failure() {
+        let writes = [
+            RegistryWrite::Dword {
+                key_path: "HKCU\\Software\\SwiftTunnel",
+                value_name: "First",
+                value: 1,
+            },
+            RegistryWrite::Dword {
+                key_path: "HKCU\\Software\\SwiftTunnel",
+                value_name: "Second",
+                value: 1,
+            },
+            RegistryWrite::Dword {
+                key_path: "HKCU\\Software\\SwiftTunnel",
+                value_name: "Third",
+                value: 1,
+            },
+        ];
+        let mut attempted = Vec::new();
+        let mut rolled_back = false;
+
+        let result = SystemOptimizer::apply_registry_writes_with_rollback(
+            &writes,
+            |write| {
+                attempted.push(write);
+                if attempted.len() == 2 {
+                    Err(anyhow::anyhow!("second write failed"))
+                } else {
+                    Ok(())
+                }
+            },
+            || {
+                rolled_back = true;
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(attempted.as_slice(), &writes[..2]);
+        assert!(rolled_back);
+    }
+
+    #[test]
+    fn registry_write_plan_does_not_roll_back_when_all_writes_succeed() {
+        let writes = [RegistryWrite::String {
+            key_path: "HKCU\\Software\\SwiftTunnel",
+            value_name: "Mode",
+            value: "Enabled",
+        }];
+        let mut rolled_back = false;
+
+        let result = SystemOptimizer::apply_registry_writes_with_rollback(
+            &writes,
+            |_| Ok(()),
+            || {
+                rolled_back = true;
+            },
+        );
+
+        assert!(result.is_ok());
+        assert!(!rolled_back);
     }
 
     #[test]

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -706,7 +706,7 @@ impl SystemOptimizer {
     }
 
     /// Apply all system optimizations
-    #[deprecated(note = "Use apply_optimizations_checked so verified applied_config is preserved")]
+    #[deprecated(note = "Use apply_optimizations_checked so persisted config is reconciled")]
     pub fn apply_optimizations(
         &mut self,
         config: &SystemOptimizationConfig,
@@ -723,11 +723,12 @@ impl SystemOptimizer {
         Ok(())
     }
 
-    /// Apply system optimizations and return the verified applied state.
+    /// Apply system optimizations and return the config safe to persist.
     ///
-    /// Process-only boosts can only be marked applied after a target process is
-    /// openable. Registry, timer, and power-plan boosts must verify via the
-    /// corresponding Windows readback before the UI persists them as active.
+    /// Process-only boosts with no target process keep the requested setting so
+    /// the next apply while Roblox is running can honor the user's intent.
+    /// Registry, timer, and power-plan boosts must verify via the corresponding
+    /// Windows readback before the UI persists them as active.
     pub fn apply_optimizations_checked(
         &mut self,
         config: &SystemOptimizationConfig,
@@ -745,11 +746,8 @@ impl SystemOptimizer {
 
         if config.set_high_priority {
             if process_id == 0 {
-                applied_config.set_high_priority = false;
-                warnings.push(
-                    "High Priority Mode skipped because no active Roblox process was detected"
-                        .to_string(),
-                );
+                warnings
+                    .push("High Priority Mode is waiting for an active Roblox process".to_string());
             } else if let Err(e) = self.set_process_priority(process_id) {
                 applied_config.set_high_priority = false;
                 warnings.push(format!(
@@ -765,11 +763,7 @@ impl SystemOptimizer {
                 warnings
                     .push("CPU affinity skipped because no CPU cores were selected".to_string());
             } else if process_id == 0 {
-                applied_config.set_cpu_affinity = false;
-                warnings.push(
-                    "CPU affinity skipped because no active Roblox process was detected"
-                        .to_string(),
-                );
+                warnings.push("CPU affinity is waiting for an active Roblox process".to_string());
             } else if let Err(e) = self.set_cpu_affinity(process_id, &config.cpu_cores) {
                 applied_config.set_cpu_affinity = false;
                 warnings.push(format!(
@@ -1441,7 +1435,7 @@ mod tests {
     }
 
     #[test]
-    fn checked_apply_does_not_mark_process_priority_applied_without_pid() {
+    fn checked_apply_preserves_process_priority_request_without_pid() {
         let mut optimizer = SystemOptimizer::new();
         let config = SystemOptimizationConfig {
             set_high_priority: true,
@@ -1450,11 +1444,32 @@ mod tests {
 
         let outcome = optimizer.apply_optimizations_checked(&config, 0);
 
-        assert!(!outcome.applied_config.set_high_priority);
+        assert!(outcome.applied_config.set_high_priority);
         assert!(outcome.warnings.iter().any(|warning| {
-            warning.contains("High Priority Mode skipped")
-                && warning.contains("no active Roblox process")
+            warning.contains("High Priority Mode")
+                && warning.contains("waiting for an active Roblox process")
         }));
+    }
+
+    #[test]
+    fn checked_apply_preserves_cpu_affinity_request_without_pid() {
+        let mut optimizer = SystemOptimizer::new();
+        let config = SystemOptimizationConfig {
+            set_cpu_affinity: true,
+            cpu_cores: vec![0, 1],
+            ..Default::default()
+        };
+
+        let outcome = optimizer.apply_optimizations_checked(&config, 0);
+
+        assert!(outcome.applied_config.set_cpu_affinity);
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("CPU affinity")
+                    && warning.contains("waiting for an active Roblox process"))
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -322,16 +322,11 @@ impl SystemOptimizer {
         F: FnMut(RegistryWrite<'a>) -> Result<()>,
         R: FnOnce(),
     {
-        let mut applied_count = 0;
-
         for write in writes.iter().copied() {
             if let Err(e) = apply(write) {
-                if applied_count > 0 {
-                    rollback();
-                }
+                rollback();
                 return Err(e);
             }
-            applied_count += 1;
         }
 
         Ok(())
@@ -1525,7 +1520,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_write_plan_skips_rollback_when_first_write_fails() {
+    fn registry_write_plan_rolls_back_even_when_first_write_fails() {
         let writes = [RegistryWrite::Dword {
             key_path: "HKCU\\Software\\SwiftTunnel",
             value_name: "First",
@@ -1542,7 +1537,7 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(!rolled_back);
+        assert!(rolled_back);
     }
 
     #[test]

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -322,11 +322,16 @@ impl SystemOptimizer {
         F: FnMut(RegistryWrite<'a>) -> Result<()>,
         R: FnOnce(),
     {
+        let mut applied_count = 0;
+
         for write in writes.iter().copied() {
             if let Err(e) = apply(write) {
-                rollback();
+                if applied_count > 0 {
+                    rollback();
+                }
                 return Err(e);
             }
+            applied_count += 1;
         }
 
         Ok(())
@@ -1517,6 +1522,27 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(attempted.as_slice(), &writes[..2]);
         assert!(rolled_back);
+    }
+
+    #[test]
+    fn registry_write_plan_skips_rollback_when_first_write_fails() {
+        let writes = [RegistryWrite::Dword {
+            key_path: "HKCU\\Software\\SwiftTunnel",
+            value_name: "First",
+            value: 1,
+        }];
+        let mut rolled_back = false;
+
+        let result = SystemOptimizer::apply_registry_writes_with_rollback(
+            &writes,
+            |_| Err(anyhow::anyhow!("first write failed")),
+            || {
+                rolled_back = true;
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(!rolled_back);
     }
 
     #[test]

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -68,6 +68,11 @@ pub struct SystemOptimizer {
     swifttunnel_power_plan_imported: bool,
 }
 
+pub struct SystemApplyOutcome {
+    pub applied_config: SystemOptimizationConfig,
+    pub warnings: Vec<String>,
+}
+
 impl SystemOptimizer {
     pub fn new() -> Self {
         Self {
@@ -152,7 +157,21 @@ impl SystemOptimizer {
         None
     }
 
-    fn set_registry_dword(key_path: &str, value_name: &str, value: u32) {
+    fn command_failure_message(command_label: &str, stderr: &[u8], stdout: &[u8]) -> String {
+        let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+        if !stderr.is_empty() {
+            return format!("{} failed: {}", command_label, stderr);
+        }
+
+        let stdout = String::from_utf8_lossy(stdout).trim().to_string();
+        if !stdout.is_empty() {
+            return format!("{} failed: {}", command_label, stdout);
+        }
+
+        format!("{} failed without an error message", command_label)
+    }
+
+    fn try_set_registry_dword(key_path: &str, value_name: &str, value: u32) -> Result<()> {
         let value_str = value.to_string();
         let output = hidden_command("reg")
             .args([
@@ -170,15 +189,50 @@ impl SystemOptimizer {
 
         match output {
             Ok(result) if result.status.success() => {}
-            Ok(_) => warn!("Failed to set {}\\{} to {}", key_path, value_name, value),
-            Err(e) => warn!(
-                "Failed to set {}\\{} to {}: {}",
-                key_path, value_name, value, e
-            ),
+            Ok(result) => {
+                return Err(anyhow::anyhow!(
+                    "{}",
+                    Self::command_failure_message(
+                        &format!("reg add {}\\{}", key_path, value_name),
+                        &result.stderr,
+                        &result.stdout,
+                    )
+                ));
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to run reg add {}\\{}: {}",
+                    key_path,
+                    value_name,
+                    e
+                ));
+            }
+        }
+
+        match Self::query_registry_dword(key_path, value_name) {
+            Some(actual) if actual == value => Ok(()),
+            Some(actual) => Err(anyhow::anyhow!(
+                "{}\\{} verified as {}, expected {}",
+                key_path,
+                value_name,
+                actual,
+                value
+            )),
+            None => Err(anyhow::anyhow!(
+                "{}\\{} was not readable after write",
+                key_path,
+                value_name
+            )),
         }
     }
 
-    fn set_registry_string(key_path: &str, value_name: &str, value: &str) {
+    fn set_registry_dword(key_path: &str, value_name: &str, value: u32) {
+        if let Err(e) = Self::try_set_registry_dword(key_path, value_name, value) {
+            warn!("{}", e);
+        }
+    }
+
+    fn try_set_registry_string(key_path: &str, value_name: &str, value: &str) -> Result<()> {
         let output = hidden_command("reg")
             .args([
                 "add", key_path, "/v", value_name, "/t", "REG_SZ", "/d", value, "/f",
@@ -187,11 +241,46 @@ impl SystemOptimizer {
 
         match output {
             Ok(result) if result.status.success() => {}
-            Ok(_) => warn!("Failed to set {}\\{} to {}", key_path, value_name, value),
-            Err(e) => warn!(
-                "Failed to set {}\\{} to {}: {}",
-                key_path, value_name, value, e
-            ),
+            Ok(result) => {
+                return Err(anyhow::anyhow!(
+                    "{}",
+                    Self::command_failure_message(
+                        &format!("reg add {}\\{}", key_path, value_name),
+                        &result.stderr,
+                        &result.stdout,
+                    )
+                ));
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to run reg add {}\\{}: {}",
+                    key_path,
+                    value_name,
+                    e
+                ));
+            }
+        }
+
+        match Self::query_registry_string(key_path, value_name) {
+            Some(actual) if actual == value => Ok(()),
+            Some(actual) => Err(anyhow::anyhow!(
+                "{}\\{} verified as {:?}, expected {:?}",
+                key_path,
+                value_name,
+                actual,
+                value
+            )),
+            None => Err(anyhow::anyhow!(
+                "{}\\{} was not readable after write",
+                key_path,
+                value_name
+            )),
+        }
+    }
+
+    fn set_registry_string(key_path: &str, value_name: &str, value: &str) {
+        if let Err(e) = Self::try_set_registry_string(key_path, value_name, value) {
+            warn!("{}", e);
         }
     }
 
@@ -285,6 +374,46 @@ impl SystemOptimizer {
                 warn!("Failed to restore power plan {}: {}", guid, e);
                 false
             }
+        }
+    }
+
+    fn try_set_active_power_plan_guid(guid: &str) -> Result<()> {
+        let output = hidden_command("powercfg")
+            .args(["/setactive", guid])
+            .output();
+
+        match output {
+            Ok(result) if result.status.success() => {}
+            Ok(result) => {
+                return Err(anyhow::anyhow!(
+                    "{}",
+                    Self::command_failure_message(
+                        &format!("powercfg /setactive {}", guid),
+                        &result.stderr,
+                        &result.stdout,
+                    )
+                ));
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to run powercfg /setactive {}: {}",
+                    guid,
+                    e
+                ));
+            }
+        }
+
+        match Self::active_power_plan_guid() {
+            Some(active) if active.eq_ignore_ascii_case(guid) => Ok(()),
+            Some(active) => Err(anyhow::anyhow!(
+                "active power plan verified as {}, expected {}",
+                active,
+                guid
+            )),
+            None => Err(anyhow::anyhow!(
+                "active power plan could not be read after setting {}",
+                guid
+            )),
         }
     }
 
@@ -512,61 +641,121 @@ impl SystemOptimizer {
         config: &SystemOptimizationConfig,
         process_id: u32,
     ) -> Result<()> {
+        let outcome = self.apply_optimizations_checked(config, process_id);
+        if !outcome.warnings.is_empty() {
+            warn!(
+                "System optimizations applied with warnings: {}",
+                outcome.warnings.join("; ")
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Apply system optimizations and return the verified applied state.
+    ///
+    /// Process-only boosts can only be marked applied after a target process is
+    /// openable. Registry, timer, and power-plan boosts must verify via the
+    /// corresponding Windows readback before the UI persists them as active.
+    pub fn apply_optimizations_checked(
+        &mut self,
+        config: &SystemOptimizationConfig,
+        process_id: u32,
+    ) -> SystemApplyOutcome {
         info!(
             "Applying system optimizations for process ID: {}",
             process_id
         );
 
+        let mut applied_config = config.clone();
+        let mut warnings = Vec::new();
+
         self.capture_system_state_snapshots(config);
 
         if config.set_high_priority {
             if process_id == 0 {
-                info!("Skipping process priority boost: no active game process detected yet");
-            } else if let Err(e) = self.set_process_priority(process_id) {
-                // Process-specific boosts can legitimately fail during restart flows.
-                // Keep applying all other boosts; priority will be retried by runtime monitors.
-                warn!(
-                    "Could not set process priority for PID {} (will retry later): {}",
-                    process_id, e
+                applied_config.set_high_priority = false;
+                warnings.push(
+                    "High Priority Mode skipped because no active Roblox process was detected"
+                        .to_string(),
                 );
+            } else if let Err(e) = self.set_process_priority(process_id) {
+                applied_config.set_high_priority = false;
+                warnings.push(format!(
+                    "High Priority Mode could not be applied to PID {}: {}",
+                    process_id, e
+                ));
             }
         }
 
-        if config.set_cpu_affinity && !config.cpu_cores.is_empty() {
-            if process_id == 0 {
-                info!("Skipping CPU affinity boost: no active game process detected yet");
-            } else if let Err(e) = self.set_cpu_affinity(process_id, &config.cpu_cores) {
-                warn!(
-                    "Could not set CPU affinity for PID {} (will retry later): {}",
-                    process_id, e
+        if config.set_cpu_affinity {
+            if config.cpu_cores.is_empty() {
+                applied_config.set_cpu_affinity = false;
+                warnings
+                    .push("CPU affinity skipped because no CPU cores were selected".to_string());
+            } else if process_id == 0 {
+                applied_config.set_cpu_affinity = false;
+                warnings.push(
+                    "CPU affinity skipped because no active Roblox process was detected"
+                        .to_string(),
                 );
+            } else if let Err(e) = self.set_cpu_affinity(process_id, &config.cpu_cores) {
+                applied_config.set_cpu_affinity = false;
+                warnings.push(format!(
+                    "CPU affinity could not be applied to PID {}: {}",
+                    process_id, e
+                ));
             }
         }
 
         if config.disable_game_bar {
-            self.disable_game_bar()?;
+            if let Err(e) = self.disable_game_bar() {
+                applied_config.disable_game_bar = false;
+                warnings.push(format!("Disable Game Bar did not verify: {}", e));
+            }
         }
 
         if config.disable_fullscreen_optimization {
-            self.disable_fullscreen_optimizations()?;
+            if let Err(e) = self.disable_fullscreen_optimizations() {
+                applied_config.disable_fullscreen_optimization = false;
+                warnings.push(format!(
+                    "Disable fullscreen optimization did not verify: {}",
+                    e
+                ));
+            }
         }
 
-        self.set_power_plan(&config.power_plan)?;
+        if let Err(e) = self.set_power_plan(&config.power_plan) {
+            applied_config.power_plan = PowerPlan::Balanced;
+            warnings.push(format!("Power plan did not verify: {}", e));
+        }
 
         // Tier 1 (Safe) Boosts
         if config.timer_resolution_1ms {
-            self.set_timer_resolution(true)?;
+            if let Err(e) = self.set_timer_resolution(true) {
+                applied_config.timer_resolution_1ms = false;
+                warnings.push(format!("Timer resolution did not verify: {}", e));
+            }
         }
 
         if config.mmcss_gaming_profile {
-            self.apply_mmcss_profile()?;
+            if let Err(e) = self.apply_mmcss_profile() {
+                applied_config.mmcss_gaming_profile = false;
+                warnings.push(format!("MMCSS Gaming Profile did not verify: {}", e));
+            }
         }
 
         if config.game_mode_enabled {
-            self.enable_game_mode()?;
+            if let Err(e) = self.enable_game_mode() {
+                applied_config.game_mode_enabled = false;
+                warnings.push(format!("Windows Game Mode did not verify: {}", e));
+            }
         }
 
-        Ok(())
+        SystemApplyOutcome {
+            applied_config,
+            warnings,
+        }
     }
 
     /// Set Roblox process to high priority
@@ -584,9 +773,8 @@ impl SystemOptimizer {
                 return Err(anyhow::anyhow!("Failed to open process"));
             }
 
-            // Store original priority for restoration
             let current_priority = GetPriorityClass(handle);
-            if current_priority != 0 {
+            if current_priority != 0 && self.original_priority.is_none() {
                 self.original_priority = Some(current_priority);
             }
 
@@ -644,62 +832,18 @@ impl SystemOptimizer {
     fn disable_game_bar(&self) -> Result<()> {
         info!("Disabling Windows Game Bar");
 
-        let output = hidden_command("reg")
-            .args([
-                "add",
-                GAME_BAR_KEY,
-                "/v",
-                GAME_BAR_VALUE,
-                "/t",
-                "REG_DWORD",
-                "/d",
-                "0",
-                "/f",
-            ])
-            .output();
-
-        match output {
-            Ok(_) => {
-                info!("Game Bar disabled successfully");
-                Ok(())
-            }
-            Err(e) => {
-                warn!("Failed to disable Game Bar: {}", e);
-                Ok(()) // Non-critical
-            }
-        }
+        Self::try_set_registry_dword(GAME_BAR_KEY, GAME_BAR_VALUE, 0)?;
+        info!("Game Bar disabled successfully");
+        Ok(())
     }
 
     /// Disable fullscreen optimizations for Roblox
     fn disable_fullscreen_optimizations(&self) -> Result<()> {
         info!("Disabling fullscreen optimizations");
 
-        // This would typically be done by modifying the Roblox executable properties
-        // For now, we'll use registry approach
-        let output = hidden_command("reg")
-            .args([
-                "add",
-                FULLSCREEN_KEY,
-                "/v",
-                FULLSCREEN_VALUE,
-                "/t",
-                "REG_DWORD",
-                "/d",
-                "2",
-                "/f",
-            ])
-            .output();
-
-        match output {
-            Ok(_) => {
-                info!("Fullscreen optimizations disabled");
-                Ok(())
-            }
-            Err(e) => {
-                warn!("Failed to disable fullscreen optimizations: {}", e);
-                Ok(())
-            }
-        }
+        Self::try_set_registry_dword(FULLSCREEN_KEY, FULLSCREEN_VALUE, 2)?;
+        info!("Fullscreen optimizations disabled");
+        Ok(())
     }
 
     /// Set Windows power plan
@@ -710,31 +854,16 @@ impl SystemOptimizer {
 
         if matches!(plan, PowerPlan::SwiftTunnel) {
             if let Err(e) = self.ensure_swifttunnel_power_plan() {
-                warn!("Could not prepare SwiftTunnel power plan: {}", e);
-                warn!("Skipping SwiftTunnel power plan activation because setup did not complete");
-                return Ok(());
+                return Err(anyhow::anyhow!(
+                    "could not prepare SwiftTunnel power plan: {}",
+                    e
+                ));
             }
         }
 
-        let output = hidden_command("powercfg")
-            .args(["/setactive", guid])
-            .output();
-
-        match output {
-            Ok(result) => {
-                if result.status.success() {
-                    info!("Power plan set successfully");
-                    Ok(())
-                } else {
-                    warn!("Failed to set power plan (may require admin)");
-                    Ok(())
-                }
-            }
-            Err(e) => {
-                warn!("Failed to set power plan: {}", e);
-                Ok(())
-            }
-        }
+        Self::try_set_active_power_plan_guid(guid)?;
+        info!("Power plan set successfully");
+        Ok(())
     }
 
     // ===== TIER 1 (SAFE) BOOSTS =====
@@ -767,7 +896,11 @@ impl SystemOptimizer {
                         self.timer_resolution_active = true;
                         info!("Timer resolution set to 1ms via timeBeginPeriod (fallback)");
                     } else {
-                        warn!("Failed to set timer resolution: error code {}", result);
+                        return Err(anyhow::anyhow!(
+                            "NtSetTimerResolution failed with 0x{:08X} and timeBeginPeriod failed with {}",
+                            status,
+                            result
+                        ));
                     }
                 }
             }
@@ -810,7 +943,7 @@ impl SystemOptimizer {
         ];
 
         for (key_path, value_name, value_data) in mmcss_keys.iter() {
-            Self::set_registry_string(key_path, value_name, value_data);
+            Self::try_set_registry_string(key_path, value_name, value_data)?;
         }
 
         // Set DWORD values separately
@@ -834,7 +967,7 @@ impl SystemOptimizer {
 
         for (key_path, value_name, value_data) in dword_keys.iter() {
             if let Ok(value) = value_data.parse::<u32>() {
-                Self::set_registry_dword(key_path, value_name, value);
+                Self::try_set_registry_dword(key_path, value_name, value)?;
             }
         }
 
@@ -871,7 +1004,7 @@ impl SystemOptimizer {
 
         for (key_path, value_name, value_data) in game_mode_keys.iter() {
             if let Ok(value) = value_data.parse::<u32>() {
-                Self::set_registry_dword(key_path, value_name, value);
+                Self::try_set_registry_dword(key_path, value_name, value)?;
             }
         }
 
@@ -1170,6 +1303,43 @@ mod tests {
             Some(true)
         ));
         assert!(!SystemOptimizer::should_import_swifttunnel_power_plan(None));
+    }
+
+    #[test]
+    fn checked_apply_does_not_mark_process_priority_applied_without_pid() {
+        let mut optimizer = SystemOptimizer::new();
+        let config = SystemOptimizationConfig {
+            set_high_priority: true,
+            ..Default::default()
+        };
+
+        let outcome = optimizer.apply_optimizations_checked(&config, 0);
+
+        assert!(!outcome.applied_config.set_high_priority);
+        assert!(outcome.warnings.iter().any(|warning| {
+            warning.contains("High Priority Mode skipped")
+                && warning.contains("no active Roblox process")
+        }));
+    }
+
+    #[test]
+    fn checked_apply_rejects_cpu_affinity_without_selected_cores() {
+        let mut optimizer = SystemOptimizer::new();
+        let config = SystemOptimizationConfig {
+            set_cpu_affinity: true,
+            cpu_cores: Vec::new(),
+            ..Default::default()
+        };
+
+        let outcome = optimizer.apply_optimizations_checked(&config, 1234);
+
+        assert!(!outcome.applied_config.set_cpu_affinity);
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("no CPU cores were selected"))
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -84,6 +84,7 @@ pub struct SystemOptimizer {
 
 pub struct SystemApplyOutcome {
     pub applied_config: SystemOptimizationConfig,
+    pub saved_config: SystemOptimizationConfig,
     pub warnings: Vec<String>,
 }
 
@@ -723,10 +724,12 @@ impl SystemOptimizer {
         Ok(())
     }
 
-    /// Apply system optimizations and return the config safe to persist.
+    /// Apply system optimizations and return verified current state plus the
+    /// config safe to persist.
     ///
-    /// Process-only boosts with no target process keep the requested setting so
-    /// the next apply while Roblox is running can honor the user's intent.
+    /// Process-only boosts with no target process are not currently applied, but
+    /// keep the persisted requested setting so the next apply while Roblox is
+    /// running can honor the user's intent.
     /// Registry, timer, and power-plan boosts must verify via the corresponding
     /// Windows readback before the UI persists them as active.
     pub fn apply_optimizations_checked(
@@ -740,16 +743,19 @@ impl SystemOptimizer {
         );
 
         let mut applied_config = config.clone();
+        let mut saved_config = config.clone();
         let mut warnings = Vec::new();
 
         self.capture_system_state_snapshots(config);
 
         if config.set_high_priority {
             if process_id == 0 {
+                applied_config.set_high_priority = false;
                 warnings
                     .push("High Priority Mode is waiting for an active Roblox process".to_string());
             } else if let Err(e) = self.set_process_priority(process_id) {
                 applied_config.set_high_priority = false;
+                saved_config.set_high_priority = false;
                 warnings.push(format!(
                     "High Priority Mode could not be applied to PID {}: {}",
                     process_id, e
@@ -760,12 +766,15 @@ impl SystemOptimizer {
         if config.set_cpu_affinity {
             if config.cpu_cores.is_empty() {
                 applied_config.set_cpu_affinity = false;
+                saved_config.set_cpu_affinity = false;
                 warnings
                     .push("CPU affinity skipped because no CPU cores were selected".to_string());
             } else if process_id == 0 {
+                applied_config.set_cpu_affinity = false;
                 warnings.push("CPU affinity is waiting for an active Roblox process".to_string());
             } else if let Err(e) = self.set_cpu_affinity(process_id, &config.cpu_cores) {
                 applied_config.set_cpu_affinity = false;
+                saved_config.set_cpu_affinity = false;
                 warnings.push(format!(
                     "CPU affinity could not be applied to PID {}: {}",
                     process_id, e
@@ -776,6 +785,7 @@ impl SystemOptimizer {
         if config.disable_game_bar {
             if let Err(e) = self.disable_game_bar() {
                 applied_config.disable_game_bar = false;
+                saved_config.disable_game_bar = false;
                 warnings.push(format!("Disable Game Bar did not verify: {}", e));
             }
         }
@@ -783,6 +793,7 @@ impl SystemOptimizer {
         if config.disable_fullscreen_optimization {
             if let Err(e) = self.disable_fullscreen_optimizations() {
                 applied_config.disable_fullscreen_optimization = false;
+                saved_config.disable_fullscreen_optimization = false;
                 warnings.push(format!(
                     "Disable fullscreen optimization did not verify: {}",
                     e
@@ -792,7 +803,8 @@ impl SystemOptimizer {
 
         if let Err(e) = self.set_power_plan(&config.power_plan) {
             if let Some(active_power_plan) = Self::active_power_plan() {
-                applied_config.power_plan = active_power_plan;
+                applied_config.power_plan = active_power_plan.clone();
+                saved_config.power_plan = active_power_plan.clone();
                 warnings.push(format!(
                     "Power plan did not verify: {}; active plan read back as {:?}",
                     e, active_power_plan
@@ -800,6 +812,7 @@ impl SystemOptimizer {
             } else {
                 applied_config.power_plan =
                     config.previous_power_plan.unwrap_or(PowerPlan::Balanced);
+                saved_config.power_plan = applied_config.power_plan.clone();
                 warnings.push(format!(
                     "Power plan did not verify and the active plan could not be mapped to a SwiftTunnel option: {}",
                     e
@@ -811,6 +824,7 @@ impl SystemOptimizer {
         if config.timer_resolution_1ms {
             if let Err(e) = self.set_timer_resolution(true) {
                 applied_config.timer_resolution_1ms = false;
+                saved_config.timer_resolution_1ms = false;
                 warnings.push(format!("Timer resolution did not verify: {}", e));
             }
         }
@@ -818,6 +832,7 @@ impl SystemOptimizer {
         if config.mmcss_gaming_profile {
             if let Err(e) = self.apply_mmcss_profile() {
                 applied_config.mmcss_gaming_profile = false;
+                saved_config.mmcss_gaming_profile = false;
                 warnings.push(format!("MMCSS Gaming Profile did not verify: {}", e));
             }
         }
@@ -825,12 +840,14 @@ impl SystemOptimizer {
         if config.game_mode_enabled {
             if let Err(e) = self.enable_game_mode() {
                 applied_config.game_mode_enabled = false;
+                saved_config.game_mode_enabled = false;
                 warnings.push(format!("Windows Game Mode did not verify: {}", e));
             }
         }
 
         SystemApplyOutcome {
             applied_config,
+            saved_config,
             warnings,
         }
     }
@@ -1444,7 +1461,8 @@ mod tests {
 
         let outcome = optimizer.apply_optimizations_checked(&config, 0);
 
-        assert!(outcome.applied_config.set_high_priority);
+        assert!(!outcome.applied_config.set_high_priority);
+        assert!(outcome.saved_config.set_high_priority);
         assert!(outcome.warnings.iter().any(|warning| {
             warning.contains("High Priority Mode")
                 && warning.contains("waiting for an active Roblox process")
@@ -1462,7 +1480,8 @@ mod tests {
 
         let outcome = optimizer.apply_optimizations_checked(&config, 0);
 
-        assert!(outcome.applied_config.set_cpu_affinity);
+        assert!(!outcome.applied_config.set_cpu_affinity);
+        assert!(outcome.saved_config.set_cpu_affinity);
         assert!(
             outcome
                 .warnings
@@ -1484,6 +1503,7 @@ mod tests {
         let outcome = optimizer.apply_optimizations_checked(&config, 1234);
 
         assert!(!outcome.applied_config.set_cpu_affinity);
+        assert!(!outcome.saved_config.set_cpu_affinity);
         assert!(
             outcome
                 .warnings

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -755,9 +755,8 @@ impl SystemOptimizer {
                     .push("High Priority Mode is waiting for an active Roblox process".to_string());
             } else if let Err(e) = self.set_process_priority(process_id) {
                 applied_config.set_high_priority = false;
-                saved_config.set_high_priority = false;
                 warnings.push(format!(
-                    "High Priority Mode could not be applied to PID {}: {}",
+                    "High Priority Mode could not be applied to PID {}; will retry while enabled: {}",
                     process_id, e
                 ));
             }
@@ -774,9 +773,8 @@ impl SystemOptimizer {
                 warnings.push("CPU affinity is waiting for an active Roblox process".to_string());
             } else if let Err(e) = self.set_cpu_affinity(process_id, &config.cpu_cores) {
                 applied_config.set_cpu_affinity = false;
-                saved_config.set_cpu_affinity = false;
                 warnings.push(format!(
-                    "CPU affinity could not be applied to PID {}: {}",
+                    "CPU affinity could not be applied to PID {}; will retry while enabled: {}",
                     process_id, e
                 ));
             }
@@ -1488,6 +1486,49 @@ mod tests {
                 .iter()
                 .any(|warning| warning.contains("CPU affinity")
                     && warning.contains("waiting for an active Roblox process"))
+        );
+    }
+
+    #[test]
+    fn checked_apply_preserves_process_priority_request_after_target_failure() {
+        let mut optimizer = SystemOptimizer::new();
+        let config = SystemOptimizationConfig {
+            set_high_priority: true,
+            ..Default::default()
+        };
+
+        let outcome = optimizer.apply_optimizations_checked(&config, u32::MAX);
+
+        assert!(!outcome.applied_config.set_high_priority);
+        assert!(outcome.saved_config.set_high_priority);
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("High Priority Mode")
+                    && warning.contains("will retry while enabled"))
+        );
+    }
+
+    #[test]
+    fn checked_apply_preserves_cpu_affinity_request_after_target_failure() {
+        let mut optimizer = SystemOptimizer::new();
+        let config = SystemOptimizationConfig {
+            set_cpu_affinity: true,
+            cpu_cores: vec![0, 1],
+            ..Default::default()
+        };
+
+        let outcome = optimizer.apply_optimizations_checked(&config, u32::MAX);
+
+        assert!(!outcome.applied_config.set_cpu_affinity);
+        assert!(outcome.saved_config.set_cpu_affinity);
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("CPU affinity")
+                    && warning.contains("will retry while enabled"))
         );
     }
 

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -127,6 +127,40 @@ impl From<swifttunnel_core::ram_cleaner::RamCleanResult> for RamCleanResultRespo
     }
 }
 
+fn ram_clean_boost_verified(result: &swifttunnel_core::ram_cleaner::RamCleanResult) -> bool {
+    result.modified_flush.success && result.standby_purge.success
+}
+
+fn ram_clean_boost_failure_reasons(
+    result: &swifttunnel_core::ram_cleaner::RamCleanResult,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+
+    if !result.modified_flush.success {
+        reasons.push(format!(
+            "modified flush {}",
+            result
+                .modified_flush
+                .skipped_reason
+                .as_deref()
+                .unwrap_or("failed without a reported reason")
+        ));
+    }
+
+    if !result.standby_purge.success {
+        reasons.push(format!(
+            "standby purge {}",
+            result
+                .standby_purge
+                .skipped_reason
+                .as_deref()
+                .unwrap_or("failed without a reported reason")
+        ));
+    }
+
+    reasons
+}
+
 #[tauri::command]
 pub async fn boost_get_system_memory() -> Result<SystemMemorySnapshotResponse, String> {
     #[cfg(windows)]
@@ -200,12 +234,35 @@ pub async fn boost_update_config(
                 } else {
                     vec![roblox_pid]
                 };
-                if let Err(e) =
-                    swifttunnel_core::ram_cleaner::clean_ram(&exclude_pids, |_, _, _, _, _| {})
-                {
-                    applied_config.system_optimization.clear_standby_memory = false;
-                    warn_list.push(format!("System optimizer: RAM clean boost: {}", e));
+                match swifttunnel_core::ram_cleaner::clean_ram(&exclude_pids, |_, _, _, _, _| {}) {
+                    Ok(result) => {
+                        for warning in &result.warnings {
+                            warn_list
+                                .push(format!("System optimizer: RAM clean boost: {}", warning));
+                        }
+
+                        if !ram_clean_boost_verified(&result) {
+                            applied_config.system_optimization.clear_standby_memory = false;
+                            let reasons = ram_clean_boost_failure_reasons(&result);
+                            warn_list.push(format!(
+                                "System optimizer: RAM clean boost did not verify: {}",
+                                reasons.join("; ")
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        applied_config.system_optimization.clear_standby_memory = false;
+                        warn_list.push(format!("System optimizer: RAM clean boost: {}", e));
+                    }
                 }
+            }
+
+            #[cfg(not(windows))]
+            if config.system_optimization.clear_standby_memory {
+                applied_config.system_optimization.clear_standby_memory = false;
+                warn_list.push(
+                    "System optimizer: RAM clean boost is only supported on Windows".to_string(),
+                );
             }
 
             {
@@ -434,5 +491,74 @@ pub async fn boost_restart_roblox(state: State<'_, AppState>) -> Result<(), Stri
     {
         let _ = state;
         Err("Roblox restart is only supported on Windows".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swifttunnel_core::ram_cleaner::{
+        ModifiedFlushResult, RamCleanResult, StandbyPurgeResult, SystemMemorySnapshot,
+    };
+
+    fn memory_snapshot() -> SystemMemorySnapshot {
+        SystemMemorySnapshot {
+            total_mb: 16_384,
+            available_mb: 4_096,
+            used_mb: 12_288,
+            load_pct: 75,
+            standby_mb: Some(512),
+            modified_mb: Some(128),
+        }
+    }
+
+    fn ram_clean_result(modified_success: bool, standby_success: bool) -> RamCleanResult {
+        RamCleanResult {
+            before: memory_snapshot(),
+            after: memory_snapshot(),
+            trimmed_count: 0,
+            standby_purge: StandbyPurgeResult {
+                attempted: standby_success,
+                success: standby_success,
+                skipped_reason: (!standby_success).then(|| "Requires Administrator".to_string()),
+            },
+            modified_flush: ModifiedFlushResult {
+                attempted: modified_success,
+                success: modified_success,
+                skipped_reason: (!modified_success)
+                    .then(|| "SeIncreaseQuotaPrivilege unavailable".to_string()),
+            },
+            freed_mb: 0,
+            standby_freed_mb: Some(0),
+            modified_freed_mb: Some(0),
+            duration_ms: 1,
+            warnings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn ram_clean_boost_requires_both_memory_list_phases_to_succeed() {
+        assert!(ram_clean_boost_verified(&ram_clean_result(true, true)));
+        assert!(!ram_clean_boost_verified(&ram_clean_result(false, true)));
+        assert!(!ram_clean_boost_verified(&ram_clean_result(true, false)));
+    }
+
+    #[test]
+    fn ram_clean_failure_reasons_report_failed_memory_list_phases() {
+        let result = ram_clean_result(false, false);
+
+        let reasons = ram_clean_boost_failure_reasons(&result);
+
+        assert_eq!(reasons.len(), 2);
+        assert!(
+            reasons
+                .iter()
+                .any(|reason| reason.contains("modified flush"))
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|reason| reason.contains("standby purge"))
+        );
     }
 }

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -580,22 +580,40 @@ mod tests {
         }
     }
 
-    fn ram_clean_result(modified_success: bool, standby_success: bool) -> RamCleanResult {
+    fn modified_flush(
+        attempted: bool,
+        success: bool,
+        skipped_reason: Option<&str>,
+    ) -> ModifiedFlushResult {
+        ModifiedFlushResult {
+            attempted,
+            success,
+            skipped_reason: skipped_reason.map(str::to_string),
+        }
+    }
+
+    fn standby_purge(
+        attempted: bool,
+        success: bool,
+        skipped_reason: Option<&str>,
+    ) -> StandbyPurgeResult {
+        StandbyPurgeResult {
+            attempted,
+            success,
+            skipped_reason: skipped_reason.map(str::to_string),
+        }
+    }
+
+    fn ram_clean_result(
+        modified_flush: ModifiedFlushResult,
+        standby_purge: StandbyPurgeResult,
+    ) -> RamCleanResult {
         RamCleanResult {
             before: memory_snapshot(),
             after: memory_snapshot(),
             trimmed_count: 0,
-            standby_purge: StandbyPurgeResult {
-                attempted: standby_success,
-                success: standby_success,
-                skipped_reason: (!standby_success).then(|| "Requires Administrator".to_string()),
-            },
-            modified_flush: ModifiedFlushResult {
-                attempted: modified_success,
-                success: modified_success,
-                skipped_reason: (!modified_success)
-                    .then(|| "SeIncreaseQuotaPrivilege unavailable".to_string()),
-            },
+            standby_purge,
+            modified_flush,
             freed_mb: 0,
             standby_freed_mb: Some(0),
             modified_freed_mb: Some(0),
@@ -606,14 +624,26 @@ mod tests {
 
     #[test]
     fn ram_clean_boost_requires_both_memory_list_phases_to_succeed() {
-        assert!(ram_clean_boost_verified(&ram_clean_result(true, true)));
-        assert!(!ram_clean_boost_verified(&ram_clean_result(false, true)));
-        assert!(!ram_clean_boost_verified(&ram_clean_result(true, false)));
+        assert!(ram_clean_boost_verified(&ram_clean_result(
+            modified_flush(true, true, None),
+            standby_purge(true, true, None),
+        )));
+        assert!(!ram_clean_boost_verified(&ram_clean_result(
+            modified_flush(false, false, Some("SeIncreaseQuotaPrivilege unavailable")),
+            standby_purge(true, true, None),
+        )));
+        assert!(!ram_clean_boost_verified(&ram_clean_result(
+            modified_flush(true, true, None),
+            standby_purge(false, false, Some("Requires Administrator")),
+        )));
     }
 
     #[test]
     fn ram_clean_privilege_skip_preserves_saved_intent() {
-        let result = ram_clean_result(false, true);
+        let result = ram_clean_result(
+            modified_flush(false, false, Some("SeIncreaseQuotaPrivilege unavailable")),
+            standby_purge(true, true, None),
+        );
 
         assert!(!ram_clean_boost_verified(&result));
         assert!(!ram_clean_boost_should_depersist(&result));
@@ -621,10 +651,14 @@ mod tests {
 
     #[test]
     fn ram_clean_attempted_phase_failure_depersists_saved_intent() {
-        let mut result = ram_clean_result(false, true);
-        result.modified_flush.attempted = true;
-        result.modified_flush.skipped_reason =
-            Some("NtSetSystemInformation failed (0xC0000001)".to_string());
+        let result = ram_clean_result(
+            modified_flush(
+                true,
+                false,
+                Some("NtSetSystemInformation failed (0xC0000001)"),
+            ),
+            standby_purge(true, true, None),
+        );
 
         assert!(!ram_clean_boost_verified(&result));
         assert!(ram_clean_boost_should_depersist(&result));
@@ -632,7 +666,10 @@ mod tests {
 
     #[test]
     fn ram_clean_failure_reasons_report_failed_memory_list_phases() {
-        let result = ram_clean_result(false, false);
+        let result = ram_clean_result(
+            modified_flush(false, false, Some("SeIncreaseQuotaPrivilege unavailable")),
+            standby_purge(false, false, Some("Requires Administrator")),
+        );
 
         let reasons = ram_clean_boost_failure_reasons(&result);
 
@@ -651,11 +688,10 @@ mod tests {
 
     #[test]
     fn ram_clean_failure_reasons_distinguish_attempted_failures_from_skips() {
-        let mut result = ram_clean_result(false, false);
-        result.modified_flush.attempted = true;
-        result.modified_flush.skipped_reason = None;
-        result.standby_purge.attempted = true;
-        result.standby_purge.skipped_reason = None;
+        let result = ram_clean_result(
+            modified_flush(true, false, None),
+            standby_purge(true, false, None),
+        );
 
         let reasons = ram_clean_boost_failure_reasons(&result);
 
@@ -671,7 +707,10 @@ mod tests {
 
     #[test]
     fn ram_clean_warnings_include_callback_only_messages_and_dedupe_result_messages() {
-        let mut result = ram_clean_result(true, true);
+        let mut result = ram_clean_result(
+            modified_flush(true, true, None),
+            standby_purge(true, true, None),
+        );
         result.warnings = vec![
             "trim failed for browser.exe".to_string(),
             "aggregate warning".to_string(),

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -197,6 +197,7 @@ pub async fn boost_get_system_memory() -> Result<SystemMemorySnapshotResponse, S
 pub struct BoostUpdateResult {
     pub warnings: Vec<String>,
     pub applied_config: swifttunnel_core::structs::Config,
+    pub saved_config: swifttunnel_core::structs::Config,
 }
 
 #[tauri::command]
@@ -216,6 +217,7 @@ pub async fn boost_update_config(
 
     tauri::async_runtime::spawn_blocking(move || {
         let mut applied_config = config.clone();
+        let mut saved_config = config.clone();
 
         let warnings = {
             let mut warn_list = Vec::new();
@@ -232,6 +234,7 @@ pub async fn boost_update_config(
                 let outcome =
                     so.apply_optimizations_checked(&config.system_optimization, roblox_pid);
                 applied_config.system_optimization = outcome.applied_config;
+                saved_config.system_optimization = outcome.saved_config;
                 warn_list.extend(
                     outcome
                         .warnings
@@ -264,6 +267,7 @@ pub async fn boost_update_config(
 
                         if !ram_clean_boost_verified(&result) {
                             applied_config.system_optimization.clear_standby_memory = false;
+                            saved_config.system_optimization.clear_standby_memory = false;
                             let reasons = ram_clean_boost_failure_reasons(&result);
                             warn_list.push(format!(
                                 "System optimizer: RAM clean boost did not verify: {}",
@@ -277,6 +281,7 @@ pub async fn boost_update_config(
                                 .push(format!("System optimizer: RAM clean boost: {}", warning));
                         }
                         applied_config.system_optimization.clear_standby_memory = false;
+                        saved_config.system_optimization.clear_standby_memory = false;
                         warn_list.push(format!("System optimizer: RAM clean boost: {}", e));
                     }
                 }
@@ -285,6 +290,7 @@ pub async fn boost_update_config(
             #[cfg(not(windows))]
             if config.system_optimization.clear_standby_memory {
                 applied_config.system_optimization.clear_standby_memory = false;
+                saved_config.system_optimization.clear_standby_memory = false;
                 warn_list.push(
                     "System optimizer: RAM clean boost is only supported on Windows".to_string(),
                 );
@@ -294,6 +300,7 @@ pub async fn boost_update_config(
                 let mut nb = network_booster.lock();
                 let outcome = nb.reconcile_optimizations_checked(&config.network_settings);
                 applied_config.network_settings = outcome.applied_config;
+                saved_config.network_settings = applied_config.network_settings.clone();
                 warn_list.extend(
                     outcome
                         .warnings
@@ -318,7 +325,7 @@ pub async fn boost_update_config(
 
         {
             let mut s = settings.lock();
-            s.config = applied_config.clone();
+            s.config = saved_config.clone();
             swifttunnel_core::settings::save_settings(&s).map_err(|e| e.to_string())?;
         }
 
@@ -332,6 +339,7 @@ pub async fn boost_update_config(
         Ok(BoostUpdateResult {
             warnings,
             applied_config,
+            saved_config,
         })
     })
     .await
@@ -398,6 +406,7 @@ pub async fn boost_sync_effective_config(
 
         Ok(BoostUpdateResult {
             warnings,
+            saved_config: applied_config.clone(),
             applied_config,
         })
     })

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -161,6 +161,19 @@ fn ram_clean_boost_failure_reasons(
     reasons
 }
 
+fn ram_clean_boost_warnings(
+    result: &swifttunnel_core::ram_cleaner::RamCleanResult,
+    mut progress_warnings: Vec<String>,
+) -> Vec<String> {
+    for warning in &result.warnings {
+        if !progress_warnings.contains(warning) {
+            progress_warnings.push(warning.clone());
+        }
+    }
+
+    progress_warnings
+}
+
 #[tauri::command]
 pub async fn boost_get_system_memory() -> Result<SystemMemorySnapshotResponse, String> {
     #[cfg(windows)]
@@ -234,9 +247,17 @@ pub async fn boost_update_config(
                 } else {
                     vec![roblox_pid]
                 };
-                match swifttunnel_core::ram_cleaner::clean_ram(&exclude_pids, |_, _, _, _, _| {}) {
+                let mut progress_warnings = Vec::new();
+                match swifttunnel_core::ram_cleaner::clean_ram(
+                    &exclude_pids,
+                    |_, _, _, _, warning| {
+                        if let Some(warning) = warning {
+                            progress_warnings.push(warning);
+                        }
+                    },
+                ) {
                     Ok(result) => {
-                        for warning in &result.warnings {
+                        for warning in ram_clean_boost_warnings(&result, progress_warnings) {
                             warn_list
                                 .push(format!("System optimizer: RAM clean boost: {}", warning));
                         }
@@ -251,6 +272,10 @@ pub async fn boost_update_config(
                         }
                     }
                     Err(e) => {
+                        for warning in progress_warnings {
+                            warn_list
+                                .push(format!("System optimizer: RAM clean boost: {}", warning));
+                        }
                         applied_config.system_optimization.clear_standby_memory = false;
                         warn_list.push(format!("System optimizer: RAM clean boost: {}", e));
                     }
@@ -559,6 +584,32 @@ mod tests {
             reasons
                 .iter()
                 .any(|reason| reason.contains("standby purge"))
+        );
+    }
+
+    #[test]
+    fn ram_clean_warnings_include_callback_only_messages_and_dedupe_result_messages() {
+        let mut result = ram_clean_result(true, true);
+        result.warnings = vec![
+            "trim failed for browser.exe".to_string(),
+            "aggregate warning".to_string(),
+        ];
+
+        let warnings = ram_clean_boost_warnings(
+            &result,
+            vec![
+                "trim failed for browser.exe".to_string(),
+                "callback-only warning".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            warnings,
+            vec![
+                "trim failed for browser.exe".to_string(),
+                "callback-only warning".to_string(),
+                "aggregate warning".to_string(),
+            ]
         );
     }
 }

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -300,7 +300,7 @@ pub async fn boost_update_config(
                 let mut nb = network_booster.lock();
                 let outcome = nb.reconcile_optimizations_checked(&config.network_settings);
                 applied_config.network_settings = outcome.applied_config;
-                saved_config.network_settings = applied_config.network_settings.clone();
+                saved_config.network_settings = config.network_settings.clone();
                 warn_list.extend(
                     outcome
                         .warnings

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -131,6 +131,18 @@ fn ram_clean_boost_verified(result: &swifttunnel_core::ram_cleaner::RamCleanResu
     result.modified_flush.success && result.standby_purge.success
 }
 
+fn ram_clean_phase_failure_detail(attempted: bool, skipped_reason: Option<&str>) -> String {
+    if let Some(reason) = skipped_reason {
+        return format!("skipped: {}", reason);
+    }
+
+    if attempted {
+        "attempted but failed without a reported reason".to_string()
+    } else {
+        "failed without a reported reason".to_string()
+    }
+}
+
 fn ram_clean_boost_failure_reasons(
     result: &swifttunnel_core::ram_cleaner::RamCleanResult,
 ) -> Vec<String> {
@@ -139,22 +151,20 @@ fn ram_clean_boost_failure_reasons(
     if !result.modified_flush.success {
         reasons.push(format!(
             "modified flush {}",
-            result
-                .modified_flush
-                .skipped_reason
-                .as_deref()
-                .unwrap_or("failed without a reported reason")
+            ram_clean_phase_failure_detail(
+                result.modified_flush.attempted,
+                result.modified_flush.skipped_reason.as_deref(),
+            )
         ));
     }
 
     if !result.standby_purge.success {
         reasons.push(format!(
             "standby purge {}",
-            result
-                .standby_purge
-                .skipped_reason
-                .as_deref()
-                .unwrap_or("failed without a reported reason")
+            ram_clean_phase_failure_detail(
+                result.standby_purge.attempted,
+                result.standby_purge.skipped_reason.as_deref(),
+            )
         ));
     }
 
@@ -594,6 +604,26 @@ mod tests {
                 .iter()
                 .any(|reason| reason.contains("standby purge"))
         );
+    }
+
+    #[test]
+    fn ram_clean_failure_reasons_distinguish_attempted_failures_from_skips() {
+        let mut result = ram_clean_result(false, false);
+        result.modified_flush.attempted = true;
+        result.modified_flush.skipped_reason = None;
+        result.standby_purge.attempted = true;
+        result.standby_purge.skipped_reason = None;
+
+        let reasons = ram_clean_boost_failure_reasons(&result);
+
+        assert!(reasons.iter().any(|reason| {
+            reason.contains("modified flush")
+                && reason.contains("attempted but failed without a reported reason")
+        }));
+        assert!(reasons.iter().any(|reason| {
+            reason.contains("standby purge")
+                && reason.contains("attempted but failed without a reported reason")
+        }));
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -182,8 +182,29 @@ pub async fn boost_update_config(
                 if let Err(e) = so.restore(roblox_pid) {
                     warn_list.push(format!("System optimizer restore: {}", e));
                 }
-                if let Err(e) = so.apply_optimizations(&config.system_optimization, roblox_pid) {
-                    warn_list.push(format!("System optimizer: {}", e));
+                let outcome =
+                    so.apply_optimizations_checked(&config.system_optimization, roblox_pid);
+                applied_config.system_optimization = outcome.applied_config;
+                warn_list.extend(
+                    outcome
+                        .warnings
+                        .into_iter()
+                        .map(|warning| format!("System optimizer: {}", warning)),
+                );
+            }
+
+            #[cfg(windows)]
+            if config.system_optimization.clear_standby_memory {
+                let exclude_pids = if roblox_pid == 0 {
+                    Vec::new()
+                } else {
+                    vec![roblox_pid]
+                };
+                if let Err(e) =
+                    swifttunnel_core::ram_cleaner::clean_ram(&exclude_pids, |_, _, _, _, _| {})
+                {
+                    applied_config.system_optimization.clear_standby_memory = false;
+                    warn_list.push(format!("System optimizer: RAM clean boost: {}", e));
                 }
             }
 

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -131,6 +131,22 @@ fn ram_clean_boost_verified(result: &swifttunnel_core::ram_cleaner::RamCleanResu
     result.modified_flush.success && result.standby_purge.success
 }
 
+fn ram_clean_phase_should_depersist(attempted: bool, success: bool) -> bool {
+    attempted && !success
+}
+
+fn ram_clean_boost_should_depersist(
+    result: &swifttunnel_core::ram_cleaner::RamCleanResult,
+) -> bool {
+    ram_clean_phase_should_depersist(
+        result.modified_flush.attempted,
+        result.modified_flush.success,
+    ) || ram_clean_phase_should_depersist(
+        result.standby_purge.attempted,
+        result.standby_purge.success,
+    )
+}
+
 fn ram_clean_phase_failure_detail(attempted: bool, skipped_reason: Option<&str>) -> String {
     if let Some(reason) = skipped_reason {
         return format!("skipped: {}", reason);
@@ -277,11 +293,19 @@ pub async fn boost_update_config(
 
                         if !ram_clean_boost_verified(&result) {
                             applied_config.system_optimization.clear_standby_memory = false;
-                            saved_config.system_optimization.clear_standby_memory = false;
+                            let depersist = ram_clean_boost_should_depersist(&result);
+                            if depersist {
+                                saved_config.system_optimization.clear_standby_memory = false;
+                            }
                             let reasons = ram_clean_boost_failure_reasons(&result);
                             warn_list.push(format!(
-                                "System optimizer: RAM clean boost did not verify: {}",
-                                reasons.join("; ")
+                                "System optimizer: RAM clean boost did not fully verify: {}{}",
+                                reasons.join("; "),
+                                if depersist {
+                                    "; setting was disabled"
+                                } else {
+                                    "; setting remains enabled for future retries"
+                                }
                             ));
                         }
                     }
@@ -585,6 +609,25 @@ mod tests {
         assert!(ram_clean_boost_verified(&ram_clean_result(true, true)));
         assert!(!ram_clean_boost_verified(&ram_clean_result(false, true)));
         assert!(!ram_clean_boost_verified(&ram_clean_result(true, false)));
+    }
+
+    #[test]
+    fn ram_clean_privilege_skip_preserves_saved_intent() {
+        let result = ram_clean_result(false, true);
+
+        assert!(!ram_clean_boost_verified(&result));
+        assert!(!ram_clean_boost_should_depersist(&result));
+    }
+
+    #[test]
+    fn ram_clean_attempted_phase_failure_depersists_saved_intent() {
+        let mut result = ram_clean_result(false, true);
+        result.modified_flush.attempted = true;
+        result.modified_flush.skipped_reason =
+            Some("NtSetSystemInformation failed (0xC0000001)".to_string());
+
+        assert!(!ram_clean_boost_verified(&result));
+        assert!(ram_clean_boost_should_depersist(&result));
     }
 
     #[test]

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -197,7 +197,7 @@ export interface RamCleanResultResponse {
 export interface BoostUpdateResult {
   warnings: string[];
   applied_config: Config;
-  saved_config?: Config;
+  saved_config: Config;
 }
 
 export type OptimizationProfile = "LowEnd" | "Balanced" | "HighEnd" | "Custom";

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -197,6 +197,7 @@ export interface RamCleanResultResponse {
 export interface BoostUpdateResult {
   warnings: string[];
   applied_config: Config;
+  saved_config?: Config;
 }
 
 export type OptimizationProfile = "LowEnd" | "Balanced" | "HighEnd" | "Custom";

--- a/swifttunnel-desktop/src/stores/boostStore.test.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.test.ts
@@ -71,6 +71,28 @@ describe("stores/boostStore", () => {
     );
   });
 
+  it("returns saved config when current applied state differs from persisted intent", async () => {
+    const applied_config = {
+      profile: "Balanced",
+      system_optimization: { set_high_priority: false },
+    };
+    const saved_config = {
+      profile: "Balanced",
+      system_optimization: { set_high_priority: true },
+    };
+    boostUpdateConfig.mockResolvedValue({
+      warnings: ["System optimizer: High Priority Mode is waiting for Roblox"],
+      applied_config,
+      saved_config,
+    });
+
+    const useBoostStore = await loadStore();
+    await expect(
+      useBoostStore.getState().updateConfig("{\"profile\":\"Balanced\"}"),
+    ).resolves.toBe(saved_config);
+    expect(useBoostStore.getState().warning).toContain("High Priority Mode");
+  });
+
   it("stores error and notifies when config update fails", async () => {
     boostUpdateConfig.mockRejectedValue(new Error("boom"));
 

--- a/swifttunnel-desktop/src/stores/boostStore.test.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.test.ts
@@ -42,10 +42,17 @@ describe("stores/boostStore", () => {
   });
 
   it("updates config without notifications on success", async () => {
-    boostUpdateConfig.mockResolvedValue({ warnings: [] });
+    const saved_config = { profile: "Balanced" };
+    boostUpdateConfig.mockResolvedValue({
+      warnings: [],
+      applied_config: saved_config,
+      saved_config,
+    });
 
     const useBoostStore = await loadStore();
-    await useBoostStore.getState().updateConfig("{\"profile\":\"Balanced\"}");
+    await expect(
+      useBoostStore.getState().updateConfig("{\"profile\":\"Balanced\"}"),
+    ).resolves.toBe(saved_config);
 
     expect(boostUpdateConfig).toHaveBeenCalledTimes(1);
     expect(boostUpdateConfig).toHaveBeenCalledWith("{\"profile\":\"Balanced\"}");
@@ -55,9 +62,11 @@ describe("stores/boostStore", () => {
   });
 
   it("stores warnings separately from fatal config errors", async () => {
+    const saved_config = { profile: "Balanced" };
     boostUpdateConfig.mockResolvedValue({
       warnings: ["Roblox version folder was not found. Launch Roblox once."],
-      applied_config: { profile: "Balanced" },
+      applied_config: saved_config,
+      saved_config,
     });
 
     const useBoostStore = await loadStore();
@@ -318,7 +327,11 @@ describe("stores/boostStore", () => {
         new Promise((resolve) =>
           setTimeout(() => {
             callOrder.push("updateConfig:resolved");
-            resolve({ warnings: [] });
+            resolve({
+              warnings: [],
+              applied_config: { test: true },
+              saved_config: { test: true },
+            });
           }, 50),
         ),
     );

--- a/swifttunnel-desktop/src/stores/boostStore.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.ts
@@ -138,7 +138,7 @@ export const useBoostStore = create<BoostStore>((set) => ({
           "Some optimizations could not be applied.",
         );
       }
-      return result.applied_config ?? JSON.parse(configJson);
+      return result.saved_config ?? result.applied_config ?? JSON.parse(configJson);
     } catch (e) {
       const message = String(e);
       set({ error: message, warning: null });

--- a/swifttunnel-desktop/src/stores/boostStore.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.ts
@@ -138,7 +138,7 @@ export const useBoostStore = create<BoostStore>((set) => ({
           "Some optimizations could not be applied.",
         );
       }
-      return result.saved_config ?? result.applied_config ?? JSON.parse(configJson);
+      return result.saved_config;
     } catch (e) {
       const message = String(e);
       set({ error: message, warning: null });


### PR DESCRIPTION
## Summary
- Make boost application return both verified current state (`applied_config`) and persisted user intent (`saved_config`) instead of using one config for both meanings.
- Verify registry and power-plan writes with readback before marking Game Bar, fullscreen optimization, MMCSS, Game Mode, timer, and power plan boosts active.
- Preserve retryable process-only High Priority / CPU Affinity requests in `saved_config` when no Roblox PID is active or when a live PID is not ready/openable yet, while reporting them as not currently applied in `applied_config`; invalid affinity with no selected cores is still de-persisted.
- Keep `saved_config` required end-to-end and preserve user intent for network boost requests while warnings expose any currently unapplied state.
- Apply the saved RAM-clean boost through the existing RAM cleaner path, require both memory-list phases before reporting it fully applied, preserve saved intent for privilege/precheck skips, and de-persist only attempted memory-list failures.

## Failure-mode plan
- Primary success: a boost shown as currently applied must correspond to a verified Windows setting or an actual process handle operation; persisted user intent is tracked separately so warnings cannot mask failed current application.
- Repairable/retryable: missing Roblox PID or a temporarily unopenable live Roblox PID is retryable, so it clears only current `applied_config` while preserving the saved request for a later apply when Roblox is ready.
- Partial-success recovery: RAM-clean privilege/precheck skips warn and clear only current `applied_config`, preserving saved intent so an admin restart or future privilege repair can retry without the user re-enabling the boost.
- Fatal/diagnostic-only: malformed affinity config with no cores is diagnostic and is removed from both applied and saved config; attempted RAM-clean kernel-call failures de-persist the setting because the operation ran and failed.
- Structured signals: verification uses readback values, exact power-plan GUIDs, operation results, explicit PID presence, selected-core validation, and RAM-clean attempted/skipped flags rather than broad output substrings.
- Partial success: successful boosts stay applied, non-retryable failed system boosts are removed from saved config, and retryable process/network/RAM-clean waits do not erase user intent.
- Tests: added positive coverage for preserving saved process-priority and CPU-affinity requests without a PID and after target-handle failures, negative coverage for CPU affinity with no selected cores, frontend coverage that `updateConfig` returns required `saved_config`, RAM-clean attempted-failure diagnostic coverage, and RAM-clean privilege-skip preservation vs attempted-failure de-persistence coverage.

## Validation
- cargo fmt --check
- git diff --check
- npm test -- --run src/stores/boostStore.test.ts
- npx tsc --noEmit

## Local Rust caveat
- cargo test -p swifttunnel-core checked_apply_preserves_ -- --nocapture and cargo test -p swifttunnel-desktop ram_clean_ -- --nocapture still fail locally before project code in the known macOS windows-future/windows-core mismatch (`IMarshal`, `marshaler`, `windows_threading::submit`). GitHub Windows CI is the authoritative Rust gate.
