### PR TITLE
[codex] Clean up UI timer lifecycles

### DIFF
--- a/swifttunnel-desktop/src/components/common/Tooltip.tsx
+++ b/swifttunnel-desktop/src/components/common/Tooltip.tsx
@@ -14,8 +14,17 @@ export function Tooltip({
   const triggerRef = useRef<HTMLSpanElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  function clearShowTimer() {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }
+
   function show() {
+    clearShowTimer();
     timerRef.current = setTimeout(() => {
+      timerRef.current = null;
       if (!triggerRef.current) return;
       const rect = triggerRef.current.getBoundingClientRect();
       const flip = rect.top < 60;
@@ -29,14 +38,12 @@ export function Tooltip({
   }
 
   function hide() {
-    if (timerRef.current) clearTimeout(timerRef.current);
+    clearShowTimer();
     setVisible(false);
   }
 
   useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
+    return clearShowTimer;
   }, []);
 
   return (

--- a/swifttunnel-desktop/src/components/ui/Tooltip.tsx
+++ b/swifttunnel-desktop/src/components/ui/Tooltip.tsx
@@ -41,6 +41,7 @@ export function Tooltip({
     anchorRef.current = el;
     if (timer.current) clearTimeout(timer.current);
     timer.current = setTimeout(() => {
+      timer.current = null;
       const r = el.getBoundingClientRect();
       let x = r.left + r.width / 2;
       let y = r.top + r.height / 2;
@@ -54,7 +55,10 @@ export function Tooltip({
   }
 
   function hide() {
-    if (timer.current) clearTimeout(timer.current);
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
     setOpen(false);
     setPos(null);
   }

--- a/swifttunnel-desktop/src/stores/toastStore.test.ts
+++ b/swifttunnel-desktop/src/stores/toastStore.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function loadStore() {
+  vi.resetModules();
+  return (await import("./toastStore")).useToastStore;
+}
+
+describe("stores/toastStore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("auto-dismisses toasts after the timeout", async () => {
+    const useToastStore = await loadStore();
+
+    useToastStore
+      .getState()
+      .addToast({ type: "success", message: "Saved" });
+
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+
+    vi.advanceTimersByTime(4000);
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it("clears the auto-dismiss timer when a toast is manually removed", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const useToastStore = await loadStore();
+
+    useToastStore
+      .getState()
+      .addToast({ type: "warning", message: "Dismiss me" });
+    const [toast] = useToastStore.getState().toasts;
+
+    useToastStore.getState().removeToast(toast.id);
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+
+    vi.advanceTimersByTime(4000);
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+});

--- a/swifttunnel-desktop/src/stores/toastStore.test.ts
+++ b/swifttunnel-desktop/src/stores/toastStore.test.ts
@@ -47,4 +47,30 @@ describe("stores/toastStore", () => {
 
     expect(useToastStore.getState().toasts).toHaveLength(0);
   });
+
+  it("lets synchronous subscribers clear the auto-dismiss timer", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const useToastStore = await loadStore();
+    const unsubscribe = useToastStore.subscribe((state) => {
+      const toast = state.toasts[0];
+      if (toast) {
+        useToastStore.getState().removeToast(toast.id);
+      }
+    });
+
+    try {
+      useToastStore
+        .getState()
+        .addToast({ type: "info", message: "Remove immediately" });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+
+    vi.advanceTimersByTime(4000);
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
 });

--- a/swifttunnel-desktop/src/stores/toastStore.ts
+++ b/swifttunnel-desktop/src/stores/toastStore.ts
@@ -16,6 +16,15 @@ interface ToastStore {
 }
 
 let nextId = 0;
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+function clearToastTimeout(id: string) {
+  const timeout = toastTimeouts.get(id);
+  if (!timeout) return;
+
+  clearTimeout(timeout);
+  toastTimeouts.delete(id);
+}
 
 export const useToastStore = create<ToastStore>((set) => ({
   toasts: [],
@@ -23,12 +32,15 @@ export const useToastStore = create<ToastStore>((set) => ({
   addToast: (toast) => {
     const id = String(++nextId);
     set((s) => ({ toasts: [...s.toasts, { ...toast, id }] }));
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
+      toastTimeouts.delete(id);
       set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
     }, 4000);
+    toastTimeouts.set(id, timeout);
   },
 
   removeToast: (id) => {
+    clearToastTimeout(id);
     set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
   },
 }));

--- a/swifttunnel-desktop/src/stores/toastStore.ts
+++ b/swifttunnel-desktop/src/stores/toastStore.ts
@@ -31,12 +31,12 @@ export const useToastStore = create<ToastStore>((set) => ({
 
   addToast: (toast) => {
     const id = String(++nextId);
-    set((s) => ({ toasts: [...s.toasts, { ...toast, id }] }));
     const timeout = setTimeout(() => {
       toastTimeouts.delete(id);
       set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
     }, 4000);
     toastTimeouts.set(id, timeout);
+    set((s) => ({ toasts: [...s.toasts, { ...toast, id }] }));
   },
 
   removeToast: (id) => {


### PR DESCRIPTION
## Summary
- Track toast auto-dismiss timers and clear them when users manually dismiss a toast, so removed toasts do not leave retained callbacks behind.
- Normalize delayed tooltip timer cleanup in both tooltip components, preventing overlapping delayed-open timers and clearing timer refs after callbacks fire.
- Add focused toast store coverage for automatic dismissal and manual-dismiss timer cleanup.

## Impact
This is a lossless lifecycle cleanup: UI behavior stays the same, but repeated toast/tooltip interactions do not accumulate stale timer handles or retained closures.

## Validation
- npm test -- --run toastStore
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check