### PR TITLE
[codex] Harden event listener lifecycle cleanup

### DIFF
--- a/swifttunnel-desktop/src/lib/events.test.ts
+++ b/swifttunnel-desktop/src/lib/events.test.ts
@@ -1,0 +1,129 @@
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+  handleAuthStateEvent: vi.fn(),
+  handleBoostMetricsEvent: vi.fn(),
+  handleRamCleanProgress: vi.fn(),
+  handleUpdaterDone: vi.fn(),
+  handleUpdaterProgress: vi.fn(),
+  handleVpnStateEvent: vi.fn(),
+  handleVpnThroughputEvent: vi.fn(),
+  fetchServerList: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({ handleStateEvent: mocks.handleAuthStateEvent }),
+  },
+}));
+
+vi.mock("../stores/boostStore", () => ({
+  useBoostStore: {
+    getState: () => ({
+      handleMetricsEvent: mocks.handleBoostMetricsEvent,
+      handleRamCleanProgress: mocks.handleRamCleanProgress,
+    }),
+  },
+}));
+
+vi.mock("../stores/serverStore", () => ({
+  useServerStore: {
+    getState: () => ({ fetchList: mocks.fetchServerList }),
+  },
+}));
+
+vi.mock("../stores/updaterStore", () => ({
+  useUpdaterStore: {
+    getState: () => ({
+      handleUpdaterDone: mocks.handleUpdaterDone,
+      handleUpdaterProgress: mocks.handleUpdaterProgress,
+    }),
+  },
+}));
+
+vi.mock("../stores/vpnStore", () => ({
+  useVpnStore: {
+    getState: () => ({
+      handleStateEvent: mocks.handleVpnStateEvent,
+      handleThroughputEvent: mocks.handleVpnThroughputEvent,
+    }),
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function loadEventsModule() {
+  vi.resetModules();
+  return await import("./events");
+}
+
+describe("lib/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("unregisters all listeners on cleanup", async () => {
+    const unlisteners = Array.from({ length: 8 }, () => vi.fn());
+    let nextUnlistener = 0;
+    mocks.listen.mockImplementation(async () => unlisteners[nextUnlistener++]);
+    const { cleanupEventListeners, initEventListeners } =
+      await loadEventsModule();
+
+    await initEventListeners();
+    await cleanupEventListeners();
+
+    expect(mocks.listen).toHaveBeenCalledTimes(8);
+    for (const unlisten of unlisteners) {
+      expect(unlisten).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("unregisters a listener that resolves after cleanup invalidates init", async () => {
+    const lateRegistration = deferred<UnlistenFn>();
+    const lateUnlisten = vi.fn();
+    mocks.listen.mockReturnValueOnce(lateRegistration.promise);
+    const { cleanupEventListeners, initEventListeners } =
+      await loadEventsModule();
+
+    const initPromise = initEventListeners();
+    expect(mocks.listen).toHaveBeenCalledTimes(1);
+
+    await cleanupEventListeners();
+    lateRegistration.resolve(lateUnlisten);
+    await initPromise;
+
+    expect(lateUnlisten).toHaveBeenCalledTimes(1);
+    expect(mocks.listen).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans partial listeners when a later registration fails", async () => {
+    const firstUnlisten = vi.fn();
+    mocks.listen
+      .mockResolvedValueOnce(firstUnlisten)
+      .mockRejectedValueOnce(new Error("listen failed"));
+    const { cleanupEventListeners, initEventListeners } =
+      await loadEventsModule();
+
+    await expect(initEventListeners()).rejects.toThrow("listen failed");
+
+    expect(firstUnlisten).toHaveBeenCalledTimes(1);
+
+    await cleanupEventListeners();
+
+    expect(firstUnlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/swifttunnel-desktop/src/lib/events.test.ts
+++ b/swifttunnel-desktop/src/lib/events.test.ts
@@ -73,7 +73,7 @@ async function loadEventsModule() {
 
 describe("lib/events", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("unregisters all listeners on cleanup", async () => {
@@ -125,5 +125,21 @@ describe("lib/events", () => {
     await cleanupEventListeners();
 
     expect(firstUnlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses listener registration errors after cleanup invalidates init", async () => {
+    const lateRegistration = deferred<UnlistenFn>();
+    mocks.listen.mockReturnValueOnce(lateRegistration.promise);
+    const { cleanupEventListeners, initEventListeners } =
+      await loadEventsModule();
+
+    const initPromise = initEventListeners();
+    expect(mocks.listen).toHaveBeenCalledTimes(1);
+
+    cleanupEventListeners();
+    lateRegistration.reject(new Error("stale listen failed"));
+
+    await expect(initPromise).resolves.toBeUndefined();
+    expect(mocks.listen).toHaveBeenCalledTimes(1);
   });
 });

--- a/swifttunnel-desktop/src/lib/events.ts
+++ b/swifttunnel-desktop/src/lib/events.ts
@@ -23,66 +23,89 @@ const EVENT_UPDATER_PROGRESS = "updater://progress";
 const EVENT_UPDATER_DONE = "updater://done";
 
 let unlisteners: UnlistenFn[] = [];
+let listenerGeneration = 0;
 
-export async function initEventListeners() {
-  // Clean up any existing listeners
-  await cleanupEventListeners();
+type EventRegistration = () => Promise<UnlistenFn>;
 
-  unlisteners.push(
-    await listen<VpnStateEvent>(EVENT_VPN_STATE_CHANGED, (event) => {
+const eventRegistrations: EventRegistration[] = [
+  () =>
+    listen<VpnStateEvent>(EVENT_VPN_STATE_CHANGED, (event) => {
       useVpnStore.getState().handleStateEvent(event.payload);
     }),
-  );
-
-  unlisteners.push(
-    await listen<AuthStateEvent>(EVENT_AUTH_STATE_CHANGED, (event) => {
+  () =>
+    listen<AuthStateEvent>(EVENT_AUTH_STATE_CHANGED, (event) => {
       useAuthStore.getState().handleStateEvent(event.payload);
     }),
-  );
-
-  unlisteners.push(
-    await listen<ThroughputEvent>(EVENT_THROUGHPUT_UPDATE, (event) => {
+  () =>
+    listen<ThroughputEvent>(EVENT_THROUGHPUT_UPDATE, (event) => {
       useVpnStore.getState().handleThroughputEvent(event.payload);
     }),
-  );
-
-  unlisteners.push(
-    await listen<PerformanceMetricsEvent>(
+  () =>
+    listen<PerformanceMetricsEvent>(
       EVENT_PERFORMANCE_METRICS_UPDATE,
       (event) => {
         useBoostStore.getState().handleMetricsEvent(event.payload);
       },
     ),
-  );
-
-  unlisteners.push(
-    await listen<RamCleanProgressEvent>(EVENT_RAM_CLEAN_PROGRESS, (event) => {
+  () =>
+    listen<RamCleanProgressEvent>(EVENT_RAM_CLEAN_PROGRESS, (event) => {
       useBoostStore.getState().handleRamCleanProgress(event.payload);
     }),
-  );
-
-  unlisteners.push(
-    await listen<string>(EVENT_SERVER_LIST_UPDATED, () => {
+  () =>
+    listen<string>(EVENT_SERVER_LIST_UPDATED, () => {
       void useServerStore.getState().fetchList();
     }),
-  );
-
-  unlisteners.push(
-    await listen<UpdaterProgressEvent>(EVENT_UPDATER_PROGRESS, (event) => {
+  () =>
+    listen<UpdaterProgressEvent>(EVENT_UPDATER_PROGRESS, (event) => {
       useUpdaterStore.getState().handleUpdaterProgress(event.payload);
     }),
-  );
-
-  unlisteners.push(
-    await listen<void>(EVENT_UPDATER_DONE, () => {
+  () =>
+    listen<void>(EVENT_UPDATER_DONE, () => {
       useUpdaterStore.getState().handleUpdaterDone();
     }),
-  );
-}
+];
 
-export async function cleanupEventListeners() {
+function cleanupRegisteredListeners() {
   for (const unlisten of unlisteners) {
     unlisten();
   }
   unlisteners = [];
+}
+
+async function registerListener(
+  generation: number,
+  registration: EventRegistration,
+) {
+  const unlisten = await registration();
+
+  if (generation !== listenerGeneration) {
+    unlisten();
+    return false;
+  }
+
+  unlisteners.push(unlisten);
+  return true;
+}
+
+export async function initEventListeners() {
+  const generation = ++listenerGeneration;
+  cleanupRegisteredListeners();
+
+  try {
+    for (const registration of eventRegistrations) {
+      const isCurrent = await registerListener(generation, registration);
+      if (!isCurrent) return;
+    }
+  } catch (error) {
+    if (generation === listenerGeneration) {
+      listenerGeneration++;
+      cleanupRegisteredListeners();
+    }
+    throw error;
+  }
+}
+
+export async function cleanupEventListeners() {
+  listenerGeneration++;
+  cleanupRegisteredListeners();
 }

--- a/swifttunnel-desktop/src/lib/events.ts
+++ b/swifttunnel-desktop/src/lib/events.ts
@@ -97,15 +97,17 @@ export async function initEventListeners() {
       if (!isCurrent) return;
     }
   } catch (error) {
-    if (generation === listenerGeneration) {
-      listenerGeneration++;
-      cleanupRegisteredListeners();
+    if (generation !== listenerGeneration) {
+      return;
     }
+
+    listenerGeneration++;
+    cleanupRegisteredListeners();
     throw error;
   }
 }
 
-export async function cleanupEventListeners() {
+export function cleanupEventListeners() {
   listenerGeneration++;
   cleanupRegisteredListeners();
 }


### PR DESCRIPTION
## Summary
- Guard Tauri event listener registration with a generation token so late async listen() resolutions cannot survive cleanup.
- Clean already registered listeners if a later registration fails, preserving all-or-nothing startup listener setup.
- Add focused tests for normal cleanup, cleanup-during-init races, and partial registration failure cleanup.

## Impact
This prevents leaked global event listeners when the React app unmounts or reinitializes while Tauri listener registration is still in flight. Event payload handling is unchanged when initialization completes normally.

## Validation
- npm test -- --run events
- npm test -- --run
- npx tsc --noEmit
- npm run build
- cargo fmt --check
- git diff --check