### PR TITLE
[codex] Harden OAuth login polling lifecycle

### DIFF
--- a/swifttunnel-desktop/src/components/auth/LoginScreen.polling.test.ts
+++ b/swifttunnel-desktop/src/components/auth/LoginScreen.polling.test.ts
@@ -70,7 +70,7 @@ describe("LoginScreen OAuth polling", () => {
 
   it("clears and cancels the OAuth flow on timeout", async () => {
     const deps = createDeps({
-      now: vi.fn(() => 120_000),
+      now: vi.fn(() => 999_999),
     });
 
     await runOAuthPollTick(deps);

--- a/swifttunnel-desktop/src/components/auth/LoginScreen.polling.test.ts
+++ b/swifttunnel-desktop/src/components/auth/LoginScreen.polling.test.ts
@@ -1,27 +1,97 @@
-import { describe, expect, it } from "vitest";
-import loginScreenSource from "./LoginScreen.tsx?raw";
+import { describe, expect, it, vi } from "vitest";
+import { runOAuthPollTick } from "./LoginScreen";
 
-function oauthPollingEffectSource() {
-  const start = loginScreenSource.indexOf("let polling = false;");
-  const end = loginScreenSource.indexOf("}, [cancelOAuth, isAwaiting, pollOAuth]);");
-  return loginScreenSource.slice(start, end);
+function createDeps(overrides?: Partial<Parameters<typeof runOAuthPollTick>[0]>) {
+  let disposed = false;
+  let polling = false;
+
+  const deps = {
+    isDisposed: vi.fn(() => disposed),
+    isPolling: vi.fn(() => polling),
+    setPolling: vi.fn((next: boolean) => {
+      polling = next;
+    }),
+    getStartedAt: vi.fn(() => 0),
+    now: vi.fn(() => 1_000),
+    setElapsedSecs: vi.fn(),
+    clearPoll: vi.fn(),
+    cancelOAuth: vi.fn(async () => {}),
+    pollOAuth: vi.fn(async () => false),
+    setDisposed: (next: boolean) => {
+      disposed = next;
+    },
+    get polling() {
+      return polling;
+    },
+    ...overrides,
+  };
+
+  return deps;
 }
 
-describe("LoginScreen OAuth polling lifecycle", () => {
-  it("guards in-flight polling work after cleanup", () => {
-    const source = oauthPollingEffectSource();
+describe("LoginScreen OAuth polling", () => {
+  it("does not start a poll tick after cleanup", async () => {
+    const deps = createDeps();
+    deps.setDisposed(true);
 
-    expect(source).toContain("let disposed = false;");
-    expect(source).toContain("disposed = true;");
-    expect(source).toContain("if (polling || disposed) return;");
-    expect(source).toContain("if (disposed) return;");
+    await runOAuthPollTick(deps);
+
+    expect(deps.setPolling).not.toHaveBeenCalled();
+    expect(deps.setElapsedSecs).not.toHaveBeenCalled();
+    expect(deps.pollOAuth).not.toHaveBeenCalled();
   });
 
-  it("always releases the polling lock when the async interval callback exits", () => {
-    const source = oauthPollingEffectSource();
+  it("clears the interval when OAuth completes", async () => {
+    const deps = createDeps({
+      pollOAuth: vi.fn(async () => true),
+    });
 
-    expect(source).toContain("try {");
-    expect(source).toContain("} finally {");
-    expect(source).toContain("polling = false;");
+    await runOAuthPollTick(deps);
+
+    expect(deps.setElapsedSecs).toHaveBeenCalledWith(1);
+    expect(deps.pollOAuth).toHaveBeenCalledTimes(1);
+    expect(deps.clearPoll).toHaveBeenCalledTimes(1);
+    expect(deps.polling).toBe(false);
+  });
+
+  it("does not clear the interval after cleanup happens during poll", async () => {
+    let deps!: ReturnType<typeof createDeps>;
+    const pollOAuth = vi.fn(async () => {
+      deps.setDisposed(true);
+      return true;
+    });
+    deps = createDeps({ pollOAuth });
+
+    await runOAuthPollTick(deps);
+
+    expect(deps.clearPoll).not.toHaveBeenCalled();
+    expect(deps.polling).toBe(false);
+  });
+
+  it("clears and cancels the OAuth flow on timeout", async () => {
+    const deps = createDeps({
+      now: vi.fn(() => 120_000),
+    });
+
+    await runOAuthPollTick(deps);
+
+    expect(deps.clearPoll).toHaveBeenCalledTimes(1);
+    expect(deps.cancelOAuth).toHaveBeenCalledWith(
+      "Login timed out. Please try again.",
+    );
+    expect(deps.pollOAuth).not.toHaveBeenCalled();
+    expect(deps.polling).toBe(false);
+  });
+
+  it("releases the polling lock when polling throws", async () => {
+    const deps = createDeps({
+      pollOAuth: vi.fn(async () => {
+        throw new Error("poll failed");
+      }),
+    });
+
+    await expect(runOAuthPollTick(deps)).rejects.toThrow("poll failed");
+
+    expect(deps.polling).toBe(false);
   });
 });

--- a/swifttunnel-desktop/src/components/auth/LoginScreen.polling.test.ts
+++ b/swifttunnel-desktop/src/components/auth/LoginScreen.polling.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import loginScreenSource from "./LoginScreen.tsx?raw";
+
+function oauthPollingEffectSource() {
+  const start = loginScreenSource.indexOf("let polling = false;");
+  const end = loginScreenSource.indexOf("}, [cancelOAuth, isAwaiting, pollOAuth]);");
+  return loginScreenSource.slice(start, end);
+}
+
+describe("LoginScreen OAuth polling lifecycle", () => {
+  it("guards in-flight polling work after cleanup", () => {
+    const source = oauthPollingEffectSource();
+
+    expect(source).toContain("let disposed = false;");
+    expect(source).toContain("disposed = true;");
+    expect(source).toContain("if (polling || disposed) return;");
+    expect(source).toContain("if (disposed) return;");
+  });
+
+  it("always releases the polling lock when the async interval callback exits", () => {
+    const source = oauthPollingEffectSource();
+
+    expect(source).toContain("try {");
+    expect(source).toContain("} finally {");
+    expect(source).toContain("polling = false;");
+  });
+});

--- a/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
+++ b/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
@@ -45,9 +45,7 @@ export async function runOAuthPollTick(deps: OAuthPollTickDeps) {
   try {
     const startedAt = deps.getStartedAt() ?? deps.now();
     const elapsedMs = deps.now() - startedAt;
-    if (!deps.isDisposed()) {
-      deps.setElapsedSecs(Math.floor(elapsedMs / 1000));
-    }
+    deps.setElapsedSecs(Math.floor(elapsedMs / 1000));
 
     if (elapsedMs >= OAUTH_TIMEOUT_MS) {
       deps.clearPoll();

--- a/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
+++ b/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
@@ -39,35 +39,46 @@ export function LoginScreen() {
 
   useEffect(() => {
     let polling = false;
+    let disposed = false;
+
+    const clearPoll = () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
 
     if (isAwaiting) {
       startedAtRef.current = Date.now();
       setElapsedSecs(0);
 
       pollRef.current = setInterval(async () => {
-        if (polling) return;
+        if (polling || disposed) return;
         polling = true;
 
-        const startedAt = startedAtRef.current ?? Date.now();
-        const elapsedMs = Date.now() - startedAt;
-        setElapsedSecs(Math.floor(elapsedMs / 1000));
-
-        if (elapsedMs >= OAUTH_TIMEOUT_MS) {
-          if (pollRef.current) {
-            clearInterval(pollRef.current);
-            pollRef.current = null;
+        try {
+          const startedAt = startedAtRef.current ?? Date.now();
+          const elapsedMs = Date.now() - startedAt;
+          if (!disposed) {
+            setElapsedSecs(Math.floor(elapsedMs / 1000));
           }
-          await cancelOAuth("Login timed out. Please try again.");
-          polling = false;
-          return;
-        }
 
-        const done = await pollOAuth();
-        if (done && pollRef.current) {
-          clearInterval(pollRef.current);
-          pollRef.current = null;
+          if (elapsedMs >= OAUTH_TIMEOUT_MS) {
+            clearPoll();
+            if (!disposed) {
+              await cancelOAuth("Login timed out. Please try again.");
+            }
+            return;
+          }
+
+          const done = await pollOAuth();
+          if (disposed) return;
+          if (done) {
+            clearPoll();
+          }
+        } finally {
+          polling = false;
         }
-        polling = false;
       }, 1000);
     } else {
       startedAtRef.current = null;
@@ -75,10 +86,8 @@ export function LoginScreen() {
     }
 
     return () => {
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
+      disposed = true;
+      clearPoll();
     };
   }, [cancelOAuth, isAwaiting, pollOAuth]);
 

--- a/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
+++ b/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
@@ -26,6 +26,45 @@ const FEATURES = [
   },
 ];
 
+type OAuthPollTickDeps = {
+  isDisposed: () => boolean;
+  isPolling: () => boolean;
+  setPolling: (polling: boolean) => void;
+  getStartedAt: () => number | null;
+  now: () => number;
+  setElapsedSecs: (elapsedSecs: number) => void;
+  clearPoll: () => void;
+  cancelOAuth: (reason?: string) => Promise<void>;
+  pollOAuth: () => Promise<boolean>;
+};
+
+export async function runOAuthPollTick(deps: OAuthPollTickDeps) {
+  if (deps.isPolling() || deps.isDisposed()) return;
+  deps.setPolling(true);
+
+  try {
+    const startedAt = deps.getStartedAt() ?? deps.now();
+    const elapsedMs = deps.now() - startedAt;
+    if (!deps.isDisposed()) {
+      deps.setElapsedSecs(Math.floor(elapsedMs / 1000));
+    }
+
+    if (elapsedMs >= OAUTH_TIMEOUT_MS) {
+      deps.clearPoll();
+      await deps.cancelOAuth("Login timed out. Please try again.");
+      return;
+    }
+
+    const done = await deps.pollOAuth();
+    if (deps.isDisposed()) return;
+    if (done) {
+      deps.clearPoll();
+    }
+  } finally {
+    deps.setPolling(false);
+  }
+}
+
 export function LoginScreen() {
   const { state, error, startOAuth, pollOAuth, cancelOAuth } = useAuthStore();
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -53,32 +92,19 @@ export function LoginScreen() {
       setElapsedSecs(0);
 
       pollRef.current = setInterval(async () => {
-        if (polling || disposed) return;
-        polling = true;
-
-        try {
-          const startedAt = startedAtRef.current ?? Date.now();
-          const elapsedMs = Date.now() - startedAt;
-          if (!disposed) {
-            setElapsedSecs(Math.floor(elapsedMs / 1000));
-          }
-
-          if (elapsedMs >= OAUTH_TIMEOUT_MS) {
-            clearPoll();
-            if (!disposed) {
-              await cancelOAuth("Login timed out. Please try again.");
-            }
-            return;
-          }
-
-          const done = await pollOAuth();
-          if (disposed) return;
-          if (done) {
-            clearPoll();
-          }
-        } finally {
-          polling = false;
-        }
+        await runOAuthPollTick({
+          isDisposed: () => disposed,
+          isPolling: () => polling,
+          setPolling: (next) => {
+            polling = next;
+          },
+          getStartedAt: () => startedAtRef.current,
+          now: () => Date.now(),
+          setElapsedSecs,
+          clearPoll,
+          cancelOAuth,
+          pollOAuth,
+        });
       }, 1000);
     } else {
       startedAtRef.current = null;


### PR DESCRIPTION
## Summary
- Guard the login OAuth polling interval with a disposed flag so in-flight callbacks stop mutating component state after cleanup.
- Centralize interval cleanup and keep the polling lock release in a finally block, preventing a stuck poll loop after unexpected async failures.
- Add a focused lifecycle regression check for the cleanup guard and polling-lock release.

## Impact
This keeps the login screen behavior the same while preventing stale async interval work from surviving unmounts or auth-state transitions.

## Validation
- npm test -- --run LoginScreen.polling
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check
- git diff --check