### PR TITLE
[codex] Harden network diagnostic result ordering

### DIFF
--- a/swifttunnel-desktop/src/stores/networkStore.test.ts
+++ b/swifttunnel-desktop/src/stores/networkStore.test.ts
@@ -125,6 +125,52 @@ describe("stores/networkStore", () => {
     expect(useNetworkStore.getState().speedError).toBeNull();
   });
 
+  it("does not let an older stability error overwrite a newer success", async () => {
+    const older = deferred<StabilityResultResponse>();
+    const newer = deferred<StabilityResultResponse>();
+    networkStartStabilityTest
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const useNetworkStore = await loadStore();
+    const olderRun = useNetworkStore.getState().runStabilityTest(5);
+    const newerRun = useNetworkStore.getState().runStabilityTest(5);
+
+    newer.resolve(stabilityResult(35));
+    await newerRun;
+    older.reject(new Error("old stability run timed out"));
+    await olderRun;
+
+    expect(useNetworkStore.getState().stabilityStatus).toBe("complete");
+    expect(useNetworkStore.getState().stabilityResult).toEqual(
+      stabilityResult(35),
+    );
+    expect(useNetworkStore.getState().stabilityError).toBeNull();
+  });
+
+  it("does not let an older bufferbloat error overwrite a newer success", async () => {
+    const older = deferred<BufferbloatResultResponse>();
+    const newer = deferred<BufferbloatResultResponse>();
+    networkStartBufferbloatTest
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const useNetworkStore = await loadStore();
+    const olderRun = useNetworkStore.getState().runBufferbloatTest();
+    const newerRun = useNetworkStore.getState().runBufferbloatTest();
+
+    newer.resolve(bufferbloatResult(8));
+    await newerRun;
+    older.reject(new Error("old bufferbloat run timed out"));
+    await olderRun;
+
+    expect(useNetworkStore.getState().bufferbloatStatus).toBe("complete");
+    expect(useNetworkStore.getState().bufferbloatResult).toEqual(
+      bufferbloatResult(8),
+    );
+    expect(useNetworkStore.getState().bufferbloatError).toBeNull();
+  });
+
   it("reset invalidates in-flight diagnostic results", async () => {
     const stability = deferred<StabilityResultResponse>();
     const speed = deferred<SpeedResultResponse>();

--- a/swifttunnel-desktop/src/stores/networkStore.test.ts
+++ b/swifttunnel-desktop/src/stores/networkStore.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  BufferbloatResultResponse,
+  SpeedResultResponse,
+  StabilityResultResponse,
+} from "../lib/types";
+
+const {
+  networkStartStabilityTest,
+  networkStartSpeedTest,
+  networkStartBufferbloatTest,
+} = vi.hoisted(() => ({
+  networkStartStabilityTest: vi.fn(),
+  networkStartSpeedTest: vi.fn(),
+  networkStartBufferbloatTest: vi.fn(),
+}));
+
+vi.mock("../lib/commands", () => ({
+  networkStartStabilityTest,
+  networkStartSpeedTest,
+  networkStartBufferbloatTest,
+}));
+
+async function loadStore() {
+  vi.resetModules();
+  return (await import("./networkStore")).useNetworkStore;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function speedResult(download: number): SpeedResultResponse {
+  return {
+    download_mbps: download,
+    upload_mbps: download / 2,
+    server: `server-${download}`,
+  };
+}
+
+function stabilityResult(avg: number): StabilityResultResponse {
+  return {
+    avg_ping: avg,
+    min_ping: avg - 2,
+    max_ping: avg + 2,
+    jitter: 1,
+    packet_loss: 0,
+    ping_spread: 4,
+    quality: "good",
+    sample_count: 2,
+    ping_samples: [
+      { elapsed_secs: 0, latency_ms: avg - 2 },
+      { elapsed_secs: 1, latency_ms: avg + 2 },
+    ],
+  };
+}
+
+function bufferbloatResult(bufferbloat: number): BufferbloatResultResponse {
+  return {
+    idle_latency: 20,
+    loaded_latency: 20 + bufferbloat,
+    bufferbloat_ms: bufferbloat,
+    grade: "A",
+  };
+}
+
+describe("stores/networkStore", () => {
+  beforeEach(() => {
+    networkStartStabilityTest.mockReset();
+    networkStartSpeedTest.mockReset();
+    networkStartBufferbloatTest.mockReset();
+  });
+
+  it("keeps the newer speed result when an older run resolves last", async () => {
+    const older = deferred<SpeedResultResponse>();
+    const newer = deferred<SpeedResultResponse>();
+    networkStartSpeedTest
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const useNetworkStore = await loadStore();
+    const olderRun = useNetworkStore.getState().runSpeedTest();
+    const newerRun = useNetworkStore.getState().runSpeedTest();
+
+    newer.resolve(speedResult(200));
+    await newerRun;
+
+    expect(useNetworkStore.getState().speedStatus).toBe("complete");
+    expect(useNetworkStore.getState().speedResult).toEqual(speedResult(200));
+
+    older.resolve(speedResult(20));
+    await olderRun;
+
+    expect(networkStartSpeedTest).toHaveBeenCalledTimes(2);
+    expect(useNetworkStore.getState().speedStatus).toBe("complete");
+    expect(useNetworkStore.getState().speedResult).toEqual(speedResult(200));
+    expect(useNetworkStore.getState().speedError).toBeNull();
+  });
+
+  it("does not let an older speed error overwrite a newer success", async () => {
+    const older = deferred<SpeedResultResponse>();
+    const newer = deferred<SpeedResultResponse>();
+    networkStartSpeedTest
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const useNetworkStore = await loadStore();
+    const olderRun = useNetworkStore.getState().runSpeedTest();
+    const newerRun = useNetworkStore.getState().runSpeedTest();
+
+    newer.resolve(speedResult(150));
+    await newerRun;
+    older.reject(new Error("old run timed out"));
+    await olderRun;
+
+    expect(useNetworkStore.getState().speedStatus).toBe("complete");
+    expect(useNetworkStore.getState().speedResult).toEqual(speedResult(150));
+    expect(useNetworkStore.getState().speedError).toBeNull();
+  });
+
+  it("reset invalidates in-flight diagnostic results", async () => {
+    const stability = deferred<StabilityResultResponse>();
+    const speed = deferred<SpeedResultResponse>();
+    const bufferbloat = deferred<BufferbloatResultResponse>();
+    networkStartStabilityTest.mockReturnValueOnce(stability.promise);
+    networkStartSpeedTest.mockReturnValueOnce(speed.promise);
+    networkStartBufferbloatTest.mockReturnValueOnce(bufferbloat.promise);
+
+    const useNetworkStore = await loadStore();
+    const stabilityRun = useNetworkStore.getState().runStabilityTest(5);
+    const speedRun = useNetworkStore.getState().runSpeedTest();
+    const bufferbloatRun = useNetworkStore.getState().runBufferbloatTest();
+
+    expect(useNetworkStore.getState().stabilityStatus).toBe("running");
+    expect(useNetworkStore.getState().speedStatus).toBe("running");
+    expect(useNetworkStore.getState().bufferbloatStatus).toBe("running");
+
+    useNetworkStore.getState().reset();
+    stability.resolve(stabilityResult(42));
+    speed.resolve(speedResult(100));
+    bufferbloat.resolve(bufferbloatResult(5));
+    await Promise.all([stabilityRun, speedRun, bufferbloatRun]);
+
+    expect(networkStartStabilityTest).toHaveBeenCalledWith(5);
+    expect(useNetworkStore.getState().stabilityStatus).toBe("idle");
+    expect(useNetworkStore.getState().stabilityResult).toBeNull();
+    expect(useNetworkStore.getState().speedStatus).toBe("idle");
+    expect(useNetworkStore.getState().speedResult).toBeNull();
+    expect(useNetworkStore.getState().bufferbloatStatus).toBe("idle");
+    expect(useNetworkStore.getState().bufferbloatResult).toBeNull();
+  });
+});

--- a/swifttunnel-desktop/src/stores/networkStore.ts
+++ b/swifttunnel-desktop/src/stores/networkStore.ts
@@ -35,106 +35,114 @@ interface NetworkStore {
   reset: () => void;
 }
 
-let stabilityRunSeq = 0;
-let speedRunSeq = 0;
-let bufferbloatRunSeq = 0;
+export const useNetworkStore = create<NetworkStore>((set) => {
+  let stabilityRunSeq = 0;
+  let speedRunSeq = 0;
+  let bufferbloatRunSeq = 0;
 
-export const useNetworkStore = create<NetworkStore>((set) => ({
-  stabilityStatus: "idle",
-  stabilityResult: null,
-  stabilityError: null,
-  speedStatus: "idle",
-  speedResult: null,
-  speedError: null,
-  bufferbloatStatus: "idle",
-  bufferbloatResult: null,
-  bufferbloatError: null,
+  return {
+    stabilityStatus: "idle",
+    stabilityResult: null,
+    stabilityError: null,
+    speedStatus: "idle",
+    speedResult: null,
+    speedError: null,
+    bufferbloatStatus: "idle",
+    bufferbloatResult: null,
+    bufferbloatError: null,
 
-  runStabilityTest: async (durationSecs = 10) => {
-    const runId = ++stabilityRunSeq;
-    try {
+    runStabilityTest: async (durationSecs = 10) => {
+      const runId = ++stabilityRunSeq;
+      try {
+        set({
+          stabilityStatus: "running",
+          stabilityResult: null,
+          stabilityError: null,
+        });
+        const result = await networkStartStabilityTest(durationSecs);
+        if (runId === stabilityRunSeq) {
+          set({
+            stabilityStatus: "complete",
+            stabilityResult: result,
+            stabilityError: null,
+          });
+        }
+      } catch (e) {
+        if (runId === stabilityRunSeq) {
+          set({
+            stabilityStatus: "error",
+            stabilityResult: null,
+            stabilityError: String(e),
+          });
+        }
+      }
+    },
+
+    runSpeedTest: async () => {
+      const runId = ++speedRunSeq;
+      try {
+        set({ speedStatus: "running", speedResult: null, speedError: null });
+        const result = await networkStartSpeedTest();
+        if (runId === speedRunSeq) {
+          set({
+            speedStatus: "complete",
+            speedResult: result,
+            speedError: null,
+          });
+        }
+      } catch (e) {
+        if (runId === speedRunSeq) {
+          set({
+            speedStatus: "error",
+            speedResult: null,
+            speedError: String(e),
+          });
+        }
+      }
+    },
+
+    runBufferbloatTest: async () => {
+      const runId = ++bufferbloatRunSeq;
+      try {
+        set({
+          bufferbloatStatus: "running",
+          bufferbloatResult: null,
+          bufferbloatError: null,
+        });
+        const result = await networkStartBufferbloatTest();
+        if (runId === bufferbloatRunSeq) {
+          set({
+            bufferbloatStatus: "complete",
+            bufferbloatResult: result,
+            bufferbloatError: null,
+          });
+        }
+      } catch (e) {
+        if (runId === bufferbloatRunSeq) {
+          set({
+            bufferbloatStatus: "error",
+            bufferbloatResult: null,
+            bufferbloatError: String(e),
+          });
+        }
+      }
+    },
+
+    reset: () => {
+      stabilityRunSeq++;
+      speedRunSeq++;
+      bufferbloatRunSeq++;
       set({
-        stabilityStatus: "running",
+        stabilityStatus: "idle",
         stabilityResult: null,
         stabilityError: null,
-      });
-      const result = await networkStartStabilityTest(durationSecs);
-      set(() =>
-        runId === stabilityRunSeq
-          ? { stabilityStatus: "complete", stabilityResult: result }
-          : {},
-      );
-    } catch (e) {
-      set(() =>
-        runId === stabilityRunSeq
-          ? { stabilityStatus: "error", stabilityError: String(e) }
-          : {},
-      );
-    }
-  },
-
-  runSpeedTest: async () => {
-    const runId = ++speedRunSeq;
-    try {
-      set({ speedStatus: "running", speedResult: null, speedError: null });
-      const result = await networkStartSpeedTest();
-      set(() =>
-        runId === speedRunSeq
-          ? { speedStatus: "complete", speedResult: result }
-          : {},
-      );
-    } catch (e) {
-      set(() =>
-        runId === speedRunSeq
-          ? { speedStatus: "error", speedError: String(e) }
-          : {},
-      );
-    }
-  },
-
-  runBufferbloatTest: async () => {
-    const runId = ++bufferbloatRunSeq;
-    try {
-      set({
-        bufferbloatStatus: "running",
+        speedStatus: "idle",
+        speedResult: null,
+        speedError: null,
+        bufferbloatStatus: "idle",
         bufferbloatResult: null,
         bufferbloatError: null,
       });
-      const result = await networkStartBufferbloatTest();
-      set(() =>
-        runId === bufferbloatRunSeq
-          ? {
-              bufferbloatStatus: "complete",
-              bufferbloatResult: result,
-            }
-          : {},
-      );
-    } catch (e) {
-      set(() =>
-        runId === bufferbloatRunSeq
-          ? {
-              bufferbloatStatus: "error",
-              bufferbloatError: String(e),
-            }
-          : {},
-      );
-    }
-  },
-
-  reset: () => {
-    stabilityRunSeq++;
-    speedRunSeq++;
-    bufferbloatRunSeq++;
-    set({
-      stabilityStatus: "idle",
-      stabilityResult: null,
-      stabilityError: null,
-      speedStatus: "idle",
-      speedResult: null,
-      speedError: null,
-      bufferbloatStatus: "idle",
-      bufferbloatResult: null,
-      bufferbloatError: null,
-    });
-  },
-}));
+    },
+  };
+});

--- a/swifttunnel-desktop/src/stores/networkStore.ts
+++ b/swifttunnel-desktop/src/stores/networkStore.ts
@@ -35,6 +35,10 @@ interface NetworkStore {
   reset: () => void;
 }
 
+let stabilityRunSeq = 0;
+let speedRunSeq = 0;
+let bufferbloatRunSeq = 0;
+
 export const useNetworkStore = create<NetworkStore>((set) => ({
   stabilityStatus: "idle",
   stabilityResult: null,
@@ -47,6 +51,7 @@ export const useNetworkStore = create<NetworkStore>((set) => ({
   bufferbloatError: null,
 
   runStabilityTest: async (durationSecs = 10) => {
+    const runId = ++stabilityRunSeq;
     try {
       set({
         stabilityStatus: "running",
@@ -54,23 +59,41 @@ export const useNetworkStore = create<NetworkStore>((set) => ({
         stabilityError: null,
       });
       const result = await networkStartStabilityTest(durationSecs);
-      set({ stabilityStatus: "complete", stabilityResult: result });
+      set(() =>
+        runId === stabilityRunSeq
+          ? { stabilityStatus: "complete", stabilityResult: result }
+          : {},
+      );
     } catch (e) {
-      set({ stabilityStatus: "error", stabilityError: String(e) });
+      set(() =>
+        runId === stabilityRunSeq
+          ? { stabilityStatus: "error", stabilityError: String(e) }
+          : {},
+      );
     }
   },
 
   runSpeedTest: async () => {
+    const runId = ++speedRunSeq;
     try {
       set({ speedStatus: "running", speedResult: null, speedError: null });
       const result = await networkStartSpeedTest();
-      set({ speedStatus: "complete", speedResult: result });
+      set(() =>
+        runId === speedRunSeq
+          ? { speedStatus: "complete", speedResult: result }
+          : {},
+      );
     } catch (e) {
-      set({ speedStatus: "error", speedError: String(e) });
+      set(() =>
+        runId === speedRunSeq
+          ? { speedStatus: "error", speedError: String(e) }
+          : {},
+      );
     }
   },
 
   runBufferbloatTest: async () => {
+    const runId = ++bufferbloatRunSeq;
     try {
       set({
         bufferbloatStatus: "running",
@@ -78,13 +101,30 @@ export const useNetworkStore = create<NetworkStore>((set) => ({
         bufferbloatError: null,
       });
       const result = await networkStartBufferbloatTest();
-      set({ bufferbloatStatus: "complete", bufferbloatResult: result });
+      set(() =>
+        runId === bufferbloatRunSeq
+          ? {
+              bufferbloatStatus: "complete",
+              bufferbloatResult: result,
+            }
+          : {},
+      );
     } catch (e) {
-      set({ bufferbloatStatus: "error", bufferbloatError: String(e) });
+      set(() =>
+        runId === bufferbloatRunSeq
+          ? {
+              bufferbloatStatus: "error",
+              bufferbloatError: String(e),
+            }
+          : {},
+      );
     }
   },
 
   reset: () => {
+    stabilityRunSeq++;
+    speedRunSeq++;
+    bufferbloatRunSeq++;
     set({
       stabilityStatus: "idle",
       stabilityResult: null,


### PR DESCRIPTION
## Summary
- Track per-diagnostic run sequence IDs so stale network test completions cannot overwrite newer state.
- Invalidate in-flight stability, speed, and bufferbloat runs on reset.
- Add focused store tests for overlapping success/error ordering and reset invalidation.

## Failure-mode plan
- Primary success: the latest user-started diagnostic controls the visible result/status.
- Retryable/repairable: stale async completions and stale async errors are ignored when a newer run or reset has superseded them.
- Structured signals: sequence IDs are the structured freshness marker; command error text is not used to decide whether a result is stale.
- Partial success: reset returns the store to idle and invalidates all in-flight diagnostics so late completions cannot resurrect old results.
- Tests: positive overlap coverage for newer success winning, plus a negative stale-error case and reset invalidation across all diagnostic families.

## Validation
- npm test -- --run networkStore
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check
- git diff --check