### PR TITLE
[codex] Harden updater check result ordering

### DIFF
--- a/swifttunnel-desktop/src/stores/updaterStore.test.ts
+++ b/swifttunnel-desktop/src/stores/updaterStore.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdaterCheckResponse } from "../lib/types";
 
 const { updaterCheckChannel, updaterInstallChannel } = vi.hoisted(() => ({
   updaterCheckChannel: vi.fn(),
@@ -42,6 +43,17 @@ vi.mock("./settingsStore", () => ({
 async function loadStore() {
   vi.resetModules();
   return (await import("./updaterStore")).useUpdaterStore;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
 }
 
 describe("stores/updaterStore", () => {
@@ -213,6 +225,72 @@ describe("stores/updaterStore", () => {
     await useUpdaterStore.getState().installUpdate();
 
     expect(updaterInstallChannel).toHaveBeenCalledWith("Stable", "1.5.1");
+  });
+
+  it("keeps the newer update check result when an older check resolves last", async () => {
+    const olderStableCheck = deferred<UpdaterCheckResponse>();
+    const newerLiveCheck = deferred<UpdaterCheckResponse>();
+    updaterCheckChannel
+      .mockReturnValueOnce(olderStableCheck.promise)
+      .mockReturnValueOnce(newerLiveCheck.promise);
+    updaterInstallChannel.mockResolvedValue({
+      installed_version: "2.0.0",
+      release_tag: "v2.0.0",
+    });
+
+    const useUpdaterStore = await loadStore();
+    const olderRun = useUpdaterStore.getState().checkForUpdates(false);
+    mockSettingsStore.settings.update_channel = "Live";
+    const newerRun = useUpdaterStore.getState().checkForUpdates(false);
+
+    newerLiveCheck.resolve({
+      current_version: "1.0.0",
+      available_version: "2.0.0",
+      release_tag: "v2.0.0",
+      channel: "Live",
+    });
+    await newerRun;
+
+    olderStableCheck.resolve({
+      current_version: "1.0.0",
+      available_version: null,
+      release_tag: null,
+      channel: "Stable",
+    });
+    await olderRun;
+
+    expect(useUpdaterStore.getState().status).toBe("update_available");
+    expect(useUpdaterStore.getState().availableVersion).toBe("2.0.0");
+
+    await useUpdaterStore.getState().installUpdate();
+    expect(updaterInstallChannel).toHaveBeenCalledWith("Live", "2.0.0");
+  });
+
+  it("does not let an older check failure overwrite a newer result", async () => {
+    const olderCheck = deferred<UpdaterCheckResponse>();
+    const newerCheck = deferred<UpdaterCheckResponse>();
+    updaterCheckChannel
+      .mockReturnValueOnce(olderCheck.promise)
+      .mockReturnValueOnce(newerCheck.promise);
+
+    const useUpdaterStore = await loadStore();
+    const olderRun = useUpdaterStore.getState().checkForUpdates(false);
+    const newerRun = useUpdaterStore.getState().checkForUpdates(false);
+
+    newerCheck.resolve({
+      current_version: "1.0.0",
+      available_version: null,
+      release_tag: null,
+      channel: "Stable",
+    });
+    await newerRun;
+
+    olderCheck.reject(new Error("old check failed"));
+    await olderRun;
+
+    expect(useUpdaterStore.getState().status).toBe("up_to_date");
+    expect(useUpdaterStore.getState().availableVersion).toBeNull();
+    expect(useUpdaterStore.getState().error).toBeNull();
   });
 
   it("updates install progress from updater progress events", async () => {

--- a/swifttunnel-desktop/src/stores/updaterStore.test.ts
+++ b/swifttunnel-desktop/src/stores/updaterStore.test.ts
@@ -293,6 +293,80 @@ describe("stores/updaterStore", () => {
     expect(useUpdaterStore.getState().error).toBeNull();
   });
 
+  it("does not let an older update-available check overwrite newer up-to-date state", async () => {
+    const olderCheck = deferred<UpdaterCheckResponse>();
+    const newerCheck = deferred<UpdaterCheckResponse>();
+    updaterCheckChannel
+      .mockReturnValueOnce(olderCheck.promise)
+      .mockReturnValueOnce(newerCheck.promise);
+
+    const useUpdaterStore = await loadStore();
+    const olderRun = useUpdaterStore.getState().checkForUpdates(false);
+    const newerRun = useUpdaterStore.getState().checkForUpdates(false);
+
+    newerCheck.resolve({
+      current_version: "2.0.0",
+      available_version: null,
+      release_tag: null,
+      channel: "Stable",
+    });
+    await newerRun;
+
+    olderCheck.resolve({
+      current_version: "1.0.0",
+      available_version: "1.5.1",
+      release_tag: "v1.5.1",
+      channel: "Stable",
+    });
+    await olderRun;
+
+    expect(useUpdaterStore.getState().status).toBe("up_to_date");
+    expect(useUpdaterStore.getState().availableVersion).toBeNull();
+
+    await useUpdaterStore.getState().installUpdate();
+    expect(updaterInstallChannel).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stale auto-install tail install a newer check result", async () => {
+    const notifyGate = deferred<void>();
+    updaterCheckChannel
+      .mockResolvedValueOnce({
+        current_version: "1.0.0",
+        available_version: "1.5.1",
+        release_tag: "v1.5.1",
+        channel: "Stable",
+      })
+      .mockResolvedValueOnce({
+        current_version: "1.0.0",
+        available_version: "2.0.0",
+        release_tag: "v2.0.0",
+        channel: "Stable",
+      });
+    notify.mockReturnValueOnce(notifyGate.promise).mockResolvedValue(undefined);
+    updaterInstallChannel.mockResolvedValue({
+      installed_version: "2.0.0",
+      release_tag: "v2.0.0",
+    });
+
+    const useUpdaterStore = await loadStore();
+    const olderRun = useUpdaterStore.getState().checkForUpdates(false, true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const newerRun = useUpdaterStore.getState().checkForUpdates(false, false);
+    await newerRun;
+
+    expect(useUpdaterStore.getState().status).toBe("update_available");
+    expect(useUpdaterStore.getState().availableVersion).toBe("2.0.0");
+
+    notifyGate.resolve();
+    await olderRun;
+
+    expect(updaterInstallChannel).not.toHaveBeenCalled();
+    expect(useUpdaterStore.getState().status).toBe("update_available");
+    expect(useUpdaterStore.getState().availableVersion).toBe("2.0.0");
+  });
+
   it("updates install progress from updater progress events", async () => {
     updaterCheckChannel.mockResolvedValue({
       current_version: "1.0.0",

--- a/swifttunnel-desktop/src/stores/updaterStore.ts
+++ b/swifttunnel-desktop/src/stores/updaterStore.ts
@@ -19,9 +19,6 @@ interface PendingUpdate {
   channel: "Stable" | "Live";
 }
 
-let pendingUpdate: PendingUpdate | null = null;
-let checkRunSeq = 0;
-
 interface UpdaterStore {
   status: UpdaterStatus;
   currentVersion: string;
@@ -36,142 +33,145 @@ interface UpdaterStore {
   handleUpdaterDone: () => void;
 }
 
-export const useUpdaterStore = create<UpdaterStore>((set) => ({
-  status: "idle",
-  currentVersion: __APP_VERSION__,
-  availableVersion: null,
-  progressPercent: 0,
-  lastChecked: null,
-  error: null,
+export const useUpdaterStore = create<UpdaterStore>((set, get) => {
+  let pendingUpdate: PendingUpdate | null = null;
+  let checkRunSeq = 0;
 
-  checkForUpdates: async (manual = false, autoInstall = false) => {
-    const runId = ++checkRunSeq;
-    try {
-      set({ status: "checking", error: null });
+  return {
+    status: "idle",
+    currentVersion: __APP_VERSION__,
+    availableVersion: null,
+    progressPercent: 0,
+    lastChecked: null,
+    error: null,
 
-      const settingsStore = useSettingsStore.getState();
-      const channel = settingsStore.settings.update_channel;
-      const update = await updaterCheckChannel(channel);
-      if (runId !== checkRunSeq) return;
+    checkForUpdates: async (manual = false, autoInstall = false) => {
+      const runId = ++checkRunSeq;
+      try {
+        set({ status: "checking", error: null });
 
-      const checkedAt = Math.floor(Date.now() / 1000);
+        const settingsStore = useSettingsStore.getState();
+        const channel = settingsStore.settings.update_channel;
+        const update = await updaterCheckChannel(channel);
+        if (runId !== checkRunSeq) return;
 
-      settingsStore.update({
-        update_settings: {
-          ...settingsStore.settings.update_settings,
-          last_check: checkedAt,
-        },
-      });
-      void settingsStore.save();
+        const checkedAt = Math.floor(Date.now() / 1000);
 
-      if (!update.available_version) {
-        pendingUpdate = null;
-        set((prev) => ({
-          status: "up_to_date",
-          currentVersion: update.current_version || prev.currentVersion,
-          availableVersion: null,
+        settingsStore.update({
+          update_settings: {
+            ...settingsStore.settings.update_settings,
+            last_check: checkedAt,
+          },
+        });
+        void settingsStore.save();
+
+        if (!update.available_version) {
+          pendingUpdate = null;
+          set((prev) => ({
+            status: "up_to_date",
+            currentVersion: update.current_version || prev.currentVersion,
+            availableVersion: null,
+            progressPercent: 0,
+            lastChecked: checkedAt,
+          }));
+          if (manual) {
+            await notify("SwiftTunnel", "You are on the latest version.");
+          }
+          return;
+        }
+
+        pendingUpdate = {
+          version: update.available_version,
+          channel,
+        };
+        set({
+          status: "update_available",
+          currentVersion: update.current_version,
+          availableVersion: update.available_version,
           progressPercent: 0,
           lastChecked: checkedAt,
-        }));
-        if (manual) {
-          await notify("SwiftTunnel", "You are on the latest version.");
+        });
+
+        if (autoInstall) {
+          await notify(
+            "SwiftTunnel Update",
+            `Updating to v${update.available_version}, restarting...`,
+          );
+          await useUpdaterStore.getState().installUpdate();
+          return;
         }
-        return;
-      }
 
-      pendingUpdate = {
-        version: update.available_version,
-        channel,
-      };
-      set({
-        status: "update_available",
-        currentVersion: update.current_version,
-        availableVersion: update.available_version,
-        progressPercent: 0,
-        lastChecked: checkedAt,
-      });
+        if (manual) {
+          await notify(
+            "Update Available",
+            `Version ${update.available_version} is ready.`,
+          );
+          return;
+        }
 
-      if (autoInstall) {
-        await notify(
-          "SwiftTunnel Update",
-          `Updating to v${update.available_version}, restarting...`,
-        );
-        await useUpdaterStore.getState().installUpdate();
-        return;
-      }
-
-      if (manual) {
         await notify(
           "Update Available",
-          `Version ${update.available_version} is ready.`,
+          `Version ${update.available_version} is ready to install.`,
         );
-        return;
+      } catch (e) {
+        if (runId !== checkRunSeq) return;
+
+        set({
+          status: "error",
+          error: String(e),
+        });
+      }
+    },
+
+    installUpdate: async () => {
+      if (!pendingUpdate) return;
+
+      try {
+        set({ status: "installing", progressPercent: 0, error: null });
+
+        const { channel, version } = pendingUpdate;
+        await updaterInstallChannel(channel, version);
+
+        pendingUpdate = null;
+        set({
+          status: "up_to_date",
+          availableVersion: null,
+          progressPercent: 100,
+        });
+
+        await notify(
+          "SwiftTunnel Update",
+          "Update installed. Restarting application...",
+        );
+      } catch (e) {
+        set({
+          status: "error",
+          error: String(e),
+        });
+      }
+    },
+
+    handleUpdaterProgress: (event) => {
+      let progressPercent: number | null = null;
+
+      if (event.total && event.total > 0) {
+        progressPercent = Math.max(
+          0,
+          Math.min(99, Math.round((event.downloaded / event.total) * 100)),
+        );
+      } else if (event.downloaded > 0) {
+        progressPercent = 1;
       }
 
-      await notify(
-        "Update Available",
-        `Version ${update.available_version} is ready to install.`,
-      );
-    } catch (e) {
-      if (runId !== checkRunSeq) return;
+      if (progressPercent !== null && get().status === "installing") {
+        set({ progressPercent });
+      }
+    },
 
-      set({
-        status: "error",
-        error: String(e),
-      });
-    }
-  },
-
-  installUpdate: async () => {
-    if (!pendingUpdate) return;
-
-    try {
-      set({ status: "installing", progressPercent: 0, error: null });
-
-      const { channel, version } = pendingUpdate;
-      await updaterInstallChannel(channel, version);
-
-      pendingUpdate = null;
-      set({
-        status: "up_to_date",
-        availableVersion: null,
-        progressPercent: 100,
-      });
-
-      await notify(
-        "SwiftTunnel Update",
-        "Update installed. Restarting application...",
-      );
-    } catch (e) {
-      set({
-        status: "error",
-        error: String(e),
-      });
-    }
-  },
-
-  handleUpdaterProgress: (event) => {
-    let progressPercent: number | null = null;
-
-    if (event.total && event.total > 0) {
-      progressPercent = Math.max(
-        0,
-        Math.min(99, Math.round((event.downloaded / event.total) * 100)),
-      );
-    } else if (event.downloaded > 0) {
-      progressPercent = 1;
-    }
-
-    if (progressPercent !== null) {
-      set((state) =>
-        state.status === "installing" ? { progressPercent } : {},
-      );
-    }
-  },
-
-  handleUpdaterDone: () => {
-    set((state) =>
-      state.status === "installing" ? { progressPercent: 100 } : {},
-    );
-  },
-}));
+    handleUpdaterDone: () => {
+      if (get().status === "installing") {
+        set({ progressPercent: 100 });
+      }
+    },
+  };
+});

--- a/swifttunnel-desktop/src/stores/updaterStore.ts
+++ b/swifttunnel-desktop/src/stores/updaterStore.ts
@@ -97,6 +97,8 @@ export const useUpdaterStore = create<UpdaterStore>((set, get) => {
             "SwiftTunnel Update",
             `Updating to v${update.available_version}, restarting...`,
           );
+          if (runId !== checkRunSeq) return;
+
           await useUpdaterStore.getState().installUpdate();
           return;
         }

--- a/swifttunnel-desktop/src/stores/updaterStore.ts
+++ b/swifttunnel-desktop/src/stores/updaterStore.ts
@@ -20,6 +20,7 @@ interface PendingUpdate {
 }
 
 let pendingUpdate: PendingUpdate | null = null;
+let checkRunSeq = 0;
 
 interface UpdaterStore {
   status: UpdaterStatus;
@@ -44,12 +45,15 @@ export const useUpdaterStore = create<UpdaterStore>((set) => ({
   error: null,
 
   checkForUpdates: async (manual = false, autoInstall = false) => {
+    const runId = ++checkRunSeq;
     try {
       set({ status: "checking", error: null });
 
       const settingsStore = useSettingsStore.getState();
       const channel = settingsStore.settings.update_channel;
       const update = await updaterCheckChannel(channel);
+      if (runId !== checkRunSeq) return;
+
       const checkedAt = Math.floor(Date.now() / 1000);
 
       settingsStore.update({
@@ -109,6 +113,8 @@ export const useUpdaterStore = create<UpdaterStore>((set) => ({
         `Version ${update.available_version} is ready to install.`,
       );
     } catch (e) {
+      if (runId !== checkRunSeq) return;
+
       set({
         status: "error",
         error: String(e),


### PR DESCRIPTION
## Summary
- Add a per-check sequence guard so stale updater check responses cannot overwrite newer state.
- Prevent stale check failures from replacing a newer successful result with an error.
- Cover concurrent Stable/Live checks and stale rejection ordering in updater store tests.

## Failure-mode plan
- Primary success: the newest update check controls visible updater state and the pending install target.
- Retryable/repairable: older async successes and failures are ignored when a newer check has started.
- Structured signals: freshness is tracked by an internal sequence ID, not version strings, channel names, or error text.
- Partial success: a newer successful check keeps its available version and install channel even if an older check finishes later.
- Tests: positive coverage for newer Live winning over older Stable, plus a negative stale-failure case that cannot overwrite a newer up-to-date result.

## Validation
- npm test -- --run updaterStore
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check
- git diff --check