### PR TITLE
[codex] Harden server refresh result ordering

### DIFF
--- a/swifttunnel-desktop/src/stores/serverStore.test.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.test.ts
@@ -207,4 +207,38 @@ describe("stores/serverStore", () => {
     expect(useServerStore.getState().source).toBe("new");
     expect(useServerStore.getState().isLoading).toBe(false);
   });
+
+  it("waits for a standalone list fetch that supersedes a refresh-owned list fetch", async () => {
+    const refreshList = deferred<ServerListResponse>();
+    const standaloneList = deferred<ServerListResponse>();
+    serverRefresh.mockResolvedValueOnce("ok");
+    serverGetList
+      .mockReturnValueOnce(refreshList.promise)
+      .mockReturnValueOnce(standaloneList.promise);
+
+    const useServerStore = await loadStore();
+    const refreshRun = useServerStore.getState().refresh();
+    let refreshSettled = false;
+    void refreshRun.then(() => {
+      refreshSettled = true;
+    });
+    await waitForCallCount(serverGetList, 1);
+
+    const standaloneRun = useServerStore.getState().fetchList();
+    await waitForCallCount(serverGetList, 2);
+
+    refreshList.resolve(serverList("refresh"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(useServerStore.getState().isLoading).toBe(true);
+    expect(useServerStore.getState().source).toBe("");
+    expect(refreshSettled).toBe(false);
+
+    standaloneList.resolve(serverList("standalone"));
+    await Promise.all([refreshRun, standaloneRun]);
+
+    expect(useServerStore.getState().source).toBe("standalone");
+    expect(useServerStore.getState().isLoading).toBe(false);
+    expect(refreshSettled).toBe(true);
+  });
 });

--- a/swifttunnel-desktop/src/stores/serverStore.test.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LatencyEntry, ServerListResponse } from "../lib/types";
+
+const {
+  serverGetList,
+  serverGetLatencies,
+  serverRefresh,
+  serverSmartSelect,
+} = vi.hoisted(() => ({
+  serverGetList: vi.fn(),
+  serverGetLatencies: vi.fn(),
+  serverRefresh: vi.fn(),
+  serverSmartSelect: vi.fn(),
+}));
+
+vi.mock("../lib/commands", () => ({
+  serverGetList,
+  serverGetLatencies,
+  serverRefresh,
+  serverSmartSelect,
+}));
+
+const { reportError } = vi.hoisted(() => ({
+  reportError: vi.fn(),
+}));
+
+vi.mock("../lib/errors", () => ({
+  reportError,
+}));
+
+async function loadStore() {
+  vi.resetModules();
+  return (await import("./serverStore")).useServerStore;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function serverList(id: string): ServerListResponse {
+  return {
+    regions: [
+      {
+        id,
+        name: id.toUpperCase(),
+        description: `${id} region`,
+        country_code: "SG",
+        servers: [`${id}-01`],
+      },
+    ],
+    servers: [
+      {
+        region: id,
+        name: `${id}-01`,
+        country_code: "SG",
+        ip: "203.0.113.10",
+        port: 51820,
+        relay_available: true,
+        relay_port: 8080,
+      },
+    ],
+    source: id,
+  };
+}
+
+describe("stores/serverStore", () => {
+  beforeEach(() => {
+    serverGetList.mockReset();
+    serverGetLatencies.mockReset();
+    serverRefresh.mockReset();
+    serverSmartSelect.mockReset();
+    reportError.mockReset();
+  });
+
+  it("keeps the newer server list when an older fetch resolves last", async () => {
+    const older = deferred<ServerListResponse>();
+    const newer = deferred<ServerListResponse>();
+    serverGetList
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const useServerStore = await loadStore();
+    const olderRun = useServerStore.getState().fetchList();
+    const newerRun = useServerStore.getState().fetchList();
+
+    newer.resolve(serverList("newer"));
+    await newerRun;
+
+    older.resolve(serverList("older"));
+    await olderRun;
+
+    expect(useServerStore.getState().source).toBe("newer");
+    expect(useServerStore.getState().regions[0]?.id).toBe("newer");
+    expect(useServerStore.getState().error).toBeNull();
+  });
+
+  it("does not let an older list failure overwrite a newer success", async () => {
+    const older = deferred<ServerListResponse>();
+    const newer = deferred<ServerListResponse>();
+    serverGetList
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const useServerStore = await loadStore();
+    const olderRun = useServerStore.getState().fetchList();
+    const newerRun = useServerStore.getState().fetchList();
+
+    newer.resolve(serverList("fresh"));
+    await newerRun;
+
+    older.reject(new Error("old list failed"));
+    await olderRun;
+
+    expect(useServerStore.getState().source).toBe("fresh");
+    expect(useServerStore.getState().isLoading).toBe(false);
+    expect(useServerStore.getState().error).toBeNull();
+  });
+
+  it("keeps the newer latency map when an older latency fetch resolves last", async () => {
+    const older = deferred<LatencyEntry[]>();
+    const newer = deferred<LatencyEntry[]>();
+    serverGetLatencies
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const useServerStore = await loadStore();
+    const olderRun = useServerStore.getState().fetchLatencies();
+    const newerRun = useServerStore.getState().fetchLatencies();
+
+    newer.resolve([{ region: "singapore", latency_ms: 41 }]);
+    await newerRun;
+
+    older.resolve([{ region: "singapore", latency_ms: 180 }]);
+    await olderRun;
+
+    expect(useServerStore.getState().getLatency("singapore")).toBe(41);
+  });
+
+  it("refresh invalidates an already in-flight list fetch", async () => {
+    const oldList = deferred<ServerListResponse>();
+    const refreshGate = deferred<string>();
+    const refreshedList = deferred<ServerListResponse>();
+    serverGetList
+      .mockReturnValueOnce(oldList.promise)
+      .mockReturnValueOnce(refreshedList.promise);
+    serverRefresh.mockReturnValueOnce(refreshGate.promise);
+
+    const useServerStore = await loadStore();
+    const oldRun = useServerStore.getState().fetchList();
+    const refreshRun = useServerStore.getState().refresh();
+
+    refreshGate.resolve("ok");
+    await Promise.resolve();
+    refreshedList.resolve(serverList("refreshed"));
+    await refreshRun;
+
+    oldList.resolve(serverList("old"));
+    await oldRun;
+
+    expect(serverRefresh).toHaveBeenCalledTimes(1);
+    expect(useServerStore.getState().source).toBe("refreshed");
+    expect(useServerStore.getState().regions[0]?.id).toBe("refreshed");
+  });
+});

--- a/swifttunnel-desktop/src/stores/serverStore.test.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.test.ts
@@ -195,7 +195,7 @@ describe("stores/serverStore", () => {
     const newRun = useServerStore.getState().refresh();
 
     oldRefresh.resolve("old");
-    await Promise.resolve();
+    await oldRun;
     expect(serverGetList).not.toHaveBeenCalled();
     expect(useServerStore.getState().isLoading).toBe(true);
 

--- a/swifttunnel-desktop/src/stores/serverStore.test.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.test.ts
@@ -44,6 +44,18 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+async function waitForCallCount(
+  mock: { mock: { calls: unknown[] } },
+  count: number,
+) {
+  for (let i = 0; i < 10; i++) {
+    if (mock.mock.calls.length >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  throw new Error(`Expected mock to be called at least ${count} times`);
+}
+
 function serverList(id: string): ServerListResponse {
   return {
     regions: [
@@ -157,7 +169,7 @@ describe("stores/serverStore", () => {
     const refreshRun = useServerStore.getState().refresh();
 
     refreshGate.resolve("ok");
-    await Promise.resolve();
+    await waitForCallCount(serverGetList, 2);
     refreshedList.resolve(serverList("refreshed"));
     await refreshRun;
 
@@ -167,5 +179,32 @@ describe("stores/serverStore", () => {
     expect(serverRefresh).toHaveBeenCalledTimes(1);
     expect(useServerStore.getState().source).toBe("refreshed");
     expect(useServerStore.getState().regions[0]?.id).toBe("refreshed");
+  });
+
+  it("lets the newest refresh own loading state after an older refresh is superseded", async () => {
+    const oldRefresh = deferred<string>();
+    const newRefresh = deferred<string>();
+    const refreshedList = deferred<ServerListResponse>();
+    serverRefresh
+      .mockReturnValueOnce(oldRefresh.promise)
+      .mockReturnValueOnce(newRefresh.promise);
+    serverGetList.mockReturnValueOnce(refreshedList.promise);
+
+    const useServerStore = await loadStore();
+    const oldRun = useServerStore.getState().refresh();
+    const newRun = useServerStore.getState().refresh();
+
+    oldRefresh.resolve("old");
+    await Promise.resolve();
+    expect(serverGetList).not.toHaveBeenCalled();
+    expect(useServerStore.getState().isLoading).toBe(true);
+
+    newRefresh.resolve("new");
+    await waitForCallCount(serverGetList, 1);
+    refreshedList.resolve(serverList("new"));
+    await Promise.all([oldRun, newRun]);
+
+    expect(useServerStore.getState().source).toBe("new");
+    expect(useServerStore.getState().isLoading).toBe(false);
   });
 });

--- a/swifttunnel-desktop/src/stores/serverStore.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.ts
@@ -8,6 +8,10 @@ import {
 } from "../lib/commands";
 import { reportError } from "../lib/errors";
 
+let listRunSeq = 0;
+let refreshRunSeq = 0;
+let latencyRunSeq = 0;
+
 interface ServerStore {
   regions: ServerRegion[];
   servers: ServerInfo[];
@@ -33,43 +37,63 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   error: null,
 
   fetchList: async () => {
+    const runId = ++listRunSeq;
     try {
       set({ isLoading: true });
       const resp = await serverGetList();
-      set({
-        regions: resp.regions,
-        servers: resp.servers,
-        source: resp.source,
-        isLoading: false,
-        error: null,
-      });
+      set(() =>
+        runId === listRunSeq
+          ? {
+              regions: resp.regions,
+              servers: resp.servers,
+              source: resp.source,
+              isLoading: false,
+              error: null,
+            }
+          : {},
+      );
     } catch (e) {
-      set({ isLoading: false, error: String(e) });
+      set(() =>
+        runId === listRunSeq
+          ? { isLoading: false, error: String(e) }
+          : {},
+      );
     }
   },
 
   fetchLatencies: async () => {
+    const runId = ++latencyRunSeq;
     try {
       const entries = await serverGetLatencies();
       const latencies = new Map<string, number | null>();
       for (const entry of entries) {
         latencies.set(entry.region, entry.latency_ms);
       }
-      set({ latencies });
+      set(() => (runId === latencyRunSeq ? { latencies } : {}));
     } catch (error) {
-      reportError("Failed to fetch server latencies", error, {
-        dedupeKey: "server-fetch-latencies",
-      });
+      if (runId === latencyRunSeq) {
+        reportError("Failed to fetch server latencies", error, {
+          dedupeKey: "server-fetch-latencies",
+        });
+      }
     }
   },
 
   refresh: async () => {
+    const runId = ++refreshRunSeq;
+    listRunSeq++;
     try {
       set({ isLoading: true });
       await serverRefresh();
+      if (runId !== refreshRunSeq) return;
+
       await get().fetchList();
     } catch (e) {
-      set({ isLoading: false, error: String(e) });
+      set(() =>
+        runId === refreshRunSeq
+          ? { isLoading: false, error: String(e) }
+          : {},
+      );
     }
   },
 

--- a/swifttunnel-desktop/src/stores/serverStore.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.ts
@@ -85,7 +85,7 @@ export const useServerStore = create<ServerStore>((set, get) => {
         set({ isLoading: true });
         await serverRefresh();
         if (runId !== refreshRunSeq) {
-          // The newer refresh owns the loading state and follow-up list fetch.
+          // This superseded refresh may resolve while the newer refresh still owns loading.
           return;
         }
 

--- a/swifttunnel-desktop/src/stores/serverStore.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.ts
@@ -84,7 +84,10 @@ export const useServerStore = create<ServerStore>((set, get) => {
       try {
         set({ isLoading: true });
         await serverRefresh();
-        if (runId !== refreshRunSeq) return;
+        if (runId !== refreshRunSeq) {
+          // The newer refresh owns the loading state and follow-up list fetch.
+          return;
+        }
 
         await get().fetchList();
       } catch (e) {

--- a/swifttunnel-desktop/src/stores/serverStore.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.ts
@@ -8,10 +8,6 @@ import {
 } from "../lib/commands";
 import { reportError } from "../lib/errors";
 
-let listRunSeq = 0;
-let refreshRunSeq = 0;
-let latencyRunSeq = 0;
-
 interface ServerStore {
   regions: ServerRegion[];
   servers: ServerInfo[];
@@ -28,84 +24,86 @@ interface ServerStore {
   getLatency: (region: string) => number | null;
 }
 
-export const useServerStore = create<ServerStore>((set, get) => ({
-  regions: [],
-  servers: [],
-  latencies: new Map(),
-  source: "",
-  isLoading: false,
-  error: null,
+export const useServerStore = create<ServerStore>((set, get) => {
+  let listRunSeq = 0;
+  let refreshRunSeq = 0;
+  let latencyRunSeq = 0;
 
-  fetchList: async () => {
-    const runId = ++listRunSeq;
-    try {
-      set({ isLoading: true });
-      const resp = await serverGetList();
-      set(() =>
-        runId === listRunSeq
-          ? {
-              regions: resp.regions,
-              servers: resp.servers,
-              source: resp.source,
-              isLoading: false,
-              error: null,
-            }
-          : {},
-      );
-    } catch (e) {
-      set(() =>
-        runId === listRunSeq
-          ? { isLoading: false, error: String(e) }
-          : {},
-      );
-    }
-  },
+  return {
+    regions: [],
+    servers: [],
+    latencies: new Map(),
+    source: "",
+    isLoading: false,
+    error: null,
 
-  fetchLatencies: async () => {
-    const runId = ++latencyRunSeq;
-    try {
-      const entries = await serverGetLatencies();
-      const latencies = new Map<string, number | null>();
-      for (const entry of entries) {
-        latencies.set(entry.region, entry.latency_ms);
+    fetchList: async () => {
+      const runId = ++listRunSeq;
+      try {
+        set({ isLoading: true });
+        const resp = await serverGetList();
+        if (runId === listRunSeq) {
+          set({
+            regions: resp.regions,
+            servers: resp.servers,
+            source: resp.source,
+            isLoading: false,
+            error: null,
+          });
+        }
+      } catch (e) {
+        if (runId === listRunSeq) {
+          set({ isLoading: false, error: String(e) });
+        }
       }
-      set(() => (runId === latencyRunSeq ? { latencies } : {}));
-    } catch (error) {
-      if (runId === latencyRunSeq) {
-        reportError("Failed to fetch server latencies", error, {
-          dedupeKey: "server-fetch-latencies",
-        });
+    },
+
+    fetchLatencies: async () => {
+      const runId = ++latencyRunSeq;
+      try {
+        const entries = await serverGetLatencies();
+        const latencies = new Map<string, number | null>();
+        for (const entry of entries) {
+          latencies.set(entry.region, entry.latency_ms);
+        }
+        if (runId === latencyRunSeq) {
+          set({ latencies });
+        }
+      } catch (error) {
+        if (runId === latencyRunSeq) {
+          reportError("Failed to fetch server latencies", error, {
+            dedupeKey: "server-fetch-latencies",
+          });
+        }
       }
-    }
-  },
+    },
 
-  refresh: async () => {
-    const runId = ++refreshRunSeq;
-    listRunSeq++;
-    try {
-      set({ isLoading: true });
-      await serverRefresh();
-      if (runId !== refreshRunSeq) return;
+    refresh: async () => {
+      const runId = ++refreshRunSeq;
+      listRunSeq++;
+      try {
+        set({ isLoading: true });
+        await serverRefresh();
+        if (runId !== refreshRunSeq) return;
 
-      await get().fetchList();
-    } catch (e) {
-      set(() =>
-        runId === refreshRunSeq
-          ? { isLoading: false, error: String(e) }
-          : {},
-      );
-    }
-  },
+        await get().fetchList();
+      } catch (e) {
+        if (runId === refreshRunSeq) {
+          set({ isLoading: false, error: String(e) });
+        }
+      }
+    },
 
-  smartSelect: async (regionId) => {
-    try {
-      return await serverSmartSelect(regionId);
-    } catch {
-      return null;
-    }
-  },
+    smartSelect: async (regionId) => {
+      try {
+        return await serverSmartSelect(regionId);
+      } catch {
+        return null;
+      }
+    },
 
-  getLatency: (region) => {
-    return get().latencies.get(region) ?? null;
-  },
-}));
+    getLatency: (region) => {
+      return get().latencies.get(region) ?? null;
+    },
+  };
+});

--- a/swifttunnel-desktop/src/stores/serverStore.ts
+++ b/swifttunnel-desktop/src/stores/serverStore.ts
@@ -28,6 +28,7 @@ export const useServerStore = create<ServerStore>((set, get) => {
   let listRunSeq = 0;
   let refreshRunSeq = 0;
   let latencyRunSeq = 0;
+  let activeListRun: Promise<void> | null = null;
 
   return {
     regions: [],
@@ -37,25 +38,34 @@ export const useServerStore = create<ServerStore>((set, get) => {
     isLoading: false,
     error: null,
 
-    fetchList: async () => {
+    fetchList: () => {
       const runId = ++listRunSeq;
-      try {
-        set({ isLoading: true });
-        const resp = await serverGetList();
-        if (runId === listRunSeq) {
-          set({
-            regions: resp.regions,
-            servers: resp.servers,
-            source: resp.source,
-            isLoading: false,
-            error: null,
-          });
+      const run = (async () => {
+        try {
+          set({ isLoading: true });
+          const resp = await serverGetList();
+          if (runId === listRunSeq) {
+            set({
+              regions: resp.regions,
+              servers: resp.servers,
+              source: resp.source,
+              isLoading: false,
+              error: null,
+            });
+          }
+        } catch (e) {
+          if (runId === listRunSeq) {
+            set({ isLoading: false, error: String(e) });
+          }
         }
-      } catch (e) {
-        if (runId === listRunSeq) {
-          set({ isLoading: false, error: String(e) });
+      })();
+
+      activeListRun = run;
+      return run.finally(() => {
+        if (activeListRun === run) {
+          activeListRun = null;
         }
-      }
+      });
     },
 
     fetchLatencies: async () => {
@@ -90,6 +100,16 @@ export const useServerStore = create<ServerStore>((set, get) => {
         }
 
         await get().fetchList();
+        let awaitedListRun: Promise<void> | null = null;
+        while (
+          runId === refreshRunSeq &&
+          get().isLoading &&
+          activeListRun &&
+          activeListRun !== awaitedListRun
+        ) {
+          awaitedListRun = activeListRun;
+          await awaitedListRun;
+        }
       } catch (e) {
         if (runId === refreshRunSeq) {
           set({ isLoading: false, error: String(e) });


### PR DESCRIPTION
## Summary
- Add freshness guards for server list, manual refresh, and latency fetches.
- Prevent stale server-list successes or errors from overwriting newer data.
- Add focused server store tests for list, latency, and refresh ordering.

## Failure-mode plan
- Primary success: the freshest server list or latency request controls the UI data used for selection and display.
- Retryable/repairable: older async successes and failures are ignored after a newer list, refresh, or latency run supersedes them.
- Structured signals: monotonic run sequence IDs are the freshness marker; source names, region IDs, and error text are not used as recovery triggers.
- Partial success: manual refresh invalidates an already in-flight list fetch before it starts the refreshed list load.
- Tests: newer-list success wins, stale-list failure cannot overwrite, newer latency map wins, and refresh invalidates an older list fetch.

## Validation
- npm test -- --run serverStore
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check
- git diff --check