### PR TITLE
[codex] Serialize settings save writes

### DIFF
--- a/swifttunnel-desktop/src/stores/settingsStore.test.ts
+++ b/swifttunnel-desktop/src/stores/settingsStore.test.ts
@@ -12,15 +12,35 @@ vi.mock("../lib/commands", () => ({
   settingsSave,
 }));
 
+const { reportError } = vi.hoisted(() => ({
+  reportError: vi.fn(),
+}));
+
+vi.mock("../lib/errors", () => ({
+  reportError,
+}));
+
 async function loadStore() {
   vi.resetModules();
   return (await import("./settingsStore")).useSettingsStore;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
 }
 
 describe("stores/settingsStore", () => {
   beforeEach(() => {
     settingsLoad.mockReset();
     settingsSave.mockReset();
+    reportError.mockReset();
   });
 
   it("loads settings and sets activeTab from current_tab", async () => {
@@ -216,5 +236,77 @@ describe("stores/settingsStore", () => {
     expect(payload.config.roblox_settings.window_width).toBe(1280);
     expect(payload.config.roblox_settings.window_height).toBe(720);
     expect(payload.config.roblox_settings.window_fullscreen).toBe(false);
+  });
+
+  it("serializes overlapping saves so the later payload writes last", async () => {
+    const firstWrite = deferred<void>();
+    settingsSave
+      .mockReturnValueOnce(firstWrite.promise)
+      .mockResolvedValueOnce(undefined);
+
+    const useSettingsStore = await loadStore();
+    useSettingsStore.setState((s) => ({
+      ...s,
+      activeTab: "connect",
+      settings: { ...s.settings, theme: "light" },
+    }));
+    const firstSave = useSettingsStore.getState().save();
+    await Promise.resolve();
+
+    useSettingsStore.setState((s) => ({
+      ...s,
+      activeTab: "boost",
+      settings: { ...s.settings, theme: "dark" },
+    }));
+    const secondSave = useSettingsStore.getState().save();
+    await Promise.resolve();
+
+    expect(settingsSave).toHaveBeenCalledTimes(1);
+    expect((settingsSave.mock.calls[0]?.[0] as AppSettings).theme).toBe(
+      "light",
+    );
+
+    firstWrite.resolve();
+    await Promise.all([firstSave, secondSave]);
+
+    expect(settingsSave).toHaveBeenCalledTimes(2);
+    const secondPayload = settingsSave.mock.calls[1]?.[0] as AppSettings;
+    expect(secondPayload.theme).toBe("dark");
+    expect(secondPayload.current_tab).toBe("boost");
+  });
+
+  it("continues queued saves after an earlier write fails", async () => {
+    const firstWrite = deferred<void>();
+    settingsSave
+      .mockReturnValueOnce(firstWrite.promise)
+      .mockResolvedValueOnce(undefined);
+
+    const useSettingsStore = await loadStore();
+    useSettingsStore.setState((s) => ({
+      ...s,
+      settings: { ...s.settings, theme: "light" },
+    }));
+    const firstSave = useSettingsStore.getState().save();
+    await Promise.resolve();
+
+    useSettingsStore.setState((s) => ({
+      ...s,
+      settings: { ...s.settings, theme: "dark" },
+    }));
+    const secondSave = useSettingsStore.getState().save();
+    await Promise.resolve();
+
+    expect(settingsSave).toHaveBeenCalledTimes(1);
+    firstWrite.reject(new Error("disk full"));
+    await Promise.all([firstSave, secondSave]);
+
+    expect(settingsSave).toHaveBeenCalledTimes(2);
+    expect((settingsSave.mock.calls[1]?.[0] as AppSettings).theme).toBe(
+      "dark",
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      "Failed to save settings",
+      expect.any(Error),
+    );
   });
 });

--- a/swifttunnel-desktop/src/stores/settingsStore.ts
+++ b/swifttunnel-desktop/src/stores/settingsStore.ts
@@ -16,45 +16,56 @@ interface SettingsStore {
   setTab: (tab: TabId) => void;
 }
 
-export const useSettingsStore = create<SettingsStore>((set, get) => ({
-  settings: DEFAULT_SETTINGS,
-  activeTab: "connect",
-  isLoaded: false,
+export const useSettingsStore = create<SettingsStore>((set, get) => {
+  let saveQueue: Promise<void> = Promise.resolve();
 
-  load: async () => {
-    try {
-      const settings = mergeAppSettings(await settingsLoad());
-      set({
-        settings,
-        activeTab: (settings.current_tab as TabId) || "connect",
-        isLoaded: true,
-      });
-    } catch (error) {
-      reportError("Failed to load settings", error);
-      set({ isLoaded: true });
-    }
-  },
+  return {
+    settings: DEFAULT_SETTINGS,
+    activeTab: "connect",
+    isLoaded: false,
 
-  save: async () => {
-    try {
+    load: async () => {
+      try {
+        const settings = mergeAppSettings(await settingsLoad());
+        set({
+          settings,
+          activeTab: (settings.current_tab as TabId) || "connect",
+          isLoaded: true,
+        });
+      } catch (error) {
+        reportError("Failed to load settings", error);
+        set({ isLoaded: true });
+      }
+    },
+
+    save: async () => {
       const { settings, activeTab } = get();
-      await settingsSave({ ...settings, current_tab: activeTab });
-    } catch (error) {
-      reportError("Failed to save settings", error);
-    }
-  },
+      const payload = { ...settings, current_tab: activeTab };
+      saveQueue = saveQueue
+        .catch(() => undefined)
+        .then(async () => {
+          try {
+            await settingsSave(payload);
+          } catch (error) {
+            reportError("Failed to save settings", error);
+          }
+        });
 
-  update: (partial) => {
-    set((state) => ({
-      settings: { ...state.settings, ...partial },
-    }));
-    // Debounced save handled by the component layer
-  },
+      await saveQueue;
+    },
 
-  setTab: (tab) => {
-    set({ activeTab: tab });
-    // Persist tab selection
-    const { settings } = get();
-    set({ settings: { ...settings, current_tab: tab } });
-  },
-}));
+    update: (partial) => {
+      set((state) => ({
+        settings: { ...state.settings, ...partial },
+      }));
+      // Debounced save handled by the component layer
+    },
+
+    setTab: (tab) => {
+      set({ activeTab: tab });
+      // Persist tab selection
+      const { settings } = get();
+      set({ settings: { ...settings, current_tab: tab } });
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- Queue settings saves so overlapping writes reach the backend in call order.
- Capture each save payload at call time, preserving the later payload as the final disk write.
- Keep the queue alive after a failed write and add focused ordering tests.

## Failure-mode plan
- Primary success: the settings file must end with the newest save payload, not whichever backend write finishes last.
- Repairable/retryable: older and newer save calls are serialized FIFO; a failed earlier write is reported but does not block later saves.
- Fatal/diagnostic-only: individual write failures remain diagnostic through reportError because the UI currently treats save as best effort.
- Structured signals: save call order is the freshness marker; completion order and error text do not decide which payload is final.
- Partial success: if one write fails, queued later writes still run and can persist the latest state.
- Tests: overlapping saves prove the second backend call waits for the first, plus a negative failed-first-save case proves the queue cannot stall forever.

## Validation
- npm test -- --run settingsStore
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check
- git diff --check