### PR TITLE
[codex] Harden auth state result ordering

### DIFF
--- a/swifttunnel-desktop/src/stores/authStore.test.ts
+++ b/swifttunnel-desktop/src/stores/authStore.test.ts
@@ -46,6 +46,18 @@ function authState(overrides: Partial<AuthStateResponse>): AuthStateResponse {
   };
 }
 
+async function waitForCallCount(
+  mock: { mock: { calls: unknown[] } },
+  count: number,
+) {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    if (mock.mock.calls.length >= count) return;
+    await Promise.resolve();
+  }
+
+  expect(mock.mock.calls.length).toBeGreaterThanOrEqual(count);
+}
+
 describe("stores/authStore", () => {
   beforeEach(() => {
     Object.values(commands).forEach((mock) => mock.mockReset());
@@ -93,6 +105,34 @@ describe("stores/authStore", () => {
 
     await useAuthStore.getState().refreshProfile();
     expect(useAuthStore.getState().error).toBeNull();
+  });
+
+  it("clears loading when refreshProfile supersedes an in-flight fetch", async () => {
+    const fetchState = deferred<AuthStateResponse>();
+    commands.authGetState.mockReturnValueOnce(fetchState.promise);
+    commands.authRefreshProfile.mockResolvedValueOnce(undefined);
+
+    const useAuthStore = await loadStore();
+    const fetchRun = useAuthStore.getState().fetchState();
+    await waitForCallCount(commands.authGetState, 1);
+
+    await useAuthStore.getState().refreshProfile();
+
+    expect(useAuthStore.getState().isLoading).toBe(false);
+    expect(useAuthStore.getState().error).toBeNull();
+
+    fetchState.resolve(
+      authState({
+        state: "logged_in",
+        email: "old@example.com",
+        user_id: "old-user",
+      }),
+    );
+    await fetchRun;
+
+    expect(useAuthStore.getState().state).toBe("logged_out");
+    expect(useAuthStore.getState().email).toBeNull();
+    expect(useAuthStore.getState().isLoading).toBe(false);
   });
 
   it("does not let a stale fetch restore logged-in state after logout", async () => {
@@ -144,6 +184,44 @@ describe("stores/authStore", () => {
     await expect(pollRun).resolves.toBe(false);
 
     expect(useAuthStore.getState().state).toBe("logged_out");
+    expect(useAuthStore.getState().error).toBe("Login cancelled.");
+  });
+
+  it("returns false when OAuth completion fetch is cancelled before it writes", async () => {
+    const fetchState = deferred<AuthStateResponse>();
+    commands.authPollOAuth.mockResolvedValueOnce({
+      completed: true,
+      token: "token-1",
+      state: "callback-state",
+    });
+    commands.authCompleteOAuth.mockResolvedValueOnce(undefined);
+    commands.authGetState.mockReturnValueOnce(fetchState.promise);
+    commands.authCancelOAuth.mockResolvedValueOnce(undefined);
+
+    const useAuthStore = await loadStore();
+    useAuthStore.setState((state) => ({
+      ...state,
+      state: "awaiting_oauth",
+      isLoading: false,
+      error: null,
+    }));
+
+    const pollRun = useAuthStore.getState().pollOAuth();
+    await waitForCallCount(commands.authGetState, 1);
+
+    await useAuthStore.getState().cancelOAuth("Login cancelled.");
+
+    fetchState.resolve(
+      authState({
+        state: "logged_in",
+        email: "new@example.com",
+        user_id: "new-user",
+      }),
+    );
+    await expect(pollRun).resolves.toBe(false);
+
+    expect(useAuthStore.getState().state).toBe("logged_out");
+    expect(useAuthStore.getState().email).toBeNull();
     expect(useAuthStore.getState().error).toBe("Login cancelled.");
   });
 });

--- a/swifttunnel-desktop/src/stores/authStore.test.ts
+++ b/swifttunnel-desktop/src/stores/authStore.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthStateResponse, OAuthPollResult } from "../lib/types";
 
 const commands = vi.hoisted(() => ({
   authGetState: vi.fn(),
@@ -19,6 +20,30 @@ vi.mock("../lib/errors", () => ({
 async function loadStore() {
   vi.resetModules();
   return (await import("./authStore")).useAuthStore;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function authState(overrides: Partial<AuthStateResponse>): AuthStateResponse {
+  return {
+    state: "logged_out",
+    email: null,
+    user_id: null,
+    is_tester: false,
+    is_banned: false,
+    banned_reason: null,
+    banned_at: null,
+    ...overrides,
+  };
 }
 
 describe("stores/authStore", () => {
@@ -68,5 +93,57 @@ describe("stores/authStore", () => {
 
     await useAuthStore.getState().refreshProfile();
     expect(useAuthStore.getState().error).toBeNull();
+  });
+
+  it("does not let a stale fetch restore logged-in state after logout", async () => {
+    const fetchState = deferred<AuthStateResponse>();
+    commands.authGetState.mockReturnValueOnce(fetchState.promise);
+    commands.authLogout.mockResolvedValueOnce(undefined);
+
+    const useAuthStore = await loadStore();
+    const fetchRun = useAuthStore.getState().fetchState();
+    await Promise.resolve();
+
+    await useAuthStore.getState().logout();
+
+    fetchState.resolve(
+      authState({
+        state: "logged_in",
+        email: "old@example.com",
+        user_id: "old-user",
+        is_tester: true,
+      }),
+    );
+    await fetchRun;
+
+    expect(useAuthStore.getState().state).toBe("logged_out");
+    expect(useAuthStore.getState().email).toBeNull();
+    expect(useAuthStore.getState().userId).toBeNull();
+    expect(useAuthStore.getState().isTester).toBe(false);
+    expect(useAuthStore.getState().isLoading).toBe(false);
+  });
+
+  it("does not let a stale OAuth poll failure overwrite cancellation", async () => {
+    const poll = deferred<OAuthPollResult>();
+    commands.authPollOAuth.mockReturnValueOnce(poll.promise);
+    commands.authCancelOAuth.mockResolvedValueOnce(undefined);
+
+    const useAuthStore = await loadStore();
+    useAuthStore.setState((state) => ({
+      ...state,
+      state: "awaiting_oauth",
+      isLoading: false,
+      error: null,
+    }));
+
+    const pollRun = useAuthStore.getState().pollOAuth();
+    await Promise.resolve();
+    await useAuthStore.getState().cancelOAuth("Login cancelled.");
+
+    poll.reject(new Error("old poll failed"));
+    await expect(pollRun).resolves.toBe(false);
+
+    expect(useAuthStore.getState().state).toBe("logged_out");
+    expect(useAuthStore.getState().error).toBe("Login cancelled.");
   });
 });

--- a/swifttunnel-desktop/src/stores/authStore.ts
+++ b/swifttunnel-desktop/src/stores/authStore.ts
@@ -32,114 +32,148 @@ interface AuthStore {
   handleStateEvent: (event: AuthStateEvent) => void;
 }
 
-export const useAuthStore = create<AuthStore>((set, get) => ({
-  state: "logged_out",
-  email: null,
-  userId: null,
-  isTester: false,
-  isBanned: false,
-  bannedReason: null,
-  bannedAt: null,
-  isLoading: true,
-  error: null,
+export const useAuthStore = create<AuthStore>((set, get) => {
+  let authRunSeq = 0;
 
-  fetchState: async () => {
-    try {
-      const resp = await authGetState();
-      set({
-        state: resp.state,
-        email: resp.email,
-        userId: resp.user_id,
-        isTester: resp.is_tester,
-        isBanned: resp.is_banned,
-        bannedReason: resp.banned_reason,
-        bannedAt: resp.banned_at,
-        isLoading: false,
-        error: null,
-      });
-    } catch (e) {
-      set({ isLoading: false, error: String(e) });
-    }
-  },
+  return {
+    state: "logged_out",
+    email: null,
+    userId: null,
+    isTester: false,
+    isBanned: false,
+    bannedReason: null,
+    bannedAt: null,
+    isLoading: true,
+    error: null,
 
-  startOAuth: async () => {
-    try {
-      set({ state: "awaiting_oauth", error: null });
-      // Native auth command already opens the browser and tracks pending state.
-      await authStartOAuth();
-    } catch (e) {
-      set({ state: "logged_out", error: String(e) });
-    }
-  },
-
-  pollOAuth: async () => {
-    try {
-      const result = await authPollOAuth();
-      if (result.completed && result.token && result.state) {
-        await authCompleteOAuth(result.token, result.state);
-        await get().fetchState();
-        return true;
+    fetchState: async () => {
+      const runId = ++authRunSeq;
+      try {
+        const resp = await authGetState();
+        if (runId === authRunSeq) {
+          set({
+            state: resp.state,
+            email: resp.email,
+            userId: resp.user_id,
+            isTester: resp.is_tester,
+            isBanned: resp.is_banned,
+            bannedReason: resp.banned_reason,
+            bannedAt: resp.banned_at,
+            isLoading: false,
+            error: null,
+          });
+        }
+      } catch (e) {
+        if (runId === authRunSeq) {
+          set({ isLoading: false, error: String(e) });
+        }
       }
-      return false;
-    } catch (e) {
-      set({ error: String(e) });
-      return false;
-    }
-  },
+    },
 
-  cancelOAuth: async (reason = "Login cancelled.") => {
-    try {
-      await authCancelOAuth();
-    } catch (error) {
-      reportError("Failed to cancel OAuth flow", error, {
-        dedupeKey: "auth-cancel-oauth",
-      });
-    }
+    startOAuth: async () => {
+      const runId = ++authRunSeq;
+      try {
+        set({ state: "awaiting_oauth", isLoading: false, error: null });
+        // Native auth command already opens the browser and tracks pending state.
+        await authStartOAuth();
+      } catch (e) {
+        if (runId === authRunSeq) {
+          set({ state: "logged_out", isLoading: false, error: String(e) });
+        }
+      }
+    },
 
-    set({
-      state: "logged_out",
-      error: reason,
-    });
-  },
+    pollOAuth: async () => {
+      const runId = ++authRunSeq;
+      try {
+        const result = await authPollOAuth();
+        if (runId !== authRunSeq) return false;
 
-  logout: async () => {
-    try {
-      await authLogout();
+        if (result.completed && result.token && result.state) {
+          await authCompleteOAuth(result.token, result.state);
+          if (runId !== authRunSeq) return false;
+
+          await get().fetchState();
+          return true;
+        }
+        return false;
+      } catch (e) {
+        if (runId === authRunSeq) {
+          set({ error: String(e) });
+        }
+        return false;
+      }
+    },
+
+    cancelOAuth: async (reason = "Login cancelled.") => {
+      const runId = ++authRunSeq;
+      try {
+        await authCancelOAuth();
+      } catch (error) {
+        reportError("Failed to cancel OAuth flow", error, {
+          dedupeKey: "auth-cancel-oauth",
+        });
+      }
+
+      if (runId === authRunSeq) {
+        set({
+          state: "logged_out",
+          isLoading: false,
+          error: reason,
+        });
+      }
+    },
+
+    logout: async () => {
+      const runId = ++authRunSeq;
+      try {
+        await authLogout();
+        if (runId === authRunSeq) {
+          set({
+            state: "logged_out",
+            email: null,
+            userId: null,
+            isTester: false,
+            isBanned: false,
+            bannedReason: null,
+            bannedAt: null,
+            isLoading: false,
+            error: null,
+          });
+        }
+      } catch (e) {
+        if (runId === authRunSeq) {
+          set({ isLoading: false, error: String(e) });
+        }
+      }
+    },
+
+    refreshProfile: async () => {
+      const runId = ++authRunSeq;
+      try {
+        set({ error: null });
+        await authRefreshProfile();
+      } catch (e) {
+        if (runId === authRunSeq) {
+          set({ error: String(e) });
+        }
+      }
+    },
+
+    handleStateEvent: (event) => {
+      authRunSeq++;
+      const isBanned = Boolean(event.is_banned);
+
       set({
-        state: "logged_out",
-        email: null,
-        userId: null,
-        isTester: false,
-        isBanned: false,
-        bannedReason: null,
-        bannedAt: null,
-        error: null,
+        state: event.state as AuthState,
+        email: event.email,
+        userId: event.user_id,
+        isLoading: false,
+        isBanned,
+        bannedReason: event.banned_reason ?? null,
+        bannedAt: event.banned_at ?? null,
+        isTester: isBanned ? false : Boolean(event.is_tester),
       });
-    } catch (e) {
-      set({ error: String(e) });
-    }
-  },
-
-  refreshProfile: async () => {
-    try {
-      set({ error: null });
-      await authRefreshProfile();
-    } catch (e) {
-      set({ error: String(e) });
-    }
-  },
-
-  handleStateEvent: (event) => {
-    const isBanned = Boolean(event.is_banned);
-
-    set({
-      state: event.state as AuthState,
-      email: event.email,
-      userId: event.user_id,
-      isBanned,
-      bannedReason: event.banned_reason ?? null,
-      bannedAt: event.banned_at ?? null,
-      isTester: isBanned ? false : Boolean(event.is_tester),
-    });
-  },
-}));
+    },
+  };
+});

--- a/swifttunnel-desktop/src/stores/authStore.ts
+++ b/swifttunnel-desktop/src/stores/authStore.ts
@@ -94,7 +94,7 @@ export const useAuthStore = create<AuthStore>((set, get) => {
           if (runId !== authRunSeq) return false;
 
           await get().fetchState();
-          return true;
+          return get().state === "logged_in" || get().state === "banned";
         }
         return false;
       } catch (e) {
@@ -153,6 +153,9 @@ export const useAuthStore = create<AuthStore>((set, get) => {
       try {
         set({ error: null });
         await authRefreshProfile();
+        if (runId === authRunSeq) {
+          set({ isLoading: false, error: null });
+        }
       } catch (e) {
         if (runId === authRunSeq) {
           set({ error: String(e) });


### PR DESCRIPTION
## Summary
- Add an auth operation sequence guard so stale fetch/poll completions cannot overwrite newer logout, cancel, or auth-event state.
- Keep terminal auth actions out of loading state when they supersede an in-flight startup fetch.
- Add focused auth store tests for stale fetch-after-logout and stale OAuth poll failure-after-cancel.

## Failure-mode plan
- Primary success: the latest auth action or auth event controls the visible auth state.
- Retryable/repairable: stale fetch and poll completions are ignored after logout, cancel, refresh, or backend auth events supersede them.
- Fatal/diagnostic-only: stale async errors are diagnostic-only and cannot replace the newer action result.
- Structured signals: an internal auth operation sequence is the freshness marker; state strings and error text are not used as recovery triggers.
- Partial success: logout/cancel/event paths explicitly clear loading so an ignored startup fetch cannot leave the UI stuck.
- Tests: stale fetch cannot restore a logged-in user after logout, and a stale poll failure cannot overwrite a user-visible OAuth cancellation.

## Validation
- npm test -- --run authStore
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check
- git diff --check