### PR TITLE
[codex] Guard concurrent RAM clean requests

### DIFF
--- a/swifttunnel-desktop/src/stores/boostStore.test.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.test.ts
@@ -161,6 +161,54 @@ describe("stores/boostStore", () => {
     expect(notify).not.toHaveBeenCalled();
   });
 
+  it("ignores a second RAM clean while one is already running", async () => {
+    boostGetSystemMemory.mockResolvedValue({
+      total_mb: 16000,
+      used_mb: 10000,
+      available_mb: 6000,
+      load_pct: 63,
+      standby_mb: null,
+      modified_mb: null,
+    });
+
+    const resp = {
+      before: { total_mb: 16000, used_mb: 10000, available_mb: 6000, load_pct: 63, standby_mb: null, modified_mb: null },
+      after: { total_mb: 16000, used_mb: 9000, available_mb: 7000, load_pct: 56, standby_mb: null, modified_mb: null },
+      trimmed_count: 8,
+      standby_purge: { attempted: true, success: true, skipped_reason: null },
+      modified_flush: { attempted: true, success: true, skipped_reason: null },
+      freed_mb: 1000,
+      standby_freed_mb: null,
+      modified_freed_mb: null,
+      duration_ms: 900,
+      warnings: [],
+    };
+
+    let resolveClean: (value: typeof resp) => void;
+    boostCleanRam.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveClean = resolve;
+        }),
+    );
+
+    const useBoostStore = await loadStore();
+    const firstClean = useBoostStore.getState().cleanRam();
+    const secondClean = useBoostStore.getState().cleanRam();
+
+    await secondClean;
+    await new Promise((r) => setTimeout(r, 0));
+    expect(boostCleanRam).toHaveBeenCalledTimes(1);
+    expect(useBoostStore.getState().isCleaningRam).toBe(true);
+
+    resolveClean!(resp);
+    await firstClean;
+
+    expect(boostCleanRam).toHaveBeenCalledTimes(1);
+    expect(useBoostStore.getState().isCleaningRam).toBe(false);
+    expect(useBoostStore.getState().ramCleanResult).toEqual(resp);
+  });
+
   it("stores error and notifies when RAM clean fails", async () => {
     boostGetSystemMemory.mockResolvedValue({
       total_mb: 16000,

--- a/swifttunnel-desktop/src/stores/boostStore.ts
+++ b/swifttunnel-desktop/src/stores/boostStore.ts
@@ -59,7 +59,7 @@ interface BoostStore {
   handleRamCleanProgress: (event: RamCleanProgressEvent) => void;
 }
 
-export const useBoostStore = create<BoostStore>((set) => ({
+export const useBoostStore = create<BoostStore>((set, get) => ({
   fps: 0,
   cpuUsage: 0,
   ramUsage: 0,
@@ -164,6 +164,8 @@ export const useBoostStore = create<BoostStore>((set) => ({
   },
 
   cleanRam: async () => {
+    if (get().isCleaningRam) return;
+
     try {
       set({
         error: null,


### PR DESCRIPTION
## Summary
- Make the boost store ignore direct `cleanRam()` calls while a RAM clean is already active.
- Keep the existing first cleaner result/progress flow unchanged.
- Add a regression test proving a second call does not start a second backend RAM clean.

## Failure-mode plan
- Primary success: one active RAM cleaner operation owns the progress/result UI.
- Retryable/repairable: a second call while cleaning is ignored and can be retried after the active clean finishes.
- Fatal/diagnostic-only: no command error text is used to decide concurrency; the structured marker is `isCleaningRam`.
- Partial success: the active cleaner still completes normally and clears `isCleaningRam`.
- Tests: concurrent direct store calls start only one backend clean and preserve the first result.

## Validation
- npm test -- --run boostStore
- npx tsc --noEmit
- npm test -- --run
- npm run build
- cargo fmt --check
- git diff --check