### PR TITLE
Harden VPN connect lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# SwiftTunnel App
+
+Windows desktop VPN client built with Tauri v2 and `swifttunnel-core`.
+
+## VPN Lifecycle Invariants
+
+- A normal, non-custom relay connection is successful only when the driver is opened/configured, the relay context is installed, and the relay accepted a fresh ticket for the active `session_id`.
+- `Connected` must never be set because the driver attached or a relay socket exists if relay-ticket acquisition or relay auth ack failed.
+- Relay auth ack status `7` means replayed/stale ticket. Treat it as a structured auth failure for the current attempt; do not collapse it into generic `bad_format` text matching and do not reuse the ticket/session as success.
+- Every failed connect after driver open must close the split-tunnel driver before returning to the UI.
+- Auto Route relay swaps must be gated by the lookup session epoch and live `Connected` state immediately before applying a relay switch. Disconnect/reset wins the race.
+- App exit must disconnect if either VPN state is not `Disconnected` or a split-tunnel handle still exists.
+- Startup boost and FFlag reapply must remain skipped for banned accounts; banned cleanup owns VPN disconnect and boost restore.
+
+## Failure-Mode Testing
+
+For VPN, driver, relay auth, Auto Route, tray/exit, or banned-state recovery changes:
+
+- Add a positive test for the repair or rollback path.
+- Add at least one negative test for a superficially similar non-repairable signal.
+- Use structured markers such as enum variants, auth error codes, state variants, and lookup epochs. Do not add new broad substring recovery triggers.
+- Bound retry or repair loops and test that stale sessions/generations cannot keep applying changes forever.

--- a/docs/vpn-lifecycle-state-machine.md
+++ b/docs/vpn-lifecycle-state-machine.md
@@ -1,0 +1,92 @@
+# VPN Lifecycle State Machine
+
+This document maps the Windows desktop connect, disconnect, and reconnect lifecycle across `swifttunnel-core/src/vpn/connection.rs` and the packet path in `swifttunnel-core/src/vpn/parallel_interceptor.rs`.
+
+Primary tunnel success is all of the following at once:
+
+- Packets are flowing through the selected relay.
+- The WinpkFilter/ndisapi driver is opened, initialized, configured, and bound to packet workers.
+- A valid relay ticket was accepted by the relay for the active `session_id`.
+
+Driver attachment, relay socket creation, or a UI `Connected` state are secondary signals. They must not mask relay ticket, packet flow, or driver binding failure.
+
+## State Diagram
+
+The app exposes `Disconnected`, `FetchingConfig`, `ConfiguringSplitTunnel`, `Connected`, `Disconnecting`, and `Error`. The diagram below maps those implementation states onto the conceptual lifecycle requested for audit.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disconnected
+
+    Disconnected --> Authenticating: user connect / startup resume
+    Failed --> Authenticating: reconnect after cleanup
+    Disconnected --> Disconnecting: exit cleanup with leaked split-tunnel handle
+
+    Authenticating --> Banned: profile refresh or structured user_banned
+    Authenticating --> Failed: missing auth token / profile refresh failure
+    Authenticating --> AcquiringTicket: backend vpn_connect has access_token
+
+    AcquiringTicket --> Banned: relay-ticket API returns UserBanned
+    AcquiringTicket --> Failed: region unavailable / ticket API unavailable / no relay candidate
+    AcquiringTicket --> BindingDriver: relay ticket accepted by relay
+
+    BindingDriver --> Failed: driver open/init/configure/interceptor start fails
+    BindingDriver --> Tunneling: relay context installed and interceptor starts
+
+    Tunneling --> Tunneling: relay health or auto-route metadata update
+    Tunneling --> Disconnecting: user disconnect / app exit / ban cleanup
+    Tunneling --> Failed: relay dead / sender panic / worker panic / connect-window watchdog rollback
+
+    Disconnecting --> Disconnected: cleanup closes driver and clears handles
+    Disconnecting --> Failed: cleanup reports fatal close failure
+    Failed --> Disconnecting: retry begins from Error state and runs cleanup first
+    Banned --> Disconnecting: banned-session cleanup disconnects VPN and restores boosts
+```
+
+States entered from more than one source:
+
+- `Authenticating`: from `Disconnected` and from `Failed` retry.
+- `Failed`: from `Authenticating`, `AcquiringTicket`, `BindingDriver`, `Tunneling`, and cleanup failure.
+- `Disconnecting`: from `Disconnected` with a leaked handle, `Tunneling`, `Failed` retry cleanup, and `Banned`.
+- `Tunneling`: from initial `BindingDriver` success and in-place relay metadata updates.
+
+## Failure-Mode Classification
+
+| Boundary | Failure signal | Classification | Required behavior |
+| --- | --- | --- | --- |
+| Profile/auth refresh | Structured `AuthError::UserBanned` or banned profile | Fatal account state | Enter `Banned`, disconnect VPN, restore boosts, skip startup boost reapply. |
+| Server selection | No API-available relay candidate for region | Fatal for attempt | Set `Error`; do not create driver/relay. |
+| Relay-ticket request | `UserBanned` | Fatal account state | Close driver if opened, return `VpnError::UserBanned`, run banned cleanup. |
+| Relay-ticket request | API/network/401 failure without structured ban | Retryable by future connect | Refuse unauthenticated fallback, close driver, return `Error`. |
+| Relay auth ack | `Ok` | Success marker | Candidate may enter `BindingDriver`. |
+| Relay auth ack | `Replay` status `7` | Fatal for current attempt, retryable only with fresh connect/ticket | Do not reuse stale ticket/session as success. Close driver and fail the attempt. |
+| Relay auth ack | `AuthDisabled`, `BadFormat`, `BadSignature`, `Expired`, `SidMismatch`, `ServerMismatch` | Fatal candidate; failover if another candidate authenticates | If none authenticate, close driver and fail. |
+| Relay auth ack | Timeout | Retryable within bounded auth hello budget and candidate failover | If none authenticate, close driver and fail. |
+| Driver FFI | Driver unavailable/open/init/configure fails | Repairable by driver repair/install or reconnect | Close any opened driver handle and fail the attempt. |
+| Interceptor startup | Reader/inbound/worker startup failure | Repairable by reconnect/driver repair depending on panic cause | Stop interceptor, close driver, set `Error`. |
+| Packet workers | Sender panic or relay dead | Fatal current tunnel | Tear down active session and set `Error`. |
+| Connect-window watchdog | Adapter went offline while setup was settling | Repairable | Roll back via cleanup and ask user to reconnect. |
+| Auto Route | Lookup generation/session stale or state not `Connected` | Diagnostic-only | Drop the relay swap; do not mutate relay after disconnect/reset wins. |
+| App exit/window destroyed | Main window destroyed while VPN handle exists | Repairable cleanup | Exit path must disconnect even if visible state already says `Disconnected`. |
+| Startup boosts | Stored auth state refreshes to `Banned` | Fatal account state | Skip saved boost/FFlag reapply and run banned cleanup. |
+
+## Defect Inventory
+
+1. **Relay auth replay status was unstructured.** `udp_relay.rs` treated unknown ack bytes as `BadFormat`; relay status `7` therefore looked like a generic malformed ack instead of a stale/replayed ticket marker. The fix adds `RelayAuthAckStatus::Replay` and tests the mapping.
+2. **Unauthenticated normal-relay fallback could mask primary tunnel failure.** `connection.rs` selected a legacy fallback candidate after ticket API failures, auth timeouts, auth-disabled acks, or policy lookup failures. The fix refuses `Connected` unless a non-custom relay candidate returned auth ack `Ok`.
+3. **Driver fallback parse failure could leak an opened driver handle.** The hardcoded-port fallback parse error did not close the opened driver. The fix closes it before returning setup failure.
+4. **Auto Route relay swaps could race disconnect.** The lookup task checked router session freshness earlier, but could still commit/switch the relay after a user disconnect/reset won the race. The fix gates both cached and probe-refinement switches on current lookup session plus live `Connected` state immediately before commit/switch.
+5. **Tray/window and boost gates were implicit and untested.** Exit disconnect, destroyed-main-window exit, and banned-state startup boost gating now have pure predicates with tests so issue-style regressions can be caught without a Windows driver.
+
+## Windows Testbench Checklist
+
+Run this on the Windows `testbench` VM before claiming Windows verification:
+
+1. Build from this branch with the normal desktop workflow.
+2. Connect to a healthy relay, confirm UI reaches `Connected`, relay auth mode is `authenticated`, and Roblox packets are flowing.
+3. Disconnect and confirm WinpkFilter adapter mode is restored, no SwiftTunnel packet worker thread remains, and a second connect succeeds.
+4. Force relay-ticket API failure or bad token; confirm the app returns `Error`, closes driver state, and a later click is accepted.
+5. Force relay auth ack status `7`; confirm the attempt fails instead of reporting `Connected`.
+6. Start Auto Route lookup, disconnect before lookup/probe completes, and confirm no relay endpoint changes after `Disconnecting`.
+7. Close the main window with VPN active and confirm app exit disconnects the tunnel.
+8. Start with a banned stored account and confirm saved network boosts and Roblox FFlags are not reapplied.

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -85,6 +85,7 @@ static CANDIDATE_EXHAUSTED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static PREFLIGHT_ENFORCED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static AUTH_REQUIRED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static AUTH_REPLAY_EVENTS: AtomicU64 = AtomicU64::new(0);
+static UNAUTHENTICATED_RELAY_EVENTS: AtomicU64 = AtomicU64::new(0);
 static POLICY_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
 static REGION_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
 
@@ -1596,7 +1597,7 @@ impl VpnConnection {
                     }
                     Err(CONNECT_FAIL_UNAUTHENTICATED_RELAY) => {
                         log_sampled_connect_event(
-                            &AUTH_REQUIRED_EVENTS,
+                            &UNAUTHENTICATED_RELAY_EVENTS,
                             CONNECT_FAIL_UNAUTHENTICATED_RELAY,
                             format!(
                                 "No relay candidate authenticated for '{}' (session {})",

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -15,6 +15,7 @@ use super::parallel_interceptor::{
 use super::process_performance::{GameProcessPerformanceManager, GameProcessPerformancePolicy};
 use super::process_watcher::{ProcessStartEvent, ProcessWatcher};
 use super::split_tunnel::{SplitTunnelConfig, SplitTunnelDriver};
+use super::udp_relay::RelayAuthAckStatus;
 use super::{VpnError, VpnResult};
 use crate::auth::http_client::AuthClient;
 use crate::auth::types::{AuthError, RelayPreflightMode, RelayQueueFullMode, VpnConfig};
@@ -67,7 +68,9 @@ const CONNECT_FAIL_HANDSHAKE_TIMEOUT: &str = "ST_CONNECT_HANDSHAKE_TIMEOUT";
 const CONNECT_FAIL_CANDIDATE_EXHAUSTED: &str = "ST_CONNECT_CANDIDATE_EXHAUSTED";
 const CONNECT_FAIL_PREFLIGHT_ENFORCED: &str = "ST_CONNECT_PREFLIGHT_ENFORCED";
 const CONNECT_FAIL_AUTH_REQUIRED: &str = "ST_CONNECT_AUTH_REQUIRED";
+const CONNECT_FAIL_AUTH_REPLAY: &str = "ST_CONNECT_AUTH_REPLAY";
 const CONNECT_FAIL_POLICY_UNAVAILABLE: &str = "ST_CONNECT_POLICY_UNAVAILABLE";
+const CONNECT_FAIL_UNAUTHENTICATED_RELAY: &str = "ST_CONNECT_UNAUTHENTICATED_RELAY";
 const CONNECT_FAIL_REGION_UNAVAILABLE: &str = "ST_CONNECT_REGION_UNAVAILABLE";
 
 /// Relay UDP port used *only* as a last-resort fallback when the resolved
@@ -81,6 +84,7 @@ static HANDSHAKE_TIMEOUT_EVENTS: AtomicU64 = AtomicU64::new(0);
 static CANDIDATE_EXHAUSTED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static PREFLIGHT_ENFORCED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static AUTH_REQUIRED_EVENTS: AtomicU64 = AtomicU64::new(0);
+static AUTH_REPLAY_EVENTS: AtomicU64 = AtomicU64::new(0);
 static POLICY_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
 static REGION_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
 
@@ -91,6 +95,7 @@ struct RelayCandidateAttempt {
     authenticated: bool,
     policy_known: bool,
     auth_required: bool,
+    auth_ack_status: Option<RelayAuthAckStatus>,
     preflight_mode: RelayPreflightMode,
     queue_full_mode: RelayQueueFullMode,
 }
@@ -273,7 +278,16 @@ fn select_candidate_after_preflight(
         ));
     }
 
-    let fallback = attempts.first().ok_or(CONNECT_FAIL_CANDIDATE_EXHAUSTED)?;
+    if attempts.is_empty() {
+        return Err(CONNECT_FAIL_CANDIDATE_EXHAUSTED);
+    }
+
+    if attempts
+        .iter()
+        .any(|attempt| attempt.auth_ack_status == Some(RelayAuthAckStatus::Replay))
+    {
+        return Err(CONNECT_FAIL_AUTH_REPLAY);
+    }
 
     if attempts.iter().any(|attempt| attempt.auth_required) {
         return Err(CONNECT_FAIL_AUTH_REQUIRED);
@@ -286,11 +300,19 @@ fn select_candidate_after_preflight(
         return Err(CONNECT_FAIL_PREFLIGHT_ENFORCED);
     }
 
-    Ok((
-        fallback.region.clone(),
-        fallback.addr,
-        fallback.queue_full_mode,
-    ))
+    if attempts.iter().any(|attempt| !attempt.policy_known) {
+        return Err(CONNECT_FAIL_POLICY_UNAVAILABLE);
+    }
+
+    Err(CONNECT_FAIL_UNAUTHENTICATED_RELAY)
+}
+
+fn auto_route_switch_allowed(
+    router: &super::auto_routing::AutoRouter,
+    session_epoch: u64,
+    state: &ConnectionState,
+) -> bool {
+    router.is_current_lookup_session(session_epoch) && state.is_connected()
 }
 
 fn relay_ticket_ban_reason(error: &AuthError) -> Option<String> {
@@ -1293,6 +1315,7 @@ impl VpnConnection {
                 format!("{}:{}", vpn_ip, FALLBACK_RELAY_PORT)
                     .parse()
                     .map_err(|e| {
+                        let _ = driver.close();
                         VpnError::SplitTunnelSetupFailed(format!(
                             "Invalid VPN server IP for relay: {}",
                             e
@@ -1328,7 +1351,7 @@ impl VpnConnection {
         let mut relay_auth_mode = if custom_relay_server.is_some() {
             "custom_legacy".to_string()
         } else {
-            "legacy_fallback".to_string()
+            "pending_authentication".to_string()
         };
         let mut queue_full_mode = RelayQueueFullMode::Bypass;
 
@@ -1375,6 +1398,7 @@ impl VpnConnection {
                             authenticated: false,
                             policy_known: false,
                             auth_required: false,
+                            auth_ack_status: None,
                             preflight_mode: RelayPreflightMode::Legacy,
                             queue_full_mode: RelayQueueFullMode::Bypass,
                         });
@@ -1403,6 +1427,7 @@ impl VpnConnection {
                             authenticated: true,
                             policy_known: true,
                             auth_required: ticket.auth_required,
+                            auth_ack_status: Some(RelayAuthAckStatus::Ok),
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1435,6 +1460,7 @@ impl VpnConnection {
                             authenticated: false,
                             policy_known: true,
                             auth_required: ticket.auth_required,
+                            auth_ack_status: Some(status),
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1455,6 +1481,7 @@ impl VpnConnection {
                             authenticated: false,
                             policy_known: true,
                             auth_required: ticket.auth_required,
+                            auth_ack_status: None,
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1472,6 +1499,7 @@ impl VpnConnection {
                             authenticated: false,
                             policy_known: true,
                             auth_required: ticket.auth_required,
+                            auth_ack_status: None,
                             preflight_mode: candidate_preflight_mode,
                             queue_full_mode: candidate_queue_full_mode,
                         });
@@ -1491,36 +1519,20 @@ impl VpnConnection {
                     ),
                 );
                 if saw_timeout {
-                    log::warn!(
-                        "V3: Falling back to legacy relay mode after authentication timeouts"
-                    );
+                    log::warn!("V3: Refusing unauthenticated relay mode after auth timeouts");
                 } else {
-                    log::warn!("V3: Falling back to legacy relay mode after candidate exhaustion");
+                    log::warn!(
+                        "V3: Refusing unauthenticated relay mode after candidate exhaustion"
+                    );
                 }
 
                 match select_candidate_after_preflight(&attempt_results) {
-                    Ok((fallback_region, fallback_addr, fallback_queue_mode)) => {
-                        let policy_known = attempt_results
-                            .iter()
-                            .find(|attempt| {
-                                attempt.region == fallback_region && attempt.addr == fallback_addr
-                            })
-                            .is_none_or(|attempt| attempt.policy_known);
-                        if !policy_known {
-                            relay_auth_mode = "policy_unavailable_legacy_fallback".to_string();
-                            log_sampled_connect_event(
-                                &POLICY_UNAVAILABLE_EVENTS,
-                                CONNECT_FAIL_POLICY_UNAVAILABLE,
-                                format!(
-                                    "Relay policy unavailable for '{}'; attempting marked legacy fallback on '{}' (session {})",
-                                    config.region, fallback_region, session_id_hex
-                                ),
-                            );
-                        }
-                        selected_relay_region = fallback_region;
-                        relay_addr = fallback_addr;
-                        queue_full_mode = fallback_queue_mode;
-                        relay.switch_relay(fallback_addr);
+                    Ok((_, _, _)) => {
+                        let _ = driver.close();
+                        return Err(VpnError::Connection(
+                            "Relay candidate selection violated authentication invariant"
+                                .to_string(),
+                        ));
                     }
                     Err(CONNECT_FAIL_PREFLIGHT_ENFORCED) => {
                         log_sampled_connect_event(
@@ -1552,6 +1564,21 @@ impl VpnConnection {
                                 .to_string(),
                         ));
                     }
+                    Err(CONNECT_FAIL_AUTH_REPLAY) => {
+                        log_sampled_connect_event(
+                            &AUTH_REPLAY_EVENTS,
+                            CONNECT_FAIL_AUTH_REPLAY,
+                            format!(
+                                "Relay rejected a replayed/stale auth ticket for '{}' (session {})",
+                                config.region, session_id_hex
+                            ),
+                        );
+                        let _ = driver.close();
+                        return Err(VpnError::Connection(
+                            "Relay rejected a stale authentication ticket; please reconnect to request a fresh session"
+                                .to_string(),
+                        ));
+                    }
                     Err(CONNECT_FAIL_POLICY_UNAVAILABLE) => {
                         log_sampled_connect_event(
                             &POLICY_UNAVAILABLE_EVENTS,
@@ -1567,6 +1594,21 @@ impl VpnConnection {
                                 .to_string(),
                         ));
                     }
+                    Err(CONNECT_FAIL_UNAUTHENTICATED_RELAY) => {
+                        log_sampled_connect_event(
+                            &AUTH_REQUIRED_EVENTS,
+                            CONNECT_FAIL_UNAUTHENTICATED_RELAY,
+                            format!(
+                                "No relay candidate authenticated for '{}' (session {})",
+                                config.region, session_id_hex
+                            ),
+                        );
+                        let _ = driver.close();
+                        return Err(VpnError::Connection(
+                            "Relay authentication failed; refusing unauthenticated relay session"
+                                .to_string(),
+                        ));
+                    }
                     Err(code) => {
                         log_sampled_connect_event(
                             &CANDIDATE_EXHAUSTED_EVENTS,
@@ -1576,6 +1618,11 @@ impl VpnConnection {
                                 config.region, session_id_hex
                             ),
                         );
+                        let _ = driver.close();
+                        return Err(VpnError::Connection(
+                            "No relay candidate authenticated; connection was rolled back"
+                                .to_string(),
+                        ));
                     }
                 }
             }
@@ -1681,7 +1728,18 @@ impl VpnConnection {
                                         )
                                     });
 
-                                if let Some((new_addr, new_region)) = router_for_lookup
+                                if !auto_route_switch_allowed(
+                                    &router_for_lookup,
+                                    session_epoch,
+                                    &state_for_lookup.borrow().clone(),
+                                ) {
+                                    log::info!(
+                                        "Auto-routing: Ignoring relay switch for {} (generation {}) because VPN disconnect/reset won the race",
+                                        ip,
+                                        generation
+                                    );
+                                    false
+                                } else if let Some((new_addr, new_region)) = router_for_lookup
                                     .commit_switch(
                                         region.clone(),
                                         selected_region,
@@ -1695,40 +1753,55 @@ impl VpnConnection {
                                         new_region,
                                         new_addr
                                     );
-                                    relay_for_lookup.switch_relay(new_addr);
-                                    state_for_lookup.send_if_modified(|state| {
-                                        if let ConnectionState::Connected {
-                                            ref mut server_region,
-                                            ref mut server_endpoint,
-                                            ..
-                                        } = *state
-                                        {
-                                            *server_region = new_region.clone();
-                                            *server_endpoint = new_addr.to_string();
-                                            true
-                                        } else {
-                                            false
-                                        }
-                                    });
-                                    if let Err(e) =
-                                        relay_for_lookup.send_keepalive_burst_async().await
-                                    {
-                                        log::warn!(
-                                            "Auto-routing: Failed to send keepalive burst to new relay: {}",
-                                            e
+                                    if !auto_route_switch_allowed(
+                                        &router_for_lookup,
+                                        session_epoch,
+                                        &state_for_lookup.borrow().clone(),
+                                    ) {
+                                        log::info!(
+                                            "Auto-routing: Dropping committed relay switch for {} (generation {}) because VPN disconnect/reset won the race",
+                                            ip,
+                                            generation
                                         );
+                                        false
+                                    } else {
+                                        relay_for_lookup.switch_relay(new_addr);
+                                        state_for_lookup.send_if_modified(|state| {
+                                            if let ConnectionState::Connected {
+                                                ref mut server_region,
+                                                ref mut server_endpoint,
+                                                ..
+                                            } = *state
+                                            {
+                                                *server_region = new_region.clone();
+                                                *server_endpoint = new_addr.to_string();
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        });
+                                        if let Err(e) =
+                                            relay_for_lookup.send_keepalive_burst_async().await
+                                        {
+                                            log::warn!(
+                                                "Auto-routing: Failed to send keepalive burst to new relay: {}",
+                                                e
+                                            );
+                                        }
+                                        log::info!(
+                                            "Auto-routing: Relay addr is now {}",
+                                            relay_for_lookup.relay_addr()
+                                        );
+                                        crate::notification::show_relay_switch(
+                                            &old_region,
+                                            &new_region,
+                                            &location,
+                                        );
+                                        true
                                     }
-                                    log::info!(
-                                        "Auto-routing: Relay addr is now {}",
-                                        relay_for_lookup.relay_addr()
-                                    );
-                                    crate::notification::show_relay_switch(
-                                        &old_region,
-                                        &new_region,
-                                        &location,
-                                    );
+                                } else {
+                                    false
                                 }
-                                true
                             } else {
                                 log::info!(
                                     "Auto-routing: No switch needed (already on best region for {})",
@@ -1785,6 +1858,18 @@ impl VpnConnection {
                                                         &ranked_candidates,
                                                         &current_relay,
                                                     );
+                                                if !auto_route_switch_allowed(
+                                                    &router_for_lookup,
+                                                    session_epoch,
+                                                    &state_for_lookup.borrow().clone(),
+                                                ) {
+                                                    log::info!(
+                                                        "Auto-routing: Ignoring probe refinement for {} (generation {}) because VPN disconnect/reset won the race",
+                                                        ip,
+                                                        generation
+                                                    );
+                                                    continue;
+                                                }
                                                 if let Some((new_addr, new_region)) =
                                                     router_for_lookup.commit_switch(
                                                         region,
@@ -1799,6 +1884,18 @@ impl VpnConnection {
                                                         new_region,
                                                         latency_improvement_ms.unwrap_or(0)
                                                     );
+                                                    if !auto_route_switch_allowed(
+                                                        &router_for_lookup,
+                                                        session_epoch,
+                                                        &state_for_lookup.borrow().clone(),
+                                                    ) {
+                                                        log::info!(
+                                                            "Auto-routing: Dropping committed probe refinement for {} (generation {}) because VPN disconnect/reset won the race",
+                                                            ip,
+                                                            generation
+                                                        );
+                                                        continue;
+                                                    }
                                                     relay_for_lookup.switch_relay(new_addr);
                                                     state_for_lookup.send_if_modified(|state| {
                                                         if let ConnectionState::Connected {
@@ -3377,6 +3474,28 @@ mod tests {
         addr.parse().expect("invalid test socket addr")
     }
 
+    fn relay_attempt(
+        region: &str,
+        addr: &str,
+        authenticated: bool,
+        policy_known: bool,
+        auth_required: bool,
+        auth_ack_status: Option<RelayAuthAckStatus>,
+        preflight_mode: RelayPreflightMode,
+        queue_full_mode: RelayQueueFullMode,
+    ) -> RelayCandidateAttempt {
+        RelayCandidateAttempt {
+            region: region.to_string(),
+            addr: parse_addr(addr),
+            authenticated,
+            policy_known,
+            auth_required,
+            auth_ack_status,
+            preflight_mode,
+            queue_full_mode,
+        }
+    }
+
     #[test]
     fn test_resolve_relay_server_exact_match() {
         let available_servers = vec![
@@ -3852,33 +3971,36 @@ mod tests {
     #[test]
     fn test_select_candidate_after_preflight_prefers_authenticated_candidate() {
         let attempts = vec![
-            RelayCandidateAttempt {
-                region: "germany-01".to_string(),
-                addr: parse_addr("10.0.0.1:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: false,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Bypass,
-            },
-            RelayCandidateAttempt {
-                region: "germany-02".to_string(),
-                addr: parse_addr("10.0.0.2:51821"),
-                authenticated: true,
-                policy_known: true,
-                auth_required: true,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Drop,
-            },
-            RelayCandidateAttempt {
-                region: "germany-03".to_string(),
-                addr: parse_addr("10.0.0.3:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: true,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Bypass,
-            },
+            relay_attempt(
+                "germany-01",
+                "10.0.0.1:51821",
+                false,
+                true,
+                false,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Bypass,
+            ),
+            relay_attempt(
+                "germany-02",
+                "10.0.0.2:51821",
+                true,
+                true,
+                true,
+                Some(RelayAuthAckStatus::Ok),
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Drop,
+            ),
+            relay_attempt(
+                "germany-03",
+                "10.0.0.3:51821",
+                false,
+                true,
+                true,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Bypass,
+            ),
         ];
 
         let selected = select_candidate_after_preflight(&attempts).unwrap();
@@ -3893,50 +4015,47 @@ mod tests {
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_legacy_falls_back_to_first() {
+    fn test_select_candidate_after_preflight_rejects_unauthenticated_legacy_fallback() {
         let attempts = vec![
-            RelayCandidateAttempt {
-                region: "germany-01".to_string(),
-                addr: parse_addr("10.0.0.1:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: false,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Bypass,
-            },
-            RelayCandidateAttempt {
-                region: "germany-02".to_string(),
-                addr: parse_addr("10.0.0.2:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: false,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Drop,
-            },
+            relay_attempt(
+                "germany-01",
+                "10.0.0.1:51821",
+                false,
+                true,
+                false,
+                Some(RelayAuthAckStatus::AuthDisabled),
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Bypass,
+            ),
+            relay_attempt(
+                "germany-02",
+                "10.0.0.2:51821",
+                false,
+                true,
+                false,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Drop,
+            ),
         ];
 
-        let selected = select_candidate_after_preflight(&attempts).unwrap();
-        assert_eq!(
-            selected,
-            (
-                "germany-01".to_string(),
-                parse_addr("10.0.0.1:51821"),
-                RelayQueueFullMode::Bypass
-            )
-        );
+        let error = select_candidate_after_preflight(&attempts)
+            .expect_err("legacy-looking non-authenticated candidates must not connect");
+        assert_eq!(error, CONNECT_FAIL_UNAUTHENTICATED_RELAY);
     }
 
     #[test]
     fn test_select_candidate_after_preflight_enforce_rejects_fallback() {
-        let attempts = vec![RelayCandidateAttempt {
-            region: "germany-01".to_string(),
-            addr: parse_addr("10.0.0.1:51821"),
-            authenticated: false,
-            policy_known: true,
-            auth_required: false,
-            preflight_mode: RelayPreflightMode::Enforce,
-            queue_full_mode: RelayQueueFullMode::Bypass,
-        }];
+        let attempts = vec![relay_attempt(
+            "germany-01",
+            "10.0.0.1:51821",
+            false,
+            true,
+            false,
+            None,
+            RelayPreflightMode::Enforce,
+            RelayQueueFullMode::Bypass,
+        )];
 
         let error = select_candidate_after_preflight(&attempts)
             .expect_err("enforced preflight should reject fallback");
@@ -3945,15 +4064,16 @@ mod tests {
 
     #[test]
     fn test_select_candidate_after_preflight_auth_required_rejects_legacy_fallback() {
-        let attempts = vec![RelayCandidateAttempt {
-            region: "germany-01".to_string(),
-            addr: parse_addr("10.0.0.1:51821"),
-            authenticated: false,
-            policy_known: true,
-            auth_required: true,
-            preflight_mode: RelayPreflightMode::Legacy,
-            queue_full_mode: RelayQueueFullMode::Bypass,
-        }];
+        let attempts = vec![relay_attempt(
+            "germany-01",
+            "10.0.0.1:51821",
+            false,
+            true,
+            true,
+            None,
+            RelayPreflightMode::Legacy,
+            RelayQueueFullMode::Bypass,
+        )];
 
         let error = select_candidate_after_preflight(&attempts)
             .expect_err("required auth should reject unauthenticated legacy fallback");
@@ -3963,24 +4083,26 @@ mod tests {
     #[test]
     fn test_select_candidate_after_preflight_strictest_policy_rejects_fallback() {
         let attempts = vec![
-            RelayCandidateAttempt {
-                region: "germany-01".to_string(),
-                addr: parse_addr("10.0.0.1:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: false,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Bypass,
-            },
-            RelayCandidateAttempt {
-                region: "germany-02".to_string(),
-                addr: parse_addr("10.0.0.2:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: true,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Drop,
-            },
+            relay_attempt(
+                "germany-01",
+                "10.0.0.1:51821",
+                false,
+                true,
+                false,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Bypass,
+            ),
+            relay_attempt(
+                "germany-02",
+                "10.0.0.2:51821",
+                false,
+                true,
+                true,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Drop,
+            ),
         ];
 
         let error = select_candidate_after_preflight(&attempts)
@@ -3989,50 +4111,91 @@ mod tests {
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_all_unknown_policy_allows_marked_fallback() {
-        let attempts = vec![RelayCandidateAttempt {
-            region: "germany-01".to_string(),
-            addr: parse_addr("10.0.0.1:51821"),
-            authenticated: false,
-            policy_known: false,
-            auth_required: false,
-            preflight_mode: RelayPreflightMode::Legacy,
-            queue_full_mode: RelayQueueFullMode::Bypass,
-        }];
+    fn test_select_candidate_after_preflight_all_unknown_policy_rejects_fallback() {
+        let attempts = vec![relay_attempt(
+            "germany-01",
+            "10.0.0.1:51821",
+            false,
+            false,
+            false,
+            None,
+            RelayPreflightMode::Legacy,
+            RelayQueueFullMode::Bypass,
+        )];
 
-        let selected = select_candidate_after_preflight(&attempts)
-            .expect("unknown policy alone should not block legacy fallback");
-        assert_eq!(
-            selected,
-            (
-                "germany-01".to_string(),
-                parse_addr("10.0.0.1:51821"),
-                RelayQueueFullMode::Bypass
-            )
-        );
+        let error = select_candidate_after_preflight(&attempts)
+            .expect_err("unknown relay policy must not mask missing authentication");
+        assert_eq!(error, CONNECT_FAIL_POLICY_UNAVAILABLE);
+    }
+
+    #[test]
+    fn test_select_candidate_after_preflight_replay_rejects_stale_session() {
+        let attempts = vec![relay_attempt(
+            "germany-01",
+            "10.0.0.1:51821",
+            false,
+            true,
+            false,
+            Some(RelayAuthAckStatus::Replay),
+            RelayPreflightMode::Legacy,
+            RelayQueueFullMode::Bypass,
+        )];
+
+        let error = select_candidate_after_preflight(&attempts)
+            .expect_err("replayed relay ticket must be fatal for this connect attempt");
+        assert_eq!(error, CONNECT_FAIL_AUTH_REPLAY);
+    }
+
+    #[test]
+    fn test_select_candidate_after_preflight_bad_format_does_not_trigger_replay_repair() {
+        let attempts = vec![relay_attempt(
+            "germany-01",
+            "10.0.0.1:51821",
+            false,
+            true,
+            false,
+            Some(RelayAuthAckStatus::BadFormat),
+            RelayPreflightMode::Legacy,
+            RelayQueueFullMode::Bypass,
+        )];
+
+        let error = select_candidate_after_preflight(&attempts)
+            .expect_err("bad-format ack is non-repairable but not a stale-ticket replay");
+        assert_eq!(error, CONNECT_FAIL_UNAUTHENTICATED_RELAY);
+    }
+
+    #[test]
+    fn test_select_candidate_after_preflight_empty_attempts_rejects_connection() {
+        let attempts = Vec::new();
+
+        let error = select_candidate_after_preflight(&attempts)
+            .expect_err("empty relay attempts cannot satisfy primary tunnel success");
+        assert_eq!(error, CONNECT_FAIL_CANDIDATE_EXHAUSTED);
     }
 
     #[test]
     fn test_select_candidate_after_preflight_auth_policy_beats_unknown_policy() {
         let attempts = vec![
-            RelayCandidateAttempt {
-                region: "germany-01".to_string(),
-                addr: parse_addr("10.0.0.1:51821"),
-                authenticated: false,
-                policy_known: false,
-                auth_required: false,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Bypass,
-            },
-            RelayCandidateAttempt {
-                region: "germany-02".to_string(),
-                addr: parse_addr("10.0.0.2:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: true,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Drop,
-            },
+            relay_attempt(
+                "germany-01",
+                "10.0.0.1:51821",
+                false,
+                false,
+                false,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Bypass,
+            ),
+            relay_attempt(
+                "germany-02",
+                "10.0.0.2:51821",
+                false,
+                true,
+                true,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Drop,
+            ),
         ];
 
         let error = select_candidate_after_preflight(&attempts)
@@ -4043,28 +4206,55 @@ mod tests {
     #[test]
     fn test_select_candidate_after_preflight_enforced_policy_beats_unknown_policy() {
         let attempts = vec![
-            RelayCandidateAttempt {
-                region: "germany-01".to_string(),
-                addr: parse_addr("10.0.0.1:51821"),
-                authenticated: false,
-                policy_known: false,
-                auth_required: false,
-                preflight_mode: RelayPreflightMode::Legacy,
-                queue_full_mode: RelayQueueFullMode::Bypass,
-            },
-            RelayCandidateAttempt {
-                region: "germany-02".to_string(),
-                addr: parse_addr("10.0.0.2:51821"),
-                authenticated: false,
-                policy_known: true,
-                auth_required: false,
-                preflight_mode: RelayPreflightMode::Enforce,
-                queue_full_mode: RelayQueueFullMode::Drop,
-            },
+            relay_attempt(
+                "germany-01",
+                "10.0.0.1:51821",
+                false,
+                false,
+                false,
+                None,
+                RelayPreflightMode::Legacy,
+                RelayQueueFullMode::Bypass,
+            ),
+            relay_attempt(
+                "germany-02",
+                "10.0.0.2:51821",
+                false,
+                true,
+                false,
+                None,
+                RelayPreflightMode::Enforce,
+                RelayQueueFullMode::Drop,
+            ),
         ];
 
         let error = select_candidate_after_preflight(&attempts)
             .expect_err("structured enforced preflight must still reject fallback");
         assert_eq!(error, CONNECT_FAIL_PREFLIGHT_ENFORCED);
+    }
+
+    #[test]
+    fn test_auto_route_switch_allowed_requires_connected_state_and_current_session() {
+        let router = super::super::auto_routing::AutoRouter::new(true, "singapore");
+        let connected = ConnectionState::Connected {
+            since: Instant::now(),
+            server_region: "singapore".to_string(),
+            server_endpoint: "10.0.0.1:51821".to_string(),
+            assigned_ip: "0.0.0.0".to_string(),
+            relay_auth_mode: "authenticated".to_string(),
+            split_tunnel_active: true,
+            tunneled_processes: vec!["RobloxPlayerBeta.exe".to_string()],
+            relay_status: None,
+        };
+
+        assert!(auto_route_switch_allowed(&router, 0, &connected));
+        assert!(!auto_route_switch_allowed(
+            &router,
+            0,
+            &ConnectionState::Disconnecting
+        ));
+
+        router.reset();
+        assert!(!auto_route_switch_allowed(&router, 0, &connected));
     }
 }

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -4247,14 +4247,14 @@ mod tests {
             relay_status: None,
         };
 
-        assert!(auto_route_switch_allowed(&router, 0, &connected));
+        assert!(auto_route_switch_allowed(&router, 1, &connected));
         assert!(!auto_route_switch_allowed(
             &router,
-            0,
+            1,
             &ConnectionState::Disconnecting
         ));
 
         router.reset();
-        assert!(!auto_route_switch_allowed(&router, 0, &connected));
+        assert!(!auto_route_switch_allowed(&router, 1, &connected));
     }
 }

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -1574,8 +1574,7 @@ impl VpnConnection {
                         );
                         let _ = driver.close();
                         return Err(VpnError::Connection(
-                            "No relay candidate authenticated; connection was rolled back"
-                                .to_string(),
+                            "No relay candidates available; connection was rolled back".to_string(),
                         ));
                     }
                 }

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -91,14 +91,10 @@ static REGION_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 struct RelayCandidateAttempt {
-    region: String,
-    addr: SocketAddr,
-    authenticated: bool,
     policy_known: bool,
     auth_required: bool,
     auth_ack_status: Option<RelayAuthAckStatus>,
     preflight_mode: RelayPreflightMode,
-    queue_full_mode: RelayQueueFullMode,
 }
 
 fn log_sampled_connect_event(counter: &AtomicU64, code: &str, message: impl AsRef<str>) {
@@ -268,44 +264,34 @@ fn watchdog_tick(
     }
 }
 
-fn select_candidate_after_preflight(
-    attempts: &[RelayCandidateAttempt],
-) -> Result<(String, SocketAddr, RelayQueueFullMode), &'static str> {
-    if let Some(attempt) = attempts.iter().find(|attempt| attempt.authenticated) {
-        return Ok((
-            attempt.region.clone(),
-            attempt.addr,
-            attempt.queue_full_mode,
-        ));
-    }
-
+fn failed_candidate_preflight_reason(attempts: &[RelayCandidateAttempt]) -> &'static str {
     if attempts.is_empty() {
-        return Err(CONNECT_FAIL_CANDIDATE_EXHAUSTED);
+        return CONNECT_FAIL_CANDIDATE_EXHAUSTED;
     }
 
     if attempts
         .iter()
         .any(|attempt| attempt.auth_ack_status == Some(RelayAuthAckStatus::Replay))
     {
-        return Err(CONNECT_FAIL_AUTH_REPLAY);
+        return CONNECT_FAIL_AUTH_REPLAY;
     }
 
     if attempts.iter().any(|attempt| attempt.auth_required) {
-        return Err(CONNECT_FAIL_AUTH_REQUIRED);
+        return CONNECT_FAIL_AUTH_REQUIRED;
     }
 
     if attempts
         .iter()
         .any(|attempt| attempt.preflight_mode == RelayPreflightMode::Enforce)
     {
-        return Err(CONNECT_FAIL_PREFLIGHT_ENFORCED);
+        return CONNECT_FAIL_PREFLIGHT_ENFORCED;
     }
 
     if attempts.iter().any(|attempt| !attempt.policy_known) {
-        return Err(CONNECT_FAIL_POLICY_UNAVAILABLE);
+        return CONNECT_FAIL_POLICY_UNAVAILABLE;
     }
 
-    Err(CONNECT_FAIL_UNAUTHENTICATED_RELAY)
+    CONNECT_FAIL_UNAUTHENTICATED_RELAY
 }
 
 fn auto_route_switch_allowed(
@@ -1394,14 +1380,10 @@ impl VpnConnection {
                             e
                         );
                         attempt_results.push(RelayCandidateAttempt {
-                            region: candidate_region.clone(),
-                            addr: *candidate_addr,
-                            authenticated: false,
                             policy_known: false,
                             auth_required: false,
                             auth_ack_status: None,
                             preflight_mode: RelayPreflightMode::Legacy,
-                            queue_full_mode: RelayQueueFullMode::Bypass,
                         });
                         continue;
                     }
@@ -1422,16 +1404,6 @@ impl VpnConnection {
                         selected_relay_region = candidate_region.clone();
                         relay_addr = *candidate_addr;
                         queue_full_mode = candidate_queue_full_mode;
-                        attempt_results.push(RelayCandidateAttempt {
-                            region: candidate_region.clone(),
-                            addr: *candidate_addr,
-                            authenticated: true,
-                            policy_known: true,
-                            auth_required: ticket.auth_required,
-                            auth_ack_status: Some(RelayAuthAckStatus::Ok),
-                            preflight_mode: candidate_preflight_mode,
-                            queue_full_mode: candidate_queue_full_mode,
-                        });
                         authenticated = true;
                         if idx > 0 {
                             log::info!(
@@ -1456,14 +1428,10 @@ impl VpnConnection {
                             session_id_hex
                         );
                         attempt_results.push(RelayCandidateAttempt {
-                            region: candidate_region.clone(),
-                            addr: *candidate_addr,
-                            authenticated: false,
                             policy_known: true,
                             auth_required: ticket.auth_required,
                             auth_ack_status: Some(status),
                             preflight_mode: candidate_preflight_mode,
-                            queue_full_mode: candidate_queue_full_mode,
                         });
                     }
                     Ok(None) => {
@@ -1477,14 +1445,10 @@ impl VpnConnection {
                             ),
                         );
                         attempt_results.push(RelayCandidateAttempt {
-                            region: candidate_region.clone(),
-                            addr: *candidate_addr,
-                            authenticated: false,
                             policy_known: true,
                             auth_required: ticket.auth_required,
                             auth_ack_status: None,
                             preflight_mode: candidate_preflight_mode,
-                            queue_full_mode: candidate_queue_full_mode,
                         });
                     }
                     Err(e) => {
@@ -1495,14 +1459,10 @@ impl VpnConnection {
                             e
                         );
                         attempt_results.push(RelayCandidateAttempt {
-                            region: candidate_region.clone(),
-                            addr: *candidate_addr,
-                            authenticated: false,
                             policy_known: true,
                             auth_required: ticket.auth_required,
                             auth_ack_status: None,
                             preflight_mode: candidate_preflight_mode,
-                            queue_full_mode: candidate_queue_full_mode,
                         });
                     }
                 }
@@ -1527,15 +1487,8 @@ impl VpnConnection {
                     );
                 }
 
-                match select_candidate_after_preflight(&attempt_results) {
-                    Ok((_, _, _)) => {
-                        let _ = driver.close();
-                        return Err(VpnError::Connection(
-                            "Relay candidate selection violated authentication invariant"
-                                .to_string(),
-                        ));
-                    }
-                    Err(CONNECT_FAIL_PREFLIGHT_ENFORCED) => {
+                match failed_candidate_preflight_reason(&attempt_results) {
+                    CONNECT_FAIL_PREFLIGHT_ENFORCED => {
                         log_sampled_connect_event(
                             &PREFLIGHT_ENFORCED_EVENTS,
                             CONNECT_FAIL_PREFLIGHT_ENFORCED,
@@ -1550,7 +1503,7 @@ impl VpnConnection {
                                 .to_string(),
                         ));
                     }
-                    Err(CONNECT_FAIL_AUTH_REQUIRED) => {
+                    CONNECT_FAIL_AUTH_REQUIRED => {
                         log_sampled_connect_event(
                             &AUTH_REQUIRED_EVENTS,
                             CONNECT_FAIL_AUTH_REQUIRED,
@@ -1565,7 +1518,7 @@ impl VpnConnection {
                                 .to_string(),
                         ));
                     }
-                    Err(CONNECT_FAIL_AUTH_REPLAY) => {
+                    CONNECT_FAIL_AUTH_REPLAY => {
                         log_sampled_connect_event(
                             &AUTH_REPLAY_EVENTS,
                             CONNECT_FAIL_AUTH_REPLAY,
@@ -1580,7 +1533,7 @@ impl VpnConnection {
                                 .to_string(),
                         ));
                     }
-                    Err(CONNECT_FAIL_POLICY_UNAVAILABLE) => {
+                    CONNECT_FAIL_POLICY_UNAVAILABLE => {
                         log_sampled_connect_event(
                             &POLICY_UNAVAILABLE_EVENTS,
                             CONNECT_FAIL_POLICY_UNAVAILABLE,
@@ -1595,7 +1548,7 @@ impl VpnConnection {
                                 .to_string(),
                         ));
                     }
-                    Err(CONNECT_FAIL_UNAUTHENTICATED_RELAY) => {
+                    CONNECT_FAIL_UNAUTHENTICATED_RELAY => {
                         log_sampled_connect_event(
                             &UNAUTHENTICATED_RELAY_EVENTS,
                             CONNECT_FAIL_UNAUTHENTICATED_RELAY,
@@ -1610,7 +1563,7 @@ impl VpnConnection {
                                 .to_string(),
                         ));
                     }
-                    Err(code) => {
+                    code => {
                         log_sampled_connect_event(
                             &CANDIDATE_EXHAUSTED_EVENTS,
                             code,
@@ -3476,24 +3429,16 @@ mod tests {
     }
 
     fn relay_attempt(
-        region: &str,
-        addr: &str,
-        authenticated: bool,
         policy_known: bool,
         auth_required: bool,
         auth_ack_status: Option<RelayAuthAckStatus>,
         preflight_mode: RelayPreflightMode,
-        queue_full_mode: RelayQueueFullMode,
     ) -> RelayCandidateAttempt {
         RelayCandidateAttempt {
-            region: region.to_string(),
-            addr: parse_addr(addr),
-            authenticated,
             policy_known,
             auth_required,
             auth_ack_status,
             preflight_mode,
-            queue_full_mode,
         }
     }
 
@@ -3970,267 +3915,119 @@ mod tests {
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_prefers_authenticated_candidate() {
+    fn test_failed_candidate_preflight_rejects_unauthenticated_legacy_fallback() {
         let attempts = vec![
             relay_attempt(
-                "germany-01",
-                "10.0.0.1:51821",
-                false,
-                true,
-                false,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Bypass,
-            ),
-            relay_attempt(
-                "germany-02",
-                "10.0.0.2:51821",
-                true,
-                true,
-                true,
-                Some(RelayAuthAckStatus::Ok),
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Drop,
-            ),
-            relay_attempt(
-                "germany-03",
-                "10.0.0.3:51821",
-                false,
-                true,
-                true,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Bypass,
-            ),
-        ];
-
-        let selected = select_candidate_after_preflight(&attempts).unwrap();
-        assert_eq!(
-            selected,
-            (
-                "germany-02".to_string(),
-                parse_addr("10.0.0.2:51821"),
-                RelayQueueFullMode::Drop
-            )
-        );
-    }
-
-    #[test]
-    fn test_select_candidate_after_preflight_rejects_unauthenticated_legacy_fallback() {
-        let attempts = vec![
-            relay_attempt(
-                "germany-01",
-                "10.0.0.1:51821",
-                false,
                 true,
                 false,
                 Some(RelayAuthAckStatus::AuthDisabled),
                 RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Bypass,
             ),
-            relay_attempt(
-                "germany-02",
-                "10.0.0.2:51821",
-                false,
-                true,
-                false,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Drop,
-            ),
+            relay_attempt(true, false, None, RelayPreflightMode::Legacy),
         ];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("legacy-looking non-authenticated candidates must not connect");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_UNAUTHENTICATED_RELAY);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_enforce_rejects_fallback() {
+    fn test_failed_candidate_preflight_enforce_rejects_fallback() {
         let attempts = vec![relay_attempt(
-            "germany-01",
-            "10.0.0.1:51821",
-            false,
             true,
             false,
             None,
             RelayPreflightMode::Enforce,
-            RelayQueueFullMode::Bypass,
         )];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("enforced preflight should reject fallback");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_PREFLIGHT_ENFORCED);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_auth_required_rejects_legacy_fallback() {
-        let attempts = vec![relay_attempt(
-            "germany-01",
-            "10.0.0.1:51821",
-            false,
-            true,
-            true,
-            None,
-            RelayPreflightMode::Legacy,
-            RelayQueueFullMode::Bypass,
-        )];
+    fn test_failed_candidate_preflight_auth_required_rejects_legacy_fallback() {
+        let attempts = vec![relay_attempt(true, true, None, RelayPreflightMode::Legacy)];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("required auth should reject unauthenticated legacy fallback");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_AUTH_REQUIRED);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_strictest_policy_rejects_fallback() {
+    fn test_failed_candidate_preflight_strictest_policy_rejects_fallback() {
         let attempts = vec![
-            relay_attempt(
-                "germany-01",
-                "10.0.0.1:51821",
-                false,
-                true,
-                false,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Bypass,
-            ),
-            relay_attempt(
-                "germany-02",
-                "10.0.0.2:51821",
-                false,
-                true,
-                true,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Drop,
-            ),
+            relay_attempt(true, false, None, RelayPreflightMode::Legacy),
+            relay_attempt(true, true, None, RelayPreflightMode::Legacy),
         ];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("auth-required candidate should reject unauthenticated fallback");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_AUTH_REQUIRED);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_all_unknown_policy_rejects_fallback() {
+    fn test_failed_candidate_preflight_all_unknown_policy_rejects_fallback() {
         let attempts = vec![relay_attempt(
-            "germany-01",
-            "10.0.0.1:51821",
-            false,
             false,
             false,
             None,
             RelayPreflightMode::Legacy,
-            RelayQueueFullMode::Bypass,
         )];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("unknown relay policy must not mask missing authentication");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_POLICY_UNAVAILABLE);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_replay_rejects_stale_session() {
+    fn test_failed_candidate_preflight_replay_rejects_stale_session() {
         let attempts = vec![relay_attempt(
-            "germany-01",
-            "10.0.0.1:51821",
-            false,
             true,
             false,
             Some(RelayAuthAckStatus::Replay),
             RelayPreflightMode::Legacy,
-            RelayQueueFullMode::Bypass,
         )];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("replayed relay ticket must be fatal for this connect attempt");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_AUTH_REPLAY);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_bad_format_does_not_trigger_replay_repair() {
+    fn test_failed_candidate_preflight_bad_format_does_not_trigger_replay_repair() {
         let attempts = vec![relay_attempt(
-            "germany-01",
-            "10.0.0.1:51821",
-            false,
             true,
             false,
             Some(RelayAuthAckStatus::BadFormat),
             RelayPreflightMode::Legacy,
-            RelayQueueFullMode::Bypass,
         )];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("bad-format ack is non-repairable but not a stale-ticket replay");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_UNAUTHENTICATED_RELAY);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_empty_attempts_rejects_connection() {
+    fn test_failed_candidate_preflight_empty_attempts_rejects_connection() {
         let attempts = Vec::new();
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("empty relay attempts cannot satisfy primary tunnel success");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_CANDIDATE_EXHAUSTED);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_auth_policy_beats_unknown_policy() {
+    fn test_failed_candidate_preflight_auth_policy_beats_unknown_policy() {
         let attempts = vec![
-            relay_attempt(
-                "germany-01",
-                "10.0.0.1:51821",
-                false,
-                false,
-                false,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Bypass,
-            ),
-            relay_attempt(
-                "germany-02",
-                "10.0.0.2:51821",
-                false,
-                true,
-                true,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Drop,
-            ),
+            relay_attempt(false, false, None, RelayPreflightMode::Legacy),
+            relay_attempt(true, true, None, RelayPreflightMode::Legacy),
         ];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("structured auth-required policy must still reject fallback");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_AUTH_REQUIRED);
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_enforced_policy_beats_unknown_policy() {
+    fn test_failed_candidate_preflight_enforced_policy_beats_unknown_policy() {
         let attempts = vec![
-            relay_attempt(
-                "germany-01",
-                "10.0.0.1:51821",
-                false,
-                false,
-                false,
-                None,
-                RelayPreflightMode::Legacy,
-                RelayQueueFullMode::Bypass,
-            ),
-            relay_attempt(
-                "germany-02",
-                "10.0.0.2:51821",
-                false,
-                true,
-                false,
-                None,
-                RelayPreflightMode::Enforce,
-                RelayQueueFullMode::Drop,
-            ),
+            relay_attempt(false, false, None, RelayPreflightMode::Legacy),
+            relay_attempt(true, false, None, RelayPreflightMode::Enforce),
         ];
 
-        let error = select_candidate_after_preflight(&attempts)
-            .expect_err("structured enforced preflight must still reject fallback");
+        let error = failed_candidate_preflight_reason(&attempts);
         assert_eq!(error, CONNECT_FAIL_PREFLIGHT_ENFORCED);
     }
 

--- a/swifttunnel-core/src/vpn/udp_relay.rs
+++ b/swifttunnel-core/src/vpn/udp_relay.rs
@@ -316,6 +316,7 @@ pub enum RelayAuthAckStatus {
     SidMismatch = 4,
     ServerMismatch = 5,
     AuthDisabled = 6,
+    Replay = 7,
 }
 
 impl RelayAuthAckStatus {
@@ -328,6 +329,7 @@ impl RelayAuthAckStatus {
             4 => Some(Self::SidMismatch),
             5 => Some(Self::ServerMismatch),
             6 => Some(Self::AuthDisabled),
+            7 => Some(Self::Replay),
             _ => None,
         }
     }
@@ -341,6 +343,7 @@ impl RelayAuthAckStatus {
             Self::SidMismatch => "sid_mismatch",
             Self::ServerMismatch => "server_mismatch",
             Self::AuthDisabled => "auth_disabled",
+            Self::Replay => "replay",
         }
     }
 }
@@ -2059,6 +2062,16 @@ mod tests {
         getrandom(&mut id2);
         // Should be different (with extremely high probability)
         assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_relay_auth_ack_status_maps_replay_structurally() {
+        assert_eq!(
+            RelayAuthAckStatus::from_u8(7),
+            Some(RelayAuthAckStatus::Replay)
+        );
+        assert_eq!(RelayAuthAckStatus::Replay.as_str(), "replay");
+        assert_eq!(RelayAuthAckStatus::from_u8(8), None);
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -190,11 +190,7 @@ fn disconnect_vpn_on_exit(app: &tauri::AppHandle) {
 
     let conn_state = state.vpn_state_handle.borrow().clone();
     let has_split_tunnel_handle = state.split_tunnel_handle.read().is_some();
-    if matches!(
-        conn_state,
-        swifttunnel_core::vpn::ConnectionState::Disconnected
-    ) && !has_split_tunnel_handle
-    {
+    if !should_disconnect_vpn_on_exit(&conn_state, has_split_tunnel_handle) {
         return;
     }
 
@@ -203,6 +199,24 @@ fn disconnect_vpn_on_exit(app: &tauri::AppHandle) {
     if let Err(e) = runtime.block_on(commands::vpn::disconnect_and_persist(&state)) {
         warn!("Failed to disconnect VPN during app exit: {}", e);
     }
+}
+
+fn should_disconnect_vpn_on_exit(
+    conn_state: &swifttunnel_core::vpn::ConnectionState,
+    has_split_tunnel_handle: bool,
+) -> bool {
+    !matches!(
+        conn_state,
+        swifttunnel_core::vpn::ConnectionState::Disconnected
+    ) || has_split_tunnel_handle
+}
+
+fn should_reapply_startup_boosts(account_is_banned: bool) -> bool {
+    !account_is_banned
+}
+
+fn should_exit_after_window_destroyed(label: &str) -> bool {
+    label == "main"
 }
 
 #[cfg(windows)]
@@ -397,7 +411,7 @@ pub fn run() {
                 matches!(auth.get_state(), AuthState::Banned(_))
             });
 
-            if account_is_banned {
+            if !should_reapply_startup_boosts(account_is_banned) {
                 info!("Stored account is banned; clearing boosts before startup recovery");
                 runtime.block_on(commands::auth::cleanup_banned_session(&app_state));
             } else {
@@ -501,7 +515,7 @@ pub fn run() {
                     event: tauri::WindowEvent::Destroyed,
                     ..
                 } => {
-                    if label == "main" {
+                    if should_exit_after_window_destroyed(&label) {
                         // The main window was destroyed (not hidden). Exit the app
                         // so the tray icon doesn't leave a zombie process. The
                         // minimize-to-tray path uses hide(), not close(), so
@@ -534,4 +548,53 @@ pub fn run() {
 
 pub fn run_testbench_harness(args: &[String]) -> i32 {
     harness::run_testbench_harness(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+    use swifttunnel_core::vpn::ConnectionState;
+
+    fn connected_state() -> ConnectionState {
+        ConnectionState::Connected {
+            since: Instant::now(),
+            server_region: "singapore".to_string(),
+            server_endpoint: "10.0.0.1:51821".to_string(),
+            assigned_ip: "0.0.0.0".to_string(),
+            relay_auth_mode: "authenticated".to_string(),
+            split_tunnel_active: true,
+            tunneled_processes: vec!["RobloxPlayerBeta.exe".to_string()],
+            relay_status: None,
+        }
+    }
+
+    #[test]
+    fn test_exit_disconnect_gate_keeps_tray_close_from_leaving_vpn_thread_alive() {
+        assert!(!should_disconnect_vpn_on_exit(
+            &ConnectionState::Disconnected,
+            false
+        ));
+        assert!(should_disconnect_vpn_on_exit(
+            &ConnectionState::Disconnected,
+            true
+        ));
+        assert!(should_disconnect_vpn_on_exit(&connected_state(), false));
+        assert!(should_disconnect_vpn_on_exit(
+            &ConnectionState::Disconnecting,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_startup_boost_reapply_is_gated_by_banned_state() {
+        assert!(!should_reapply_startup_boosts(true));
+        assert!(should_reapply_startup_boosts(false));
+    }
+
+    #[test]
+    fn test_only_main_window_destroy_requests_app_exit() {
+        assert!(should_exit_after_window_destroyed("main"));
+        assert!(!should_exit_after_window_destroyed("settings"));
+    }
 }


### PR DESCRIPTION
## Summary

- Added the VPN lifecycle state diagram and failure-mode inventory in `docs/vpn-lifecycle-state-machine.md`.
- Made relay auth ack status `7` a structured `Replay` marker and stopped normal relay connects from reporting success without an authenticated candidate.
- Closed the driver on an uncovered fallback parse failure, gated Auto Route relay swaps against disconnect/reset races, and added desktop exit/boost lifecycle predicates with tests.
- Added app-level `CLAUDE.md` invariants for relay auth, driver cleanup, Auto Route, exit disconnect, and banned-state boost gating.
- Addressed Greptile feedback by splitting unauthenticated-relay telemetry, removing the dead success-return path from the failed-candidate classifier, and clarifying the empty-candidate user error.

## Defect inventory

- `swifttunnel-core/src/vpn/udp_relay.rs:310` -> `b410024`: relay replay ack status `7` was not structured, so stale/replayed tickets could collapse into `bad_format` handling. Added `RelayAuthAckStatus::Replay` and mapping tests at `swifttunnel-core/src/vpn/udp_relay.rs:2067`.
- `swifttunnel-core/src/vpn/connection.rs:267` and `swifttunnel-core/src/vpn/connection.rs:1490` -> `8832dc6` + `c88f036`: normal relay connects could fall back to unauthenticated legacy mode after ticket/policy/auth-ack failure, masking the primary success failure. Selection now requires an authenticated candidate; failed candidates classify to a failure reason only.
- `swifttunnel-core/src/vpn/connection.rs:1305` -> `8832dc6`: fallback relay endpoint parse failure after driver open did not close the driver. The error path now closes the driver before returning.
- `swifttunnel-core/src/vpn/connection.rs:297`, `swifttunnel-core/src/vpn/connection.rs:1710`, and `swifttunnel-core/src/vpn/connection.rs:1841` -> `8832dc6` + `f6be992`: Auto Route cached/probe relay switches could race a user disconnect. Switches now require current lookup session and live `Connected` state immediately before applying, with the test aligned to the router initial epoch.
- `swifttunnel-desktop/src-tauri/src/lib.rs:204`, `swifttunnel-desktop/src-tauri/src/lib.rs:414`, and `swifttunnel-desktop/src-tauri/src/lib.rs:518` -> `5a5e87e`: exit disconnect, banned-state boost gating, and main-window-destroy exit behavior were implicit and untested. Added pure gates and tests at `swifttunnel-desktop/src-tauri/src/lib.rs:553`.
- `swifttunnel-core/src/vpn/connection.rs:88` and `swifttunnel-core/src/vpn/connection.rs:1551` -> `9d35bad`: Greptile caught that `CONNECT_FAIL_UNAUTHENTICATED_RELAY` reused `AUTH_REQUIRED_EVENTS`; the telemetry now has a dedicated counter.
- `swifttunnel-core/src/vpn/connection.rs:1566` -> `90b47cc`: Greptile caught that the empty-candidate catchall used an auth-failure-style message. The message now reports that no relay candidates were available.

## Commits

- `b410024` Handle relay auth replay ack
- `8832dc6` Harden relay connect lifecycle
- `5a5e87e` Test desktop lifecycle gates
- `4e5e13e` Document VPN lifecycle invariants
- `f6be992` Fix auto route race test epoch
- `9d35bad` Split unauthenticated relay telemetry
- `c88f036` Align relay failure classifier contract
- `90b47cc` Clarify empty relay candidate failure

## Verification

- `cargo fmt --all -- --check` ✅
- `git diff --check` ✅
- `npm test` ✅ 19 files / 123 tests passed
- `npm run build` ✅
- PR checks on `90b47cc` ✅ Frontend Build, Rust Check (GitHub Windows), Split Tunnel Testbench Availability, Greptile Review
- Forced CI with `force_testbench=true` ✅ https://github.com/Swift-tunnel/swifttunnel-app/actions/runs/25974947529
  - Rust Check (GitHub Windows) ✅
  - Frontend Build ✅
  - Split Tunnel Testbench (Windows) ✅ ran `Windows-testbench/run_split_tunnel_integration_test.ps1` on the self-hosted `swifttunnel-testbench` runner
- `cargo check --workspace` ⚠️ blocked on macOS before this crate compiles by the existing `windows-future 0.3.2` / `windows-core 0.62.2` mismatch (`windows_core::imp::IMarshal`, `windows_core::imp::marshaler`, and `windows_threading::submit` missing).
- `cargo test --workspace` ⚠️ same macOS dependency blocker.

The Windows runtime checklist remains documented in `docs/vpn-lifecycle-state-machine.md` for manual scenario follow-up beyond the automated split-tunnel testbench.
