### PR TITLE
Fix and extend PC boosts so they actually apply on Windows 11

### DIFF
--- a/swifttunnel-core/src/bin/testbench_shared/mod.rs
+++ b/swifttunnel-core/src/bin/testbench_shared/mod.rs
@@ -635,7 +635,6 @@ pub async fn connect_vpn(
         tunnel_apps,
         resolve_custom_relay_server(opts, settings),
         false,
-        settings.config.network_settings.gaming_qos,
         available_servers,
         settings.whitelisted_regions.clone(),
         settings.forced_servers.clone(),

--- a/swifttunnel-core/src/firewall_fixer.rs
+++ b/swifttunnel-core/src/firewall_fixer.rs
@@ -13,6 +13,13 @@ const ROBLOX_EXECUTABLES: [&str; 3] = [
     "RobloxCrashHandler.exe",
 ];
 
+// Executable names written by earlier SwiftTunnel versions that we now reject.
+// On upgrade these rules are still in the Windows firewall and would keep
+// allowing the named (generic) host process through. The pre-apply cleanup
+// pass explicitly deletes them so the over-scoping bug is closed for users
+// migrating from older builds.
+const LEGACY_FIREWALL_EXECUTABLES: &[&str] = &["Windows10Universal.exe"];
+
 const FIREWALL_RULE_PREFIX: &str = "SwiftTunnel - Roblox";
 
 pub struct FirewallFixer {
@@ -29,7 +36,15 @@ impl FirewallFixer {
     fn remove_swifttunnel_rules_by_prefix() {
         // Delete all known rule names individually via netsh instead of
         // PowerShell Get-NetFirewallRule piping, which triggers AV heuristics.
-        for exe_name in &ROBLOX_EXECUTABLES {
+        //
+        // Iterate the current executable list AND the legacy list so older
+        // installs that wrote rules for Windows10Universal.exe (the shared
+        // Microsoft Store host) have those rules removed on upgrade.
+        let cleanup_targets = ROBLOX_EXECUTABLES
+            .iter()
+            .copied()
+            .chain(LEGACY_FIREWALL_EXECUTABLES.iter().copied());
+        for exe_name in cleanup_targets {
             for (suffix, dir) in [("Out", "out"), ("In", "in")] {
                 let rule_name = format!("{} {} {}", FIREWALL_RULE_PREFIX, exe_name, suffix);
                 let _ = hidden_command("netsh")
@@ -367,5 +382,18 @@ mod tests {
         // Restore depends on this prefix matching what we wrote previously.
         // Changing the prefix would orphan rules from older app versions.
         assert_eq!(FIREWALL_RULE_PREFIX, "SwiftTunnel - Roblox");
+    }
+
+    #[test]
+    fn legacy_firewall_executables_targets_windows10universal() {
+        // Older SwiftTunnel builds wrote firewall rules for
+        // Windows10Universal.exe. Removing it from ROBLOX_EXECUTABLES is not
+        // enough — the rules on the user's box must also be deleted on
+        // upgrade. This test pins the cleanup list so a regression
+        // (dropping the entry, renaming the constant) breaks the build.
+        assert!(
+            LEGACY_FIREWALL_EXECUTABLES.contains(&"Windows10Universal.exe"),
+            "legacy firewall cleanup must keep Windows10Universal.exe so upgrade installs strip it"
+        );
     }
 }

--- a/swifttunnel-core/src/firewall_fixer.rs
+++ b/swifttunnel-core/src/firewall_fixer.rs
@@ -3,11 +3,14 @@ use crate::structs::*;
 use log::{info, warn};
 use std::path::PathBuf;
 
-const ROBLOX_EXECUTABLES: [&str; 4] = [
+// UWP Roblox runs under Windows10Universal.exe, a generic Store host shared by
+// unrelated Microsoft Store apps. Adding firewall rules keyed to that name
+// would scope to Mail, Weather, etc. Per CLAUDE.md, UWP Roblox is intentionally
+// not tunnel-eligible, so we omit it here.
+const ROBLOX_EXECUTABLES: [&str; 3] = [
     "RobloxPlayerBeta.exe",
     "RobloxStudioBeta.exe",
     "RobloxCrashHandler.exe",
-    "Windows10Universal.exe",
 ];
 
 const FIREWALL_RULE_PREFIX: &str = "SwiftTunnel - Roblox";
@@ -51,6 +54,13 @@ impl FirewallFixer {
         }
 
         info!("Applying Roblox firewall fix");
+
+        // Remove any stale SwiftTunnel rules first so a Roblox reinstall (which
+        // changes the executable path under Versions\version-*) doesn't leave
+        // orphaned `program=` filters pointing at vanished paths. Rules are
+        // matched by exact `SwiftTunnel - Roblox <exe> {In,Out}` name so we
+        // never touch unrelated firewall rules.
+        Self::remove_swifttunnel_rules_by_prefix();
 
         // 1. Find all Roblox executables and add firewall allow rules
         let executables = find_roblox_executables();
@@ -327,5 +337,35 @@ mod tests {
         let mut fixer = FirewallFixer::new();
         let result = fixer.restore();
         assert!(result.is_ok());
+    }
+
+    /// Negative test (per global CLAUDE.md failure-mode rules): the generic
+    /// UWP Store host `Windows10Universal.exe` must not be in our firewall
+    /// rule list. It is shared across unrelated Microsoft Store apps and
+    /// CLAUDE.md explicitly marks UWP Roblox as not tunnel-eligible.
+    #[test]
+    fn windows10universal_is_not_a_roblox_executable_target() {
+        assert!(
+            !ROBLOX_EXECUTABLES.contains(&"Windows10Universal.exe"),
+            "Windows10Universal.exe is a generic Store host shared with other Store apps; \
+             firewall rules keyed to it would scope to Mail, Weather, etc."
+        );
+    }
+
+    #[test]
+    fn roblox_executables_list_only_targets_real_player_binaries() {
+        for exe in &ROBLOX_EXECUTABLES {
+            assert!(
+                exe.starts_with("Roblox"),
+                "unexpected firewall target {exe}: must be a Roblox-prefixed exe"
+            );
+        }
+    }
+
+    #[test]
+    fn rule_name_prefix_is_stable() {
+        // Restore depends on this prefix matching what we wrote previously.
+        // Changing the prefix would orphan rules from older app versions.
+        assert_eq!(FIREWALL_RULE_PREFIX, "SwiftTunnel - Roblox");
     }
 }

--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -7,22 +7,17 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 const LEGACY_ROBLOX_PRIORITY_POLICY: &str = "RobloxPriority";
-// UWP Roblox shares the generic Windows10Universal.exe Store host with other
-// Microsoft Store apps. A QoS policy keyed to that name would tag Mail,
-// Weather, etc. with DSCP EF (46), competing with real game traffic for the
-// router's EF queue. UWP Roblox is intentionally not tunnel-eligible per
-// CLAUDE.md, so we omit it from the executable list.
-const ROBLOX_QOS_EXECUTABLES: [&str; 3] = [
-    "RobloxPlayerBeta.exe",
-    "RobloxStudioBeta.exe",
-    "RobloxCrashHandler.exe",
+// QoS policies written by previous SwiftTunnel versions. The feature is gone,
+// but cleanup still removes SwiftTunnel-owned policies so upgrades do not
+// strand stale DSCP tagging rules on user machines.
+const REMOVED_QOS_POLICY_NAMES: &[&str] = &[
+    "SwiftTunnel_QoS_RobloxPlayerBeta",
+    "SwiftTunnel_QoS_RobloxStudioBeta",
+    "SwiftTunnel_QoS_RobloxCrashHandler",
+    "SwiftTunnel_QoS_Relay_SwiftTunnel",
+    "SwiftTunnel_QoS_Relay_swifttunnel-desktop",
+    "SwiftTunnel_QoS_Windows10Universal",
 ];
-const RELAY_QOS_EXECUTABLES: [&str; 2] = ["SwiftTunnel.exe", "swifttunnel-desktop.exe"];
-// QoS policies written by previous SwiftTunnel versions that must be cleaned
-// up on upgrade. Without removal, a stale Windows10Universal DSCP policy from
-// an older build would keep tagging unrelated Microsoft Store app traffic
-// long after this release ships.
-const LEGACY_QOS_POLICY_NAMES: &[&str] = &["SwiftTunnel_QoS_Windows10Universal"];
 const NETWORK_SYSTEM_PROFILE_KEY: &str =
     r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile";
 const REG_VALUE_TCP_ACK_FREQUENCY: &str = "TcpAckFrequency";
@@ -68,7 +63,6 @@ fn snapshot_path() -> Option<PathBuf> {
 }
 
 pub struct NetworkBooster {
-    qos_enabled: bool,
     nagle_registry_snapshot: HashMap<String, NagleRegistrySnapshot>,
     network_throttling_snapshot: Option<NetworkThrottlingSnapshot>,
     qos_registry_snapshot: Option<QosRegistrySnapshot>,
@@ -83,7 +77,6 @@ pub struct NetworkApplyOutcome {
 impl NetworkBooster {
     pub fn new() -> Self {
         Self {
-            qos_enabled: false,
             nagle_registry_snapshot: HashMap::new(),
             network_throttling_snapshot: None,
             qos_registry_snapshot: None,
@@ -118,7 +111,7 @@ impl NetworkBooster {
     /// Reconcile network optimizations and report which toggles actually applied.
     ///
     /// This is used by the desktop UI so a toggle only persists as "on" after
-    /// the backing registry/QoS operation succeeds.
+    /// the backing registry operation succeeds.
     pub fn reconcile_optimizations_checked(
         &mut self,
         config: &NetworkConfig,
@@ -131,14 +124,7 @@ impl NetworkBooster {
         let mut applied_config = requested_config.clone();
         let mut warnings = Vec::new();
 
-        if requested_config.prioritize_roblox_traffic {
-            if let Err(e) = self.prioritize_game_traffic() {
-                applied_config.prioritize_roblox_traffic = false;
-                warnings.push(format!("Prioritize Roblox traffic: {}", e));
-            }
-        } else if let Err(e) = self.remove_prioritize_game_traffic() {
-            warnings.push(format!("Remove Roblox priority QoS policy: {}", e));
-        }
+        Self::cleanup_removed_qos_policies();
 
         // Tier 1 (Safe) Network Boosts
         if requested_config.disable_nagle {
@@ -157,15 +143,6 @@ impl NetworkBooster {
             }
         } else if let Err(e) = self.restore_network_throttling() {
             warnings.push(format!("Restore network throttling defaults: {}", e));
-        }
-
-        if requested_config.gaming_qos {
-            if let Err(e) = self.enable_gaming_qos() {
-                applied_config.gaming_qos = false;
-                warnings.push(format!("Enable gaming QoS: {}", e));
-            }
-        } else if let Err(e) = self.disable_gaming_qos() {
-            warnings.push(format!("Disable gaming QoS: {}", e));
         }
 
         if requested_config.firewall_fix {
@@ -189,13 +166,6 @@ impl NetworkBooster {
         {
             warnings.push("Disable network throttling did not verify after apply".to_string());
         }
-        if applied_config.gaming_qos && !effective_config.gaming_qos {
-            warnings.push("Gaming QoS did not verify after apply".to_string());
-        }
-        if applied_config.prioritize_roblox_traffic && !effective_config.prioritize_roblox_traffic {
-            warnings.push("Roblox priority QoS did not verify after apply".to_string());
-        }
-
         NetworkApplyOutcome {
             applied_config: effective_config,
             warnings,
@@ -302,22 +272,6 @@ impl NetworkBooster {
         None
     }
 
-    fn registry_key_exists(key_path: &str) -> bool {
-        hidden_command("reg")
-            .args(["query", key_path])
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-
-    fn qos_policy_exists(policy_name: &str) -> bool {
-        let policy_path = format!(
-            r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-            policy_name
-        );
-        Self::registry_key_exists(&policy_path)
-    }
-
     pub fn effective_network_config(&self, desired: &NetworkConfig) -> NetworkConfig {
         let mut effective = desired.clone();
         effective.normalize_legacy_master_boost();
@@ -345,28 +299,6 @@ impl NetworkBooster {
                     NETWORK_SYSTEM_PROFILE_KEY,
                     REG_VALUE_SYSTEM_RESPONSIVENESS,
                 ) == Some(0);
-        }
-
-        if requested.gaming_qos {
-            let dscp_enabled = Self::query_registry_dword(
-                r"HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\QoS",
-                "Do not use NLA",
-            ) == Some(1);
-            let roblox_policies_present = ROBLOX_QOS_EXECUTABLES.iter().all(|exe| {
-                let policy_name = format!("SwiftTunnel_QoS_{}", exe.replace(".exe", ""));
-                Self::qos_policy_exists(&policy_name)
-            });
-            let relay_policies_present = RELAY_QOS_EXECUTABLES.iter().all(|exe| {
-                let policy_name = format!("SwiftTunnel_QoS_Relay_{}", exe.replace(".exe", ""));
-                Self::qos_policy_exists(&policy_name)
-            });
-            effective.gaming_qos =
-                dscp_enabled && roblox_policies_present && relay_policies_present;
-        }
-
-        if requested.prioritize_roblox_traffic {
-            effective.prioritize_roblox_traffic =
-                Self::qos_policy_exists(LEGACY_ROBLOX_PRIORITY_POLICY);
         }
 
         effective.normalize_legacy_master_boost();
@@ -448,30 +380,7 @@ impl NetworkBooster {
         }
     }
 
-    /// Prioritize game traffic using QoS
-    fn prioritize_game_traffic(&self) -> Result<()> {
-        info!("Prioritizing Roblox game traffic");
-
-        // Use Windows QoS to prioritize Roblox traffic
-        let output = hidden_command("powershell")
-            .args(&[
-                "-Command",
-                "New-NetQosPolicy -Name 'RobloxPriority' -AppPathNameMatchCondition 'RobloxPlayerBeta.exe' -NetworkProfile All -PriorityValue8021Action 7 -ErrorAction SilentlyContinue"
-            ])
-            .output()?;
-
-        if output.status.success() {
-            info!("QoS policy created for Roblox");
-        } else {
-            return Err(anyhow::anyhow!(
-                "failed to create QoS policy (Administrator may be required)"
-            ));
-        }
-
-        Ok(())
-    }
-
-    fn remove_prioritize_game_traffic(&self) -> Result<()> {
+    fn remove_legacy_roblox_priority_policy() -> Result<()> {
         let script = Self::legacy_qos_policy_removal_script(LEGACY_ROBLOX_PRIORITY_POLICY);
         let output = hidden_command("powershell")
             .args(["-Command", &script])
@@ -479,10 +388,26 @@ impl NetworkBooster {
 
         if !output.status.success() {
             return Err(anyhow::anyhow!(
-                "failed to remove legacy RobloxPriority QoS policy"
+                "failed to remove removed RobloxPriority QoS policy"
             ));
         }
         Ok(())
+    }
+
+    fn cleanup_removed_qos_policies() {
+        for policy_name in REMOVED_QOS_POLICY_NAMES {
+            let policy_path = format!(
+                r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
+                policy_name
+            );
+            let _ = hidden_command("reg")
+                .args(["delete", &policy_path, "/f"])
+                .output();
+        }
+
+        if let Err(e) = Self::remove_legacy_roblox_priority_policy() {
+            warn!("Removed QoS policy cleanup failed: {}", e);
+        }
     }
 
     fn powershell_single_quote(value: &str) -> String {
@@ -653,326 +578,23 @@ impl NetworkBooster {
         Ok(())
     }
 
-    // ===== GAMING QOS =====
-
-    /// Enable Gaming QoS - marks Roblox and relay UDP packets with DSCP EF (46)
-    /// This uses Windows QoS Policy via registry to mark packets without needing socket ownership
-    pub fn enable_gaming_qos(&mut self) -> Result<()> {
-        info!("Enabling Gaming QoS with DSCP EF (46) priority");
-
-        // Strip QoS policies from prior SwiftTunnel versions before writing
-        // fresh ones (covers Windows10Universal removal on upgrade).
-        Self::remove_legacy_qos_policies();
-
-        let run_reg_add = |args: &[&str], label: &str| -> Result<()> {
-            let output = hidden_command("reg").args(args).output()?;
-            if !output.status.success() {
-                return Err(anyhow::anyhow!("failed to write {}", label));
-            }
-            Ok(())
+    fn restore_removed_qos_registry_snapshot(&mut self) -> Result<()> {
+        let Some(snapshot) = self.qos_registry_snapshot.clone() else {
+            return Ok(());
         };
 
-        if self.qos_registry_snapshot.is_none() {
-            self.qos_registry_snapshot = Some(QosRegistrySnapshot {
-                do_not_use_nla: Self::query_registry_dword(TCPIP_QOS_KEY, REG_VALUE_DO_NOT_USE_NLA),
-                disable_user_tos_setting: Self::query_registry_dword(
-                    TCPIP_PARAMETERS_KEY,
-                    REG_VALUE_DISABLE_USER_TOS_SETTING,
-                ),
-            });
-        }
-
-        // Step 1: Enable DSCP tagging in Windows (required for QoS policies to work)
-        // Create QoS key under Tcpip if it doesn't exist, then set "Do not use NLA" = 1
-        run_reg_add(
-            &[
-                "add",
-                TCPIP_QOS_KEY,
-                "/v",
-                REG_VALUE_DO_NOT_USE_NLA,
-                "/t",
-                "REG_DWORD",
-                "/d",
-                "1",
-                "/f",
-            ],
-            "DSCP tagging registry key",
+        Self::restore_registry_dword(
+            TCPIP_QOS_KEY,
+            REG_VALUE_DO_NOT_USE_NLA,
+            snapshot.do_not_use_nla,
         )?;
-        info!("DSCP tagging enabled in registry");
-
-        // Step 2: Also disable the UserTOSSetting override
-        run_reg_add(
-            &[
-                "add",
-                TCPIP_PARAMETERS_KEY,
-                "/v",
-                REG_VALUE_DISABLE_USER_TOS_SETTING,
-                "/t",
-                "REG_DWORD",
-                "/d",
-                "0",
-                "/f",
-            ],
-            "UserTOSSetting registry key",
+        Self::restore_registry_dword(
+            TCPIP_PARAMETERS_KEY,
+            REG_VALUE_DISABLE_USER_TOS_SETTING,
+            snapshot.disable_user_tos_setting,
         )?;
-
-        // Step 3: Create QoS policies for Roblox and tunnel relay app traffic.
-        // DSCP 46 = 101110 binary = highest priority for low-latency traffic.
-        let write_policy =
-            |policy_name: String, exe: &str, protocol: &str, remote_port: &str| -> Result<()> {
-                let policy_path = format!(
-                    r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-                    policy_name
-                );
-
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Version",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "1.0",
-                        "/f",
-                    ],
-                    "QoS policy Version",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Application Name",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        exe,
-                        "/f",
-                    ],
-                    "QoS policy Application Name",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Protocol",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        protocol,
-                        "/f",
-                    ],
-                    "QoS policy Protocol",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "DSCP Value",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "46",
-                        "/f",
-                    ],
-                    "QoS policy DSCP Value",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Throttle Rate",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "-1",
-                        "/f",
-                    ],
-                    "QoS policy Throttle Rate",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Local Port",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "*",
-                        "/f",
-                    ],
-                    "QoS policy Local Port",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Local IP",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "*",
-                        "/f",
-                    ],
-                    "QoS policy Local IP",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Local IP Prefix Length",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "*",
-                        "/f",
-                    ],
-                    "QoS policy Local IP Prefix Length",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Remote Port",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        remote_port,
-                        "/f",
-                    ],
-                    "QoS policy Remote Port",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Remote IP",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "*",
-                        "/f",
-                    ],
-                    "QoS policy Remote IP",
-                )?;
-                run_reg_add(
-                    &[
-                        "add",
-                        &policy_path,
-                        "/v",
-                        "Remote IP Prefix Length",
-                        "/t",
-                        "REG_SZ",
-                        "/d",
-                        "*",
-                        "/f",
-                    ],
-                    "QoS policy Remote IP Prefix Length",
-                )?;
-                Ok(())
-            };
-
-        for exe in ROBLOX_QOS_EXECUTABLES {
-            let policy_name = format!("SwiftTunnel_QoS_{}", exe.replace(".exe", ""));
-            write_policy(policy_name, exe, "*", "*")?;
-            info!("Created QoS policy for {}", exe);
-        }
-
-        // Fallback for tunnel traffic: app process packets to relay port 51821.
-        for exe in RELAY_QOS_EXECUTABLES {
-            let policy_name = format!("SwiftTunnel_QoS_Relay_{}", exe.replace(".exe", ""));
-            write_policy(policy_name, exe, "UDP", "51821")?;
-            info!("Created relay QoS policy for {}", exe);
-        }
-
-        self.qos_enabled = true;
-        info!("Gaming QoS enabled - Roblox + relay traffic marked with DSCP 46 (EF)");
+        self.qos_registry_snapshot = None;
         Ok(())
-    }
-
-    /// Delete QoS policies left behind by older SwiftTunnel versions.
-    /// Safe to call repeatedly — `reg delete` on a missing key returns an
-    /// error status, which we ignore.
-    fn remove_legacy_qos_policies() {
-        for policy_name in LEGACY_QOS_POLICY_NAMES {
-            let policy_path = format!(
-                r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-                policy_name
-            );
-            let _ = hidden_command("reg")
-                .args(["delete", &policy_path, "/f"])
-                .output();
-        }
-    }
-
-    /// Disable Gaming QoS - removes the QoS policies and DSCP registry keys
-    pub fn disable_gaming_qos(&mut self) -> Result<()> {
-        info!("Disabling Gaming QoS");
-
-        // Also strip legacy policy names so disable+enable cycles clean up
-        // stale entries even when the user never re-enables.
-        Self::remove_legacy_qos_policies();
-
-        for exe in ROBLOX_QOS_EXECUTABLES {
-            let policy_name = format!("SwiftTunnel_QoS_{}", exe.replace(".exe", ""));
-            let policy_path = format!(
-                r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-                policy_name
-            );
-
-            // Delete the policy key
-            let _ = hidden_command("reg")
-                .args(["delete", &policy_path, "/f"])
-                .output();
-        }
-
-        for exe in RELAY_QOS_EXECUTABLES {
-            let policy_name = format!("SwiftTunnel_QoS_Relay_{}", exe.replace(".exe", ""));
-            let policy_path = format!(
-                r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-                policy_name
-            );
-            let _ = hidden_command("reg")
-                .args(["delete", &policy_path, "/f"])
-                .output();
-        }
-
-        if let Some(snapshot) = self.qos_registry_snapshot.clone() {
-            Self::restore_registry_dword(
-                TCPIP_QOS_KEY,
-                REG_VALUE_DO_NOT_USE_NLA,
-                snapshot.do_not_use_nla,
-            )?;
-            Self::restore_registry_dword(
-                TCPIP_PARAMETERS_KEY,
-                REG_VALUE_DISABLE_USER_TOS_SETTING,
-                snapshot.disable_user_tos_setting,
-            )?;
-            self.qos_registry_snapshot = None;
-        } else {
-            info!(
-                "No Gaming QoS registry snapshot captured; leaving global DSCP/TOS values unchanged"
-            );
-        }
-
-        self.qos_enabled = false;
-        info!("Gaming QoS disabled");
-        Ok(())
-    }
-
-    /// Check if Gaming QoS is currently enabled
-    pub fn is_qos_enabled(&self) -> bool {
-        self.qos_enabled
     }
 
     /// Restore original DNS settings
@@ -989,12 +611,9 @@ impl NetworkBooster {
             errors.push(format!("network throttling registry restore: {}", e));
         }
 
-        // Remove old QoS policy (legacy)
-        if let Err(e) = self.remove_prioritize_game_traffic() {
-            warn!("Legacy QoS policy removal failed during restore: {}", e);
-        }
-        if let Err(e) = self.disable_gaming_qos() {
-            errors.push(format!("Gaming QoS restore: {}", e));
+        Self::cleanup_removed_qos_policies();
+        if let Err(e) = self.restore_removed_qos_registry_snapshot() {
+            errors.push(format!("removed QoS registry snapshot restore: {}", e));
         }
 
         // Remove firewall rules
@@ -1097,46 +716,16 @@ pub fn cleanup_all_system_state() -> Result<()> {
         warn!("Cleanup: failed to remove hosts overrides: {e}");
     }
 
-    // 2. Delete SwiftTunnel QoS registry policies
-    for exe in ROBLOX_QOS_EXECUTABLES {
-        let policy_name = format!("SwiftTunnel_QoS_{}", exe.replace(".exe", ""));
-        let policy_path = format!(
-            r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-            policy_name
-        );
-        let _ = hidden_command("reg")
-            .args(["delete", &policy_path, "/f"])
-            .output();
-    }
-    for exe in RELAY_QOS_EXECUTABLES {
-        let policy_name = format!("SwiftTunnel_QoS_Relay_{}", exe.replace(".exe", ""));
-        let policy_path = format!(
-            r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-            policy_name
-        );
-        let _ = hidden_command("reg")
-            .args(["delete", &policy_path, "/f"])
-            .output();
-    }
+    // 2. Delete removed SwiftTunnel QoS policies from older releases.
+    NetworkBooster::cleanup_removed_qos_policies();
 
     info!(
-        "Cleanup: leaving global TCP/QoS registry values untouched unless a persisted SwiftTunnel snapshot restored them"
+        "Cleanup: leaving global TCP registry values untouched unless a persisted SwiftTunnel snapshot restored them"
     );
 
     // 3. Remove firewall rules.
     let mut firewall = FirewallFixer::new();
     let _ = firewall.restore();
-
-    // 4. Delete legacy RobloxPriority QoS policy
-    let _ = hidden_command("powershell")
-        .args([
-            "-Command",
-            &format!(
-                "Remove-NetQosPolicy -Name '{}' -Confirm:$false -ErrorAction SilentlyContinue",
-                LEGACY_ROBLOX_PRIORITY_POLICY
-            ),
-        ])
-        .output();
 
     // 8. Remove the snapshot file itself
     NetworkBooster::clear_snapshot();
@@ -1298,10 +887,8 @@ mod tests {
     fn apply_optimizations_succeeds_despite_individual_failures() {
         let mut booster = NetworkBooster::new();
         let config = NetworkConfig {
-            prioritize_roblox_traffic: true,
             disable_nagle: true,
             disable_network_throttling: true,
-            gaming_qos: true,
             ..Default::default()
         };
 
@@ -1323,10 +910,8 @@ mod tests {
     fn apply_optimizations_with_nothing_enabled() {
         let mut booster = NetworkBooster::new();
         let config = NetworkConfig {
-            prioritize_roblox_traffic: false,
             disable_nagle: false,
             disable_network_throttling: false,
-            gaming_qos: false,
             ..Default::default()
         };
 
@@ -1334,34 +919,19 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    /// Negative test (per global CLAUDE.md failure-mode rules): the UWP host
-    /// `Windows10Universal.exe` must never appear in the QoS exec list — a
-    /// DSCP EF policy keyed to it would mark unrelated Microsoft Store apps
-    /// (Mail, Weather, etc.) with the same high-priority class as gameplay
-    /// traffic, defeating the point of EF.
     #[test]
-    fn windows10universal_is_not_in_qos_executable_list() {
-        assert!(!ROBLOX_QOS_EXECUTABLES.contains(&"Windows10Universal.exe"));
-    }
-
-    #[test]
-    fn roblox_qos_executables_are_real_roblox_binaries() {
-        for exe in &ROBLOX_QOS_EXECUTABLES {
-            assert!(
-                exe.starts_with("Roblox"),
-                "unexpected QoS target {exe}: must be a Roblox-prefixed exe"
-            );
-        }
-    }
-
-    #[test]
-    fn legacy_qos_policy_names_targets_the_old_windows10universal_policy() {
-        // On upgrade, prior SwiftTunnel versions left a
-        // SwiftTunnel_QoS_Windows10Universal policy behind. The cleanup list
-        // must include it so we don't keep tagging unrelated Store traffic.
+    fn removed_qos_policy_cleanup_covers_all_swifttunnel_policy_names() {
         assert!(
-            LEGACY_QOS_POLICY_NAMES.contains(&"SwiftTunnel_QoS_Windows10Universal"),
-            "legacy QoS cleanup list lost its Windows10Universal entry"
+            REMOVED_QOS_POLICY_NAMES.contains(&"SwiftTunnel_QoS_Windows10Universal"),
+            "removed QoS cleanup list must strip the over-broad Store host policy"
+        );
+        assert!(
+            REMOVED_QOS_POLICY_NAMES.contains(&"SwiftTunnel_QoS_RobloxPlayerBeta"),
+            "removed QoS cleanup list must strip the former Roblox player policy"
+        );
+        assert!(
+            REMOVED_QOS_POLICY_NAMES.contains(&"SwiftTunnel_QoS_Relay_swifttunnel-desktop"),
+            "removed QoS cleanup list must strip the former relay policy"
         );
     }
 }

--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -7,13 +7,22 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 const LEGACY_ROBLOX_PRIORITY_POLICY: &str = "RobloxPriority";
-const ROBLOX_QOS_EXECUTABLES: [&str; 4] = [
+// UWP Roblox shares the generic Windows10Universal.exe Store host with other
+// Microsoft Store apps. A QoS policy keyed to that name would tag Mail,
+// Weather, etc. with DSCP EF (46), competing with real game traffic for the
+// router's EF queue. UWP Roblox is intentionally not tunnel-eligible per
+// CLAUDE.md, so we omit it from the executable list.
+const ROBLOX_QOS_EXECUTABLES: [&str; 3] = [
     "RobloxPlayerBeta.exe",
     "RobloxStudioBeta.exe",
     "RobloxCrashHandler.exe",
-    "Windows10Universal.exe",
 ];
 const RELAY_QOS_EXECUTABLES: [&str; 2] = ["SwiftTunnel.exe", "swifttunnel-desktop.exe"];
+// QoS policies written by previous SwiftTunnel versions that must be cleaned
+// up on upgrade. Without removal, a stale Windows10Universal DSCP policy from
+// an older build would keep tagging unrelated Microsoft Store app traffic
+// long after this release ships.
+const LEGACY_QOS_POLICY_NAMES: &[&str] = &["SwiftTunnel_QoS_Windows10Universal"];
 const NETWORK_SYSTEM_PROFILE_KEY: &str =
     r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile";
 const REG_VALUE_TCP_ACK_FREQUENCY: &str = "TcpAckFrequency";
@@ -651,6 +660,10 @@ impl NetworkBooster {
     pub fn enable_gaming_qos(&mut self) -> Result<()> {
         info!("Enabling Gaming QoS with DSCP EF (46) priority");
 
+        // Strip QoS policies from prior SwiftTunnel versions before writing
+        // fresh ones (covers Windows10Universal removal on upgrade).
+        Self::remove_legacy_qos_policies();
+
         let run_reg_add = |args: &[&str], label: &str| -> Result<()> {
             let output = hidden_command("reg").args(args).output()?;
             if !output.status.success() {
@@ -887,9 +900,28 @@ impl NetworkBooster {
         Ok(())
     }
 
+    /// Delete QoS policies left behind by older SwiftTunnel versions.
+    /// Safe to call repeatedly — `reg delete` on a missing key returns an
+    /// error status, which we ignore.
+    fn remove_legacy_qos_policies() {
+        for policy_name in LEGACY_QOS_POLICY_NAMES {
+            let policy_path = format!(
+                r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
+                policy_name
+            );
+            let _ = hidden_command("reg")
+                .args(["delete", &policy_path, "/f"])
+                .output();
+        }
+    }
+
     /// Disable Gaming QoS - removes the QoS policies and DSCP registry keys
     pub fn disable_gaming_qos(&mut self) -> Result<()> {
         info!("Disabling Gaming QoS");
+
+        // Also strip legacy policy names so disable+enable cycles clean up
+        // stale entries even when the user never re-enables.
+        Self::remove_legacy_qos_policies();
 
         for exe in ROBLOX_QOS_EXECUTABLES {
             let policy_name = format!("SwiftTunnel_QoS_{}", exe.replace(".exe", ""));
@@ -1300,5 +1332,36 @@ mod tests {
 
         let result = booster.apply_optimizations(&config);
         assert!(result.is_ok());
+    }
+
+    /// Negative test (per global CLAUDE.md failure-mode rules): the UWP host
+    /// `Windows10Universal.exe` must never appear in the QoS exec list — a
+    /// DSCP EF policy keyed to it would mark unrelated Microsoft Store apps
+    /// (Mail, Weather, etc.) with the same high-priority class as gameplay
+    /// traffic, defeating the point of EF.
+    #[test]
+    fn windows10universal_is_not_in_qos_executable_list() {
+        assert!(!ROBLOX_QOS_EXECUTABLES.contains(&"Windows10Universal.exe"));
+    }
+
+    #[test]
+    fn roblox_qos_executables_are_real_roblox_binaries() {
+        for exe in &ROBLOX_QOS_EXECUTABLES {
+            assert!(
+                exe.starts_with("Roblox"),
+                "unexpected QoS target {exe}: must be a Roblox-prefixed exe"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_qos_policy_names_targets_the_old_windows10universal_policy() {
+        // On upgrade, prior SwiftTunnel versions left a
+        // SwiftTunnel_QoS_Windows10Universal policy behind. The cleanup list
+        // must include it so we don't keep tagging unrelated Store traffic.
+        assert!(
+            LEGACY_QOS_POLICY_NAMES.contains(&"SwiftTunnel_QoS_Windows10Universal"),
+            "legacy QoS cleanup list lost its Windows10Universal entry"
+        );
     }
 }

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -581,13 +581,18 @@ impl RobloxOptimizer {
         // denied, key locked, etc.). Substring matching English phrases
         // breaks on non-English Windows. Probe the registry instead: if the
         // value is genuinely absent the desired post-state already holds.
-        let still_present = hidden_command("reg")
+        //
+        // Propagate a probe-spawn failure with `?` rather than `unwrap_or`
+        // — silently treating "we couldn't even run `reg query`" as
+        // success would let an admin-required delete report cleared while
+        // the GPU preference is still live (Greptile-flagged regression).
+        let probe = hidden_command("reg")
             .args(["query", key_path, "/v", value_name])
-            .output()
-            .map(|probe| probe.status.success())
-            .unwrap_or(false);
+            .output()?;
 
-        if !still_present {
+        if !probe.status.success() {
+            // `reg query` failed with a clean non-zero exit — the value
+            // is gone, which is the post-state we wanted.
             return Ok(());
         }
 

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -394,8 +394,118 @@ impl RobloxOptimizer {
             warnings.push(msg);
         }
 
+        // Per-app GPU preference: on hybrid laptops (Intel iGPU + dGPU)
+        // Roblox often defaults to the integrated GPU. Setting "High
+        // performance" via HKCU\...\UserGpuPreferences routes it to the
+        // discrete GPU, which can be 3-10× the framerate. Reversed when
+        // Ultraboost is disabled.
+        if let Err(e) = Self::sync_gpu_preference(config.ultraboost) {
+            let msg = format!("Could not sync Roblox GPU preference: {}", e);
+            warn!("{}", msg);
+            warnings.push(msg);
+        }
+
         info!("Roblox optimizations applied successfully");
         Ok(warnings)
+    }
+
+    /// `HKCU\SOFTWARE\Microsoft\DirectX\UserGpuPreferences` — Windows uses
+    /// this key to route per-app GPU selection. The value name is the
+    /// executable's absolute path; the data is `GpuPreference=N;` where
+    /// `2` = High performance and `1` = Power saving.
+    const USER_GPU_PREFERENCES_KEY: &'static str =
+        r"HKCU\SOFTWARE\Microsoft\DirectX\UserGpuPreferences";
+    const ROBLOX_GPU_EXECUTABLES: &'static [&'static str] =
+        &["RobloxPlayerBeta.exe", "RobloxStudioBeta.exe"];
+    const GPU_PREFERENCE_HIGH_PERFORMANCE: &'static str = "GpuPreference=2;";
+
+    /// Mirror the Ultraboost toggle into Windows' per-app GPU preference.
+    ///
+    /// When `enable == true`, every `RobloxPlayerBeta.exe` /
+    /// `RobloxStudioBeta.exe` discovered under
+    /// `%LOCALAPPDATA%\Roblox\Versions\version-*` is registered as
+    /// `GpuPreference=2;` (High performance). When `enable == false`, any
+    /// existing preference values that target those paths are deleted so the
+    /// system reverts to Windows' default GPU selection.
+    fn sync_gpu_preference(enable: bool) -> Result<()> {
+        let executables = Self::collect_roblox_gpu_executables();
+        if executables.is_empty() {
+            // Nothing to do — Roblox isn't installed (or hasn't been launched
+            // yet). Not an error: avoid noisy popups if the user enables
+            // Ultraboost before installing Roblox.
+            return Ok(());
+        }
+
+        for path in executables {
+            let path_str = path.to_string_lossy().to_string();
+            let result = if enable {
+                Self::set_registry_string_value(
+                    Self::USER_GPU_PREFERENCES_KEY,
+                    &path_str,
+                    Self::GPU_PREFERENCE_HIGH_PERFORMANCE,
+                )
+            } else {
+                Self::delete_registry_value(Self::USER_GPU_PREFERENCES_KEY, &path_str)
+            };
+
+            if let Err(e) = result {
+                warn!(
+                    "GPU preference {} for {} failed: {}",
+                    if enable { "apply" } else { "clear" },
+                    path_str,
+                    e
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn collect_roblox_gpu_executables() -> Vec<PathBuf> {
+        let version_folders = Self::find_roblox_version_folders();
+        let mut out = Vec::new();
+        for folder in version_folders {
+            for exe in Self::ROBLOX_GPU_EXECUTABLES {
+                let candidate = folder.join(exe);
+                if candidate.exists() {
+                    out.push(candidate);
+                }
+            }
+        }
+        out
+    }
+
+    fn set_registry_string_value(key_path: &str, value_name: &str, data: &str) -> Result<()> {
+        let output = hidden_command("reg")
+            .args([
+                "add", key_path, "/v", value_name, "/t", "REG_SZ", "/d", data, "/f",
+            ])
+            .output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(anyhow::anyhow!("reg add failed: {}", stderr.trim()))
+        }
+    }
+
+    fn delete_registry_value(key_path: &str, value_name: &str) -> Result<()> {
+        let output = hidden_command("reg")
+            .args(["delete", key_path, "/v", value_name, "/f"])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        // `reg delete` returns non-zero when the value doesn't exist; treat
+        // that as success because the desired post-state is "value absent".
+        // Anything else (permission denied, key locked) is propagated.
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        if stderr.contains("cannot find") || stderr.contains("unable to find") {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("reg delete failed: {}", stderr.trim()))
+        }
     }
 
     /// Apply XML-level settings (FPS cap, graphics quality, window size).
@@ -724,17 +834,42 @@ impl RobloxOptimizer {
     // ═══════════════════════════════════════════════════════════════════════════════
 
     /// Allowlisted performance FFlags applied by Ultraboost.
+    ///
+    /// Every entry was verified against Roblox's Sept-2025 client FFlag
+    /// allowlist; non-allowlisted flags are silently ignored by the engine
+    /// and are intentionally not written here. Additions over the prior
+    /// version:
+    ///   * `DFFlagDebugPauseVoxelizer=True` — pauses the voxel-lighting
+    ///     voxelizer thread, cutting CPU work in scenes with Voxel
+    ///     dynamic lighting (most legacy games).
+    ///   * Four CSG LOD switching distances pinned at `0` — forces the
+    ///     lowest-poly LOD bucket at the shortest possible distance.
+    ///   * `FFlagDebugGraphicsPreferVulkan=False` /
+    ///     `FFlagDebugGraphicsPreferOpenGL=False` — defensive negations so
+    ///     a bootstrapper preset cannot silently undo our D3D11 selection
+    ///     (Vulkan on Roblox/Windows is unofficial and crash-prone).
+    ///
+    /// `DFIntDebugFRMQualityLevelOverride` is `1` (lowest) instead of the
+    /// prior `4`; Roblox's FRM quality scales 1-21 and community
+    /// performance presets use the minimum for maximum FPS.
     const ULTRABOOST_FFLAGS: &[(&str, &str)] = &[
         ("FFlagHandleAltEnterFullscreenManually", "False"),
         ("FFlagDebugGraphicsPreferD3D11", "True"),
+        ("FFlagDebugGraphicsPreferVulkan", "False"),
+        ("FFlagDebugGraphicsPreferOpenGL", "False"),
         ("FIntDebugForceMSAASamples", "0"),
         ("DFFlagTextureQualityOverrideEnabled", "True"),
         ("DFIntTextureQualityOverride", "0"),
-        ("DFIntDebugFRMQualityLevelOverride", "4"),
+        ("DFIntDebugFRMQualityLevelOverride", "1"),
         ("FFlagDebugSkyGray", "True"),
         ("FIntFRMMinGrassDistance", "0"),
         ("FIntFRMMaxGrassDistance", "0"),
         ("FIntGrassMovementReducedMotionFactor", "0"),
+        ("DFFlagDebugPauseVoxelizer", "True"),
+        ("DFIntCSGLevelOfDetailSwitchingDistance", "0"),
+        ("DFIntCSGLevelOfDetailSwitchingDistanceL12", "0"),
+        ("DFIntCSGLevelOfDetailSwitchingDistanceL23", "0"),
+        ("DFIntCSGLevelOfDetailSwitchingDistanceL34", "0"),
     ];
 
     /// Retired FFlag. Previously written for FPS unlock, but the framerate cap is
@@ -742,11 +877,16 @@ impl RobloxOptimizer {
     /// from existing ClientAppSettings so prior versions' entries are cleaned up.
     const FPS_UNLOCK_FFLAG: &str = "DFIntTaskSchedulerTargetFps";
 
-    /// Old blocked FFlags that must be cleaned up from previous versions
+    /// Old blocked FFlags that must be cleaned up from previous versions.
+    ///
+    /// `DFFlagDebugPauseVoxelizer` was previously listed here because earlier
+    /// builds wrote it as a disabled override. It is now actively part of
+    /// `ULTRABOOST_FFLAGS` (it's allowlisted and yields a real CPU lift on
+    /// voxel-lighting scenes), so removing it from the cleanup list prevents
+    /// us from immediately stripping our own write.
     const LEGACY_BLOCKED_FFLAGS: &[&str] = &[
         "DFIntDebugDynamicRenderKiloPixels",
         "FIntRenderShadowIntensity",
-        "DFFlagDebugPauseVoxelizer",
         "FFlagDisablePostFx",
         "FIntDebugTextureManagerSkipMips",
     ];
@@ -1348,6 +1488,11 @@ impl RobloxOptimizer {
         let optimizer = Self::new();
         if let Err(e) = optimizer.remove_all_fflags() {
             warn!("Failed to remove Roblox FFlags during uninstall: {e}");
+        }
+        // Also drop the per-app dGPU preference entries we may have written.
+        // Best-effort; missing values are not an error.
+        if let Err(e) = Self::sync_gpu_preference(false) {
+            warn!("Failed to clear Roblox GPU preference during uninstall: {e}");
         }
         info!("Roblox optimizer: uninstall cleanup completed");
     }
@@ -2471,19 +2616,23 @@ mod tests {
 
     #[test]
     fn ultraboost_fflags_count() {
+        // 10 originals + Vulkan/OpenGL defensive negations + 5 new allowlisted
+        // perf flags (DFFlagDebugPauseVoxelizer + 4 CSG LOD distance entries).
         assert_eq!(
             RobloxOptimizer::ULTRABOOST_FFLAGS.len(),
-            10,
-            "Expected 10 ultraboost FFlags"
+            17,
+            "Expected 17 ultraboost FFlags"
         );
     }
 
     #[test]
     fn legacy_blocked_fflags_count() {
+        // DFFlagDebugPauseVoxelizer moved out of LEGACY_BLOCKED_FFLAGS because
+        // it is now an active Ultraboost flag (allowlisted and useful).
         assert_eq!(
             RobloxOptimizer::LEGACY_BLOCKED_FFLAGS.len(),
-            5,
-            "Expected 5 legacy blocked FFlags"
+            4,
+            "Expected 4 legacy blocked FFlags"
         );
     }
 

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -436,6 +436,7 @@ impl RobloxOptimizer {
             return Ok(());
         }
 
+        let mut failures: Vec<String> = Vec::new();
         for path in executables {
             let path_str = path.to_string_lossy().to_string();
             let result = if enable {
@@ -449,15 +450,25 @@ impl RobloxOptimizer {
             };
 
             if let Err(e) = result {
-                warn!(
-                    "GPU preference {} for {} failed: {}",
-                    if enable { "apply" } else { "clear" },
-                    path_str,
-                    e
-                );
+                let op = if enable { "apply" } else { "clear" };
+                warn!("GPU preference {} for {} failed: {}", op, path_str, e);
+                failures.push(format!("{}: {}", path_str, e));
             }
         }
-        Ok(())
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            // Surface a single Err so the call site's warnings collector
+            // (and downstream UI) actually fires. Without this the boost
+            // reports "applied" even when every registry write failed.
+            Err(anyhow::anyhow!(
+                "GPU preference {} failed for {} executable(s): {}",
+                if enable { "apply" } else { "clear" },
+                failures.len(),
+                failures.join("; ")
+            ))
+        }
     }
 
     fn collect_roblox_gpu_executables() -> Vec<PathBuf> {
@@ -497,15 +508,23 @@ impl RobloxOptimizer {
             return Ok(());
         }
 
-        // `reg delete` returns non-zero when the value doesn't exist; treat
-        // that as success because the desired post-state is "value absent".
-        // Anything else (permission denied, key locked) is propagated.
-        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
-        if stderr.contains("cannot find") || stderr.contains("unable to find") {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!("reg delete failed: {}", stderr.trim()))
+        // `reg delete` returns a non-zero exit code with a localised error
+        // string for both "value missing" and real failures (permission
+        // denied, key locked, etc.). Substring matching English phrases
+        // breaks on non-English Windows. Probe the registry instead: if the
+        // value is genuinely absent the desired post-state already holds.
+        let still_present = hidden_command("reg")
+            .args(["query", key_path, "/v", value_name])
+            .output()
+            .map(|probe| probe.status.success())
+            .unwrap_or(false);
+
+        if !still_present {
+            return Ok(());
         }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!("reg delete failed: {}", stderr.trim()))
     }
 
     /// Apply XML-level settings (FPS cap, graphics quality, window size).

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -428,17 +428,33 @@ impl RobloxOptimizer {
     /// existing preference values that target those paths are deleted so the
     /// system reverts to Windows' default GPU selection.
     fn sync_gpu_preference(enable: bool) -> Result<()> {
-        let executables = Self::collect_roblox_gpu_executables();
-        if executables.is_empty() {
+        let mut targets: Vec<String> = Self::collect_roblox_gpu_executables()
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+
+        // On the disable path, also pick up GPU-preference entries written
+        // by older Roblox version folders that have since been deleted by
+        // Roblox auto-update. Functionally inert (Windows ignores prefs
+        // for non-existent paths) but they accumulate over update cycles
+        // and clutter diagnostics — Greptile flagged this hygiene gap.
+        if !enable {
+            for stale in Self::collect_stale_roblox_gpu_preference_names() {
+                if !targets.contains(&stale) {
+                    targets.push(stale);
+                }
+            }
+        }
+
+        if targets.is_empty() {
             // Nothing to do — Roblox isn't installed (or hasn't been launched
-            // yet). Not an error: avoid noisy popups if the user enables
-            // Ultraboost before installing Roblox.
+            // yet) AND no stale entries exist. Not an error: avoid noisy
+            // popups if the user enables Ultraboost before installing Roblox.
             return Ok(());
         }
 
         let mut failures: Vec<String> = Vec::new();
-        for path in executables {
-            let path_str = path.to_string_lossy().to_string();
+        for path_str in targets {
             let result = if enable {
                 Self::set_registry_string_value(
                     Self::USER_GPU_PREFERENCES_KEY,
@@ -469,6 +485,58 @@ impl RobloxOptimizer {
                 failures.join("; ")
             ))
         }
+    }
+
+    /// Enumerate `HKCU\SOFTWARE\Microsoft\DirectX\UserGpuPreferences` value
+    /// names that look like a Roblox version-folder executable. Used by the
+    /// disable path to clean up entries written for version-* folders that
+    /// Roblox auto-updated away — `reg query` returns the value name (the
+    /// full exe path) regardless of whether the file still exists on disk.
+    fn collect_stale_roblox_gpu_preference_names() -> Vec<String> {
+        let output = match hidden_command("reg")
+            .args(["query", Self::USER_GPU_PREFERENCES_KEY])
+            .output()
+        {
+            Ok(out) if out.status.success() => out,
+            // No key at all means nothing to clean up.
+            _ => return Vec::new(),
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Self::parse_gpu_preference_names(&stdout)
+    }
+
+    /// Pure parser pulled out so tests can validate without running `reg`.
+    /// Picks rows that name an executable under a Roblox version folder.
+    fn parse_gpu_preference_names(reg_query_output: &str) -> Vec<String> {
+        let mut names = Vec::new();
+        for line in reg_query_output.lines() {
+            // `reg query` rows look like:
+            //   "    C:\…\version-abcdef\RobloxPlayerBeta.exe    REG_SZ    GpuPreference=2;"
+            // The value name is everything between leading whitespace and
+            // the type column (`REG_SZ` etc.).
+            let Some((name_part, _rest)) = line.split_once("    REG_SZ") else {
+                continue;
+            };
+            let name = name_part.trim();
+            if name.is_empty() {
+                continue;
+            }
+            let lowered = name.to_ascii_lowercase();
+            // Only pick up entries that look like our prior writes: under a
+            // Roblox version folder AND one of our known executable stems.
+            if !lowered.contains(r"\roblox\versions\version-") {
+                continue;
+            }
+            let is_known_exe = Self::ROBLOX_GPU_EXECUTABLES
+                .iter()
+                .any(|exe| lowered.ends_with(&exe.to_ascii_lowercase()));
+            if !is_known_exe {
+                continue;
+            }
+            names.push(name.to_string());
+        }
+        names
     }
 
     fn collect_roblox_gpu_executables() -> Vec<PathBuf> {
@@ -2662,6 +2730,41 @@ mod tests {
             1,
             "Expected 1 retired ultraboost FFlag"
         );
+    }
+
+    /// Regression test for the GPU-preference cleanup gap Greptile flagged:
+    /// `sync_gpu_preference(false)` must also pick up entries written for
+    /// Roblox version folders that have been auto-updated away. Parses a
+    /// fake `reg query` table including unrelated apps + a stale entry.
+    #[test]
+    fn parse_gpu_preference_names_picks_only_roblox_version_entries() {
+        let sample = r#"
+HKEY_CURRENT_USER\SOFTWARE\Microsoft\DirectX\UserGpuPreferences
+    DirectXUserGlobalSettings    REG_SZ    VRROptimizeEnable=0;
+    C:\Program Files\Discord\Discord.exe    REG_SZ    GpuPreference=2;
+    C:\Users\evelyn\AppData\Local\Roblox\Versions\version-aaa111\RobloxPlayerBeta.exe    REG_SZ    GpuPreference=2;
+    C:\Users\evelyn\AppData\Local\Roblox\Versions\version-bbb222\RobloxStudioBeta.exe    REG_SZ    GpuPreference=2;
+    C:\Users\evelyn\AppData\Local\Roblox\Versions\version-ccc333\Other.exe    REG_SZ    GpuPreference=2;
+"#;
+        let names = RobloxOptimizer::parse_gpu_preference_names(sample);
+        assert_eq!(
+            names,
+            vec![
+                "C:\\Users\\evelyn\\AppData\\Local\\Roblox\\Versions\\version-aaa111\\RobloxPlayerBeta.exe".to_string(),
+                "C:\\Users\\evelyn\\AppData\\Local\\Roblox\\Versions\\version-bbb222\\RobloxStudioBeta.exe".to_string(),
+            ],
+            "Must keep Roblox version entries and exclude Discord, the global setting, and non-known exes"
+        );
+    }
+
+    #[test]
+    fn parse_gpu_preference_names_returns_empty_for_no_matches() {
+        let sample = r#"
+HKEY_CURRENT_USER\SOFTWARE\Microsoft\DirectX\UserGpuPreferences
+    DirectXUserGlobalSettings    REG_SZ    VRROptimizeEnable=0;
+    C:\Program Files\Steam\Steam.exe    REG_SZ    GpuPreference=2;
+"#;
+        assert!(RobloxOptimizer::parse_gpu_preference_names(sample).is_empty());
     }
 
     #[test]

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -715,13 +715,15 @@ impl RobloxOptimizer {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        Self::parse_registry_string_value(&stdout, value_name).ok_or_else(|| {
-            anyhow::anyhow!(
-                "reg query succeeded for {}\\{} but no REG_SZ row was parsed",
-                key_path,
-                value_name
-            )
-        })
+        Self::parse_registry_string_value(&stdout, value_name)
+            .map(Some)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "reg query succeeded for {}\\{} but no REG_SZ row was parsed",
+                    key_path,
+                    value_name
+                )
+            })
     }
 
     fn parse_registry_string_value(reg_query_output: &str, value_name: &str) -> Option<String> {

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -1,6 +1,7 @@
 use crate::hidden_command;
 use crate::structs::*;
 use log::{error, info, warn};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -30,6 +31,25 @@ pub struct RobloxOptimizer {
 enum FFlagApplyOutcome {
     Applied,
     SkippedMissingRobloxVersion,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct GpuPreferenceSnapshot {
+    #[serde(default)]
+    values: HashMap<String, Option<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GpuPreferenceRestoreAction {
+    Restore(String),
+    Delete,
+    LeaveUntouched,
+}
+
+const GPU_PREFERENCE_SNAPSHOT_FILE: &str = "gpu_preference_snapshots.json";
+
+fn gpu_preference_snapshot_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("SwiftTunnel").join(GPU_PREFERENCE_SNAPSHOT_FILE))
 }
 
 impl RobloxOptimizer {
@@ -424,21 +444,28 @@ impl RobloxOptimizer {
     /// When `enable == true`, every `RobloxPlayerBeta.exe` /
     /// `RobloxStudioBeta.exe` discovered under
     /// `%LOCALAPPDATA%\Roblox\Versions\version-*` is registered as
-    /// `GpuPreference=2;` (High performance). When `enable == false`, any
-    /// existing preference values that target those paths are deleted so the
-    /// system reverts to Windows' default GPU selection.
+    /// `GpuPreference=2;` (High performance), after snapshotting any existing
+    /// user value. When `enable == false`, only values tracked in the snapshot
+    /// are restored or deleted; unknown values are left untouched because they
+    /// may be user-owned.
     fn sync_gpu_preference(enable: bool) -> Result<()> {
         let mut targets: Vec<String> = Self::collect_roblox_gpu_executables()
             .into_iter()
             .map(|p| p.to_string_lossy().into_owned())
             .collect();
 
-        // On the disable path, also pick up GPU-preference entries written
-        // by older Roblox version folders that have since been deleted by
-        // Roblox auto-update. Functionally inert (Windows ignores prefs
-        // for non-existent paths) but they accumulate over update cycles
-        // and clutter diagnostics — Greptile flagged this hygiene gap.
+        // On the disable path, include tracked entries for older Roblox
+        // version folders that may have since been deleted by Roblox
+        // auto-update. Untracked stale rows are observed for diagnostics but
+        // not deleted: without a snapshot they are indistinguishable from a
+        // user-owned Windows graphics preference.
         if !enable {
+            let snapshot = Self::load_gpu_preference_snapshot();
+            for tracked in snapshot.values.keys() {
+                if !targets.contains(tracked) {
+                    targets.push(tracked.clone());
+                }
+            }
             for stale in Self::collect_stale_roblox_gpu_preference_names() {
                 if !targets.contains(&stale) {
                     targets.push(stale);
@@ -454,36 +481,161 @@ impl RobloxOptimizer {
         }
 
         let mut failures: Vec<String> = Vec::new();
-        for path_str in targets {
-            let result = if enable {
-                Self::set_registry_string_value(
+
+        if enable {
+            let mut snapshot = Self::load_gpu_preference_snapshot();
+            for path_str in &targets {
+                if !snapshot.values.contains_key(path_str) {
+                    let original =
+                        Self::query_registry_string_value(Self::USER_GPU_PREFERENCES_KEY, path_str)
+                            .map_err(|e| {
+                                anyhow::anyhow!(
+                                    "Could not snapshot existing GPU preference for {}: {}",
+                                    path_str,
+                                    e
+                                )
+                            })?;
+                    snapshot.values.insert(path_str.clone(), original);
+                }
+            }
+            Self::persist_gpu_preference_snapshot(&snapshot)?;
+
+            for path_str in targets {
+                if let Err(e) = Self::set_registry_string_value(
                     Self::USER_GPU_PREFERENCES_KEY,
                     &path_str,
                     Self::GPU_PREFERENCE_HIGH_PERFORMANCE,
-                )
-            } else {
-                Self::delete_registry_value(Self::USER_GPU_PREFERENCES_KEY, &path_str)
-            };
+                ) {
+                    warn!("GPU preference apply for {} failed: {}", path_str, e);
+                    failures.push(format!("{}: {}", path_str, e));
+                }
+            }
 
-            if let Err(e) = result {
-                let op = if enable { "apply" } else { "clear" };
-                warn!("GPU preference {} for {} failed: {}", op, path_str, e);
-                failures.push(format!("{}: {}", path_str, e));
+            if failures.is_empty() {
+                return Ok(());
+            }
+
+            return Err(anyhow::anyhow!(
+                "GPU preference apply failed for {} executable(s): {}",
+                failures.len(),
+                failures.join("; ")
+            ));
+        }
+
+        let mut snapshot = Self::load_gpu_preference_snapshot();
+        for path_str in targets {
+            match Self::gpu_preference_restore_action(snapshot.values.get(&path_str)) {
+                GpuPreferenceRestoreAction::Restore(original) => {
+                    if let Err(e) = Self::set_registry_string_value(
+                        Self::USER_GPU_PREFERENCES_KEY,
+                        &path_str,
+                        &original,
+                    ) {
+                        warn!("GPU preference restore for {} failed: {}", path_str, e);
+                        failures.push(format!("{}: {}", path_str, e));
+                    } else {
+                        snapshot.values.remove(&path_str);
+                    }
+                }
+                GpuPreferenceRestoreAction::Delete => {
+                    if let Err(e) =
+                        Self::delete_registry_value(Self::USER_GPU_PREFERENCES_KEY, &path_str)
+                    {
+                        warn!("GPU preference clear for {} failed: {}", path_str, e);
+                        failures.push(format!("{}: {}", path_str, e));
+                    } else {
+                        snapshot.values.remove(&path_str);
+                    }
+                }
+                GpuPreferenceRestoreAction::LeaveUntouched => {
+                    info!(
+                        "Leaving untracked Roblox GPU preference untouched: {}",
+                        path_str
+                    );
+                }
             }
         }
 
+        if let Err(e) = Self::persist_gpu_preference_snapshot(&snapshot) {
+            failures.push(format!("snapshot persistence: {}", e));
+        }
+
         if failures.is_empty() {
-            Ok(())
-        } else {
-            // Surface a single Err so the call site's warnings collector
-            // (and downstream UI) actually fires. Without this the boost
-            // reports "applied" even when every registry write failed.
-            Err(anyhow::anyhow!(
-                "GPU preference {} failed for {} executable(s): {}",
-                if enable { "apply" } else { "clear" },
-                failures.len(),
-                failures.join("; ")
-            ))
+            return Ok(());
+        }
+
+        Err(anyhow::anyhow!(
+            "GPU preference restore failed for {} executable(s): {}",
+            failures.len(),
+            failures.join("; ")
+        ))
+    }
+
+    fn load_gpu_preference_snapshot() -> GpuPreferenceSnapshot {
+        let Some(path) = gpu_preference_snapshot_path() else {
+            return GpuPreferenceSnapshot::default();
+        };
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return GpuPreferenceSnapshot::default();
+            }
+            Err(e) => {
+                warn!("Failed to read Roblox GPU preference snapshot: {}", e);
+                return GpuPreferenceSnapshot::default();
+            }
+        };
+
+        match serde_json::from_str(&content) {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                warn!("Failed to parse Roblox GPU preference snapshot: {}", e);
+                GpuPreferenceSnapshot::default()
+            }
+        }
+    }
+
+    fn persist_gpu_preference_snapshot(snapshot: &GpuPreferenceSnapshot) -> Result<()> {
+        let Some(path) = gpu_preference_snapshot_path() else {
+            return if snapshot.values.is_empty() {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(
+                    "could not resolve config directory for GPU preference snapshot"
+                ))
+            };
+        };
+
+        if snapshot.values.is_empty() {
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to remove GPU preference snapshot {}: {}",
+                        path.display(),
+                        e
+                    ));
+                }
+            }
+            return Ok(());
+        }
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(snapshot)?;
+        fs::write(&path, json)?;
+        Ok(())
+    }
+
+    fn gpu_preference_restore_action(
+        snapshot: Option<&Option<String>>,
+    ) -> GpuPreferenceRestoreAction {
+        match snapshot {
+            Some(Some(original)) => GpuPreferenceRestoreAction::Restore(original.clone()),
+            Some(None) => GpuPreferenceRestoreAction::Delete,
+            None => GpuPreferenceRestoreAction::LeaveUntouched,
         }
     }
 
@@ -551,6 +703,37 @@ impl RobloxOptimizer {
             }
         }
         out
+    }
+
+    fn query_registry_string_value(key_path: &str, value_name: &str) -> Result<Option<String>> {
+        let output = hidden_command("reg")
+            .args(["query", key_path, "/v", value_name])
+            .output()?;
+
+        if !output.status.success() {
+            return Ok(None);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Self::parse_registry_string_value(&stdout, value_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "reg query succeeded for {}\\{} but no REG_SZ row was parsed",
+                key_path,
+                value_name
+            )
+        })
+    }
+
+    fn parse_registry_string_value(reg_query_output: &str, value_name: &str) -> Option<String> {
+        for line in reg_query_output.lines() {
+            let Some((name_part, data)) = line.split_once("    REG_SZ") else {
+                continue;
+            };
+            if name_part.trim().eq_ignore_ascii_case(value_name) {
+                return Some(data.trim().to_string());
+            }
+        }
+        None
     }
 
     fn set_registry_string_value(key_path: &str, value_name: &str, data: &str) -> Result<()> {
@@ -2770,6 +2953,63 @@ HKEY_CURRENT_USER\SOFTWARE\Microsoft\DirectX\UserGpuPreferences
     C:\Program Files\Steam\Steam.exe    REG_SZ    GpuPreference=2;
 "#;
         assert!(RobloxOptimizer::parse_gpu_preference_names(sample).is_empty());
+    }
+
+    #[test]
+    fn gpu_preference_restore_action_restores_snapshot_values() {
+        let original = Some("GpuPreference=1;".to_string());
+        assert_eq!(
+            RobloxOptimizer::gpu_preference_restore_action(Some(&original)),
+            GpuPreferenceRestoreAction::Restore("GpuPreference=1;".to_string())
+        );
+    }
+
+    #[test]
+    fn gpu_preference_restore_action_deletes_only_snapshot_absent_values() {
+        let originally_absent = None;
+        assert_eq!(
+            RobloxOptimizer::gpu_preference_restore_action(Some(&originally_absent)),
+            GpuPreferenceRestoreAction::Delete
+        );
+        assert_eq!(
+            RobloxOptimizer::gpu_preference_restore_action(None),
+            GpuPreferenceRestoreAction::LeaveUntouched
+        );
+    }
+
+    #[test]
+    fn gpu_preference_snapshot_preserves_absent_original_values() {
+        let mut snapshot = GpuPreferenceSnapshot::default();
+        snapshot.values.insert(
+            r"C:\Users\evelyn\AppData\Local\Roblox\Versions\version-aaa111\RobloxPlayerBeta.exe"
+                .to_string(),
+            None,
+        );
+        snapshot.values.insert(
+            r"C:\Users\evelyn\AppData\Local\Roblox\Versions\version-bbb222\RobloxStudioBeta.exe"
+                .to_string(),
+            Some("GpuPreference=1;".to_string()),
+        );
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let roundtrip: GpuPreferenceSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip, snapshot);
+    }
+
+    #[test]
+    fn parse_registry_string_value_extracts_path_named_value_data() {
+        let sample = r#"
+HKEY_CURRENT_USER\SOFTWARE\Microsoft\DirectX\UserGpuPreferences
+    C:\Users\evelyn\AppData\Local\Roblox\Versions\version-aaa111\RobloxPlayerBeta.exe    REG_SZ    GpuPreference=1;
+"#;
+
+        assert_eq!(
+            RobloxOptimizer::parse_registry_string_value(
+                sample,
+                r"C:\Users\evelyn\AppData\Local\Roblox\Versions\version-aaa111\RobloxPlayerBeta.exe",
+            ),
+            Some("GpuPreference=1;".to_string())
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/settings.rs
+++ b/swifttunnel-core/src/settings.rs
@@ -523,7 +523,6 @@ mod tests {
         assert!(settings.config.network_settings.enable_network_boost);
         assert!(settings.config.network_settings.disable_nagle);
         assert!(settings.config.network_settings.disable_network_throttling);
-        assert!(!settings.config.network_settings.gaming_qos);
         assert!(!settings.config.network_settings.firewall_fix);
     }
 
@@ -546,7 +545,6 @@ mod tests {
         assert!(!settings.config.network_settings.enable_network_boost);
         assert!(!settings.config.network_settings.disable_nagle);
         assert!(!settings.config.network_settings.disable_network_throttling);
-        assert!(!settings.config.network_settings.gaming_qos);
     }
 
     #[test]

--- a/swifttunnel-core/src/structs.rs
+++ b/swifttunnel-core/src/structs.rs
@@ -190,15 +190,11 @@ impl GraphicsQuality {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct NetworkConfig {
     pub enable_network_boost: bool,
-    pub prioritize_roblox_traffic: bool,
     // Tier 1 (Safe) Network Boosts
     #[serde(default)]
     pub disable_nagle: bool,
     #[serde(default)]
     pub disable_network_throttling: bool,
-    /// Gaming QoS - Marks Roblox and relay tunnel UDP packets with DSCP EF (46)
-    #[serde(default)]
-    pub gaming_qos: bool,
     /// Firewall Fix - Adds Windows Firewall allow rules for Roblox, flushes DNS, resets Winsock
     #[serde(default)]
     pub firewall_fix: bool,
@@ -208,11 +204,9 @@ impl Default for NetworkConfig {
     fn default() -> Self {
         Self {
             enable_network_boost: false,
-            prioritize_roblox_traffic: false,
             // Tier 1 network boosts are opt-in by default.
             disable_nagle: false,
             disable_network_throttling: false,
-            gaming_qos: false,
             firewall_fix: false, // Off by default, one-click fix for Roblox launch crashes
         }
     }
@@ -220,11 +214,7 @@ impl Default for NetworkConfig {
 
 impl NetworkConfig {
     fn any_specific_boost_enabled(&self) -> bool {
-        self.prioritize_roblox_traffic
-            || self.disable_nagle
-            || self.disable_network_throttling
-            || self.gaming_qos
-            || self.firewall_fix
+        self.disable_nagle || self.disable_network_throttling || self.firewall_fix
     }
 
     pub fn has_enabled_boosts(&self) -> bool {
@@ -244,6 +234,9 @@ impl<'de> Deserialize<'de> for NetworkConfig {
         #[derive(Default, Deserialize)]
         struct NetworkConfigWire {
             enable_network_boost: Option<bool>,
+            // Removed QoS fields are accepted only so legacy settings with
+            // explicit per-toggle state do not get mistaken for old master-only
+            // configs and have unrelated boosts enabled during migration.
             prioritize_roblox_traffic: Option<bool>,
             disable_nagle: Option<bool>,
             disable_network_throttling: Option<bool>,
@@ -252,18 +245,16 @@ impl<'de> Deserialize<'de> for NetworkConfig {
         }
 
         let wire = NetworkConfigWire::deserialize(deserializer)?;
-        let has_any_specific_field = wire.prioritize_roblox_traffic.is_some()
-            || wire.disable_nagle.is_some()
+        let has_any_specific_field = wire.disable_nagle.is_some()
             || wire.disable_network_throttling.is_some()
-            || wire.gaming_qos.is_some()
-            || wire.firewall_fix.is_some();
+            || wire.firewall_fix.is_some()
+            || wire.prioritize_roblox_traffic.is_some()
+            || wire.gaming_qos.is_some();
 
         let mut config = NetworkConfig {
             enable_network_boost: wire.enable_network_boost.unwrap_or(false),
-            prioritize_roblox_traffic: wire.prioritize_roblox_traffic.unwrap_or(false),
             disable_nagle: wire.disable_nagle.unwrap_or(false),
             disable_network_throttling: wire.disable_network_throttling.unwrap_or(false),
-            gaming_qos: wire.gaming_qos.unwrap_or(false),
             firewall_fix: wire.firewall_fix.unwrap_or(false),
         };
 
@@ -434,16 +425,6 @@ pub mod boost_info {
         requires_admin: true,
     };
 
-    pub const GAMING_QOS: BoostInfo = BoostInfo {
-        id: "gaming_qos",
-        title: "Gaming QoS",
-        short_desc: "Router traffic prioritization",
-        long_desc: "Marks Roblox and SwiftTunnel relay UDP packets with DSCP EF (Expedited Forwarding) priority. If your router supports QoS, gameplay traffic is prioritized over downloads, streaming, and other activity. Safe, no side effects.",
-        impact: "-5-20ms if router honors QoS",
-        risk_level: RiskLevel::Safe,
-        requires_admin: true,
-    };
-
     pub const FIREWALL_FIX: BoostInfo = BoostInfo {
         id: "firewall_fix",
         title: "Roblox Firewall Fix",
@@ -477,13 +458,8 @@ pub mod boost_info {
     }
 
     /// Get all network boost infos
-    pub fn network_boosts() -> [&'static BoostInfo; 4] {
-        [
-            &DISABLE_NAGLE,
-            &NETWORK_THROTTLING,
-            &GAMING_QOS,
-            &FIREWALL_FIX,
-        ]
+    pub fn network_boosts() -> [&'static BoostInfo; 3] {
+        [&DISABLE_NAGLE, &NETWORK_THROTTLING, &FIREWALL_FIX]
     }
 
     /// Get all Roblox boost infos
@@ -573,10 +549,8 @@ mod tests {
     fn test_network_config_default() {
         let cfg = NetworkConfig::default();
         assert!(!cfg.enable_network_boost);
-        assert!(!cfg.prioritize_roblox_traffic);
         assert!(!cfg.disable_nagle);
         assert!(!cfg.disable_network_throttling);
-        assert!(!cfg.gaming_qos);
         assert!(!cfg.firewall_fix);
     }
 
@@ -587,8 +561,6 @@ mod tests {
         assert!(cfg.enable_network_boost);
         assert!(cfg.disable_nagle);
         assert!(cfg.disable_network_throttling);
-        assert!(!cfg.gaming_qos);
-        assert!(!cfg.prioritize_roblox_traffic);
         assert!(!cfg.firewall_fix);
     }
 
@@ -611,6 +583,21 @@ mod tests {
     }
 
     #[test]
+    fn test_network_config_drops_removed_qos_fields_without_inventing_boosts() {
+        let cfg: NetworkConfig = serde_json::from_str(
+            r#"{
+              "enable_network_boost": true,
+              "prioritize_roblox_traffic": true,
+              "gaming_qos": true
+            }"#,
+        )
+        .unwrap();
+
+        assert!(!cfg.enable_network_boost);
+        assert!(!cfg.has_enabled_boosts());
+    }
+
+    #[test]
     fn test_network_config_master_tracks_specific_boosts() {
         let mut cfg = NetworkConfig {
             disable_network_throttling: true,
@@ -622,7 +609,6 @@ mod tests {
         assert!(cfg.enable_network_boost);
         assert!(!cfg.disable_nagle);
         assert!(cfg.disable_network_throttling);
-        assert!(!cfg.gaming_qos);
     }
 
     #[test]
@@ -716,7 +702,7 @@ mod tests {
 
     #[test]
     fn test_network_boosts_count() {
-        assert_eq!(boost_info::network_boosts().len(), 4);
+        assert_eq!(boost_info::network_boosts().len(), 3);
     }
 
     #[test]
@@ -740,10 +726,6 @@ mod tests {
         assert!(
             boost_info::NETWORK_THROTTLING.requires_admin,
             "Network throttling writes to HKLM, must require admin"
-        );
-        assert!(
-            boost_info::GAMING_QOS.requires_admin,
-            "QoS writes to HKLM, must require admin"
         );
         assert!(
             boost_info::FIREWALL_FIX.requires_admin,

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -960,12 +960,26 @@ impl SystemOptimizer {
             1,
         );
 
-        // The kernel reads this key only at boot — log so users grepping for
-        // "why isn't my timer boost working" get a useful breadcrumb.
-        info!(
-            "Wrote {}\\{}=1; reboot required for the global override to take effect on Windows 11 22H2+",
-            GLOBAL_TIMER_RESOLUTION_KEY, GLOBAL_TIMER_RESOLUTION_VALUE
-        );
+        // `set_registry_dword` is fire-and-forget (it only warns on failure)
+        // because most callers in this module want best-effort semantics.
+        // For this HKLM write we actually care: a non-admin session will be
+        // rejected by Windows, and logging "Wrote …=1" anyway leaves users
+        // chasing a phantom reboot prompt. Verify via readback before
+        // claiming success, and downgrade to warn! when the write was
+        // dropped so the failure shows up in user logs.
+        match Self::query_registry_dword(
+            GLOBAL_TIMER_RESOLUTION_KEY,
+            GLOBAL_TIMER_RESOLUTION_VALUE,
+        ) {
+            Some(1) => info!(
+                "Wrote {}\\{}=1; reboot required for the global override to take effect on Windows 11 22H2+",
+                GLOBAL_TIMER_RESOLUTION_KEY, GLOBAL_TIMER_RESOLUTION_VALUE
+            ),
+            other => warn!(
+                "GlobalTimerResolutionRequests write was not visible after apply (read back {:?}); admin rights may be required for HKLM\\…\\kernel — the 0.5ms timer boost will remain process-scoped on Windows 11",
+                other
+            ),
+        }
     }
 
     fn restore_global_timer_resolution_override(&mut self) {

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -8,8 +8,6 @@ use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::Media::{timeBeginPeriod, timeEndPeriod};
 use windows::Win32::System::Threading::*;
 
-const ALL_CORES_AFFINITY_MASK: usize = usize::MAX;
-
 // ntdll.dll functions for low-level system control
 unsafe extern "system" {
     // Sub-millisecond timer resolution (0.5ms)
@@ -687,17 +685,21 @@ impl SystemOptimizer {
                     && process_mask != 0
                 {
                     self.original_affinity = Some(process_mask);
-                } else {
-                    // Fall back to "all cores in the system" if we can't read
-                    // the current mask — better than leaving the process
-                    // pinned forever after disable.
-                    self.original_affinity = Some(if system_mask != 0 {
-                        system_mask
-                    } else {
-                        ALL_CORES_AFFINITY_MASK
-                    });
+                } else if system_mask != 0 {
+                    // Fall back to the system-wide mask. Windows rejects any
+                    // SetProcessAffinityMask whose bits extend past the
+                    // system mask, so we must never store usize::MAX — that
+                    // restore call would fail and leave Roblox pinned to
+                    // SwiftTunnel's chosen cores. If even system_mask is
+                    // unreadable we skip capturing entirely (per Greptile).
+                    self.original_affinity = Some(system_mask);
                     warn!(
-                        "Could not read original affinity for PID {}; restore will use system mask",
+                        "Could not read original affinity for PID {}; restore will use system mask 0x{:X}",
+                        process_id, system_mask
+                    );
+                } else {
+                    warn!(
+                        "Could not read original or system affinity mask for PID {}; affinity restore is skipped",
                         process_id
                     );
                 }

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -66,15 +66,38 @@ struct MmcssSnapshot {
     system_responsiveness: Option<u32>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", content = "value", rename_all = "snake_case")]
+enum RegistryDwordSnapshot {
+    Present(u32),
+    Absent,
+}
+
+impl RegistryDwordSnapshot {
+    fn from_snapshot(snapshot: Option<u32>) -> Self {
+        match snapshot {
+            Some(value) => Self::Present(value),
+            None => Self::Absent,
+        }
+    }
+
+    fn into_snapshot(self) -> Option<u32> {
+        match self {
+            Self::Present(value) => Some(value),
+            Self::Absent => None,
+        }
+    }
+}
+
 /// On-disk snapshot of persistent system settings SwiftTunnel has changed.
 ///
 /// This is intentionally narrow: process priority, process affinity, and timer
 /// requests are process-local and disappear on exit, but
 /// `GlobalTimerResolutionRequests` is an HKLM value that survives crashes.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 struct PersistentSystemSnapshot {
     #[serde(default)]
-    global_timer_snapshot: Option<Option<u32>>,
+    global_timer_snapshot: Option<RegistryDwordSnapshot>,
 }
 
 const SYSTEM_SNAPSHOT_FILE: &str = "system_optimizer_snapshots.json";
@@ -383,7 +406,9 @@ impl SystemOptimizer {
 
     fn persistent_snapshot(&self) -> PersistentSystemSnapshot {
         PersistentSystemSnapshot {
-            global_timer_snapshot: self.global_timer_snapshot,
+            global_timer_snapshot: self
+                .global_timer_snapshot
+                .map(RegistryDwordSnapshot::from_snapshot),
         }
     }
 
@@ -1324,8 +1349,8 @@ impl SystemOptimizer {
             return;
         };
 
-        if snapshot.global_timer_snapshot.is_some() {
-            self.global_timer_snapshot = snapshot.global_timer_snapshot;
+        if let Some(snapshot) = snapshot.global_timer_snapshot {
+            self.global_timer_snapshot = Some(snapshot.into_snapshot());
             if let Err(e) = self.restore_global_timer_resolution_override() {
                 warn!(
                     "Failed to recover GlobalTimerResolutionRequests from snapshot: {}",
@@ -1876,20 +1901,26 @@ mod tests {
     #[test]
     fn persistent_system_snapshot_preserves_absent_and_present_timer_values() {
         let absent = PersistentSystemSnapshot {
-            global_timer_snapshot: Some(None),
+            global_timer_snapshot: Some(RegistryDwordSnapshot::Absent),
         };
         let absent_json = serde_json::to_string(&absent).unwrap();
         let absent_roundtrip: PersistentSystemSnapshot =
             serde_json::from_str(&absent_json).unwrap();
-        assert_eq!(absent_roundtrip.global_timer_snapshot, Some(None));
+        assert_eq!(
+            absent_roundtrip.global_timer_snapshot,
+            Some(RegistryDwordSnapshot::Absent)
+        );
 
         let present = PersistentSystemSnapshot {
-            global_timer_snapshot: Some(Some(1)),
+            global_timer_snapshot: Some(RegistryDwordSnapshot::Present(1)),
         };
         let present_json = serde_json::to_string(&present).unwrap();
         let present_roundtrip: PersistentSystemSnapshot =
             serde_json::from_str(&present_json).unwrap();
-        assert_eq!(present_roundtrip.global_timer_snapshot, Some(Some(1)));
+        assert_eq!(
+            present_roundtrip.global_timer_snapshot,
+            Some(RegistryDwordSnapshot::Present(1))
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -1,6 +1,7 @@
 use crate::hidden_command;
 use crate::structs::*;
 use log::{info, warn};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -65,6 +66,23 @@ struct MmcssSnapshot {
     system_responsiveness: Option<u32>,
 }
 
+/// On-disk snapshot of persistent system settings SwiftTunnel has changed.
+///
+/// This is intentionally narrow: process priority, process affinity, and timer
+/// requests are process-local and disappear on exit, but
+/// `GlobalTimerResolutionRequests` is an HKLM value that survives crashes.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct PersistentSystemSnapshot {
+    #[serde(default)]
+    global_timer_snapshot: Option<Option<u32>>,
+}
+
+const SYSTEM_SNAPSHOT_FILE: &str = "system_optimizer_snapshots.json";
+
+fn system_snapshot_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("SwiftTunnel").join(SYSTEM_SNAPSHOT_FILE))
+}
+
 pub struct SystemOptimizer {
     original_priority: Option<u32>,
     original_affinity: Option<usize>,
@@ -77,6 +95,23 @@ pub struct SystemOptimizer {
     game_mode_enabled_snapshot: Option<Option<u32>>,
     mmcss_snapshot: Option<MmcssSnapshot>,
     swifttunnel_power_plan_imported: bool,
+}
+
+pub struct SystemApplyOutcome {
+    pub applied_config: SystemOptimizationConfig,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SystemBoostToggle {
+    HighPriority,
+    CpuAffinity,
+    GameBar,
+    FullscreenOptimization,
+    PowerPlan,
+    TimerResolution,
+    MmcssGamingProfile,
+    GameMode,
 }
 
 impl SystemOptimizer {
@@ -205,6 +240,12 @@ impl SystemOptimizer {
     }
 
     fn set_registry_dword(key_path: &str, value_name: &str, value: u32) {
+        if let Err(e) = Self::set_registry_dword_checked(key_path, value_name, value) {
+            warn!("{}", e);
+        }
+    }
+
+    fn set_registry_dword_checked(key_path: &str, value_name: &str, value: u32) -> Result<()> {
         let value_str = value.to_string();
         let output = hidden_command("reg")
             .args([
@@ -218,43 +259,63 @@ impl SystemOptimizer {
                 &value_str,
                 "/f",
             ])
-            .output();
+            .output()?;
 
-        match output {
-            Ok(result) if result.status.success() => {}
-            Ok(_) => warn!("Failed to set {}\\{} to {}", key_path, value_name, value),
-            Err(e) => warn!(
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(anyhow::anyhow!(
                 "Failed to set {}\\{} to {}: {}",
-                key_path, value_name, value, e
-            ),
+                key_path,
+                value_name,
+                value,
+                stderr.trim()
+            ))
         }
     }
 
     fn set_registry_string(key_path: &str, value_name: &str, value: &str) {
+        if let Err(e) = Self::set_registry_string_checked(key_path, value_name, value) {
+            warn!("{}", e);
+        }
+    }
+
+    fn set_registry_string_checked(key_path: &str, value_name: &str, value: &str) -> Result<()> {
         let output = hidden_command("reg")
             .args([
                 "add", key_path, "/v", value_name, "/t", "REG_SZ", "/d", value, "/f",
             ])
-            .output();
+            .output()?;
 
-        match output {
-            Ok(result) if result.status.success() => {}
-            Ok(_) => warn!("Failed to set {}\\{} to {}", key_path, value_name, value),
-            Err(e) => warn!(
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(anyhow::anyhow!(
                 "Failed to set {}\\{} to {}: {}",
-                key_path, value_name, value, e
-            ),
+                key_path,
+                value_name,
+                value,
+                stderr.trim()
+            ))
         }
     }
 
     fn restore_registry_dword(key_path: &str, value_name: &str, snapshot: Option<u32>) {
+        if let Err(e) = Self::restore_registry_dword_checked(key_path, value_name, snapshot) {
+            warn!("{}", e);
+        }
+    }
+
+    fn restore_registry_dword_checked(
+        key_path: &str,
+        value_name: &str,
+        snapshot: Option<u32>,
+    ) -> Result<()> {
         match snapshot {
-            Some(value) => Self::set_registry_dword(key_path, value_name, value),
-            None => {
-                let _ = hidden_command("reg")
-                    .args(["delete", key_path, "/v", value_name, "/f"])
-                    .output();
-            }
+            Some(value) => Self::set_registry_dword_checked(key_path, value_name, value),
+            None => Self::delete_registry_value_checked(key_path, value_name),
         }
     }
 
@@ -269,9 +330,89 @@ impl SystemOptimizer {
         }
     }
 
+    fn delete_registry_value_checked(key_path: &str, value_name: &str) -> Result<()> {
+        let output = hidden_command("reg")
+            .args(["delete", key_path, "/v", value_name, "/f"])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let probe = hidden_command("reg")
+            .args(["query", key_path, "/v", value_name])
+            .output()?;
+        if !probe.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!(
+            "Failed to delete {}\\{}: {}",
+            key_path,
+            value_name,
+            stderr.trim()
+        ))
+    }
+
     fn capture_dword_snapshot(slot: &mut Option<Option<u32>>, key_path: &str, value_name: &str) {
         if slot.is_none() {
             *slot = Some(Self::query_registry_dword(key_path, value_name));
+        }
+    }
+
+    fn load_persistent_snapshot() -> Option<PersistentSystemSnapshot> {
+        let path = system_snapshot_path()?;
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                warn!("Failed to read system optimizer snapshot: {}", e);
+                return None;
+            }
+        };
+
+        match serde_json::from_str(&content) {
+            Ok(snapshot) => Some(snapshot),
+            Err(e) => {
+                warn!("Failed to parse system optimizer snapshot: {}", e);
+                None
+            }
+        }
+    }
+
+    fn persistent_snapshot(&self) -> PersistentSystemSnapshot {
+        PersistentSystemSnapshot {
+            global_timer_snapshot: self.global_timer_snapshot,
+        }
+    }
+
+    fn persist_snapshot(&self) {
+        let snapshot = self.persistent_snapshot();
+        if snapshot.global_timer_snapshot.is_none() {
+            Self::clear_snapshot();
+            return;
+        }
+
+        let Some(path) = system_snapshot_path() else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        match serde_json::to_string_pretty(&snapshot) {
+            Ok(json) => {
+                if let Err(e) = fs::write(&path, json) {
+                    warn!("Failed to persist system optimizer snapshot: {}", e);
+                }
+            }
+            Err(e) => warn!("Failed to serialize system optimizer snapshot: {}", e),
+        }
+    }
+
+    fn clear_snapshot() {
+        if let Some(path) = system_snapshot_path() {
+            let _ = fs::remove_file(path);
         }
     }
 
@@ -491,6 +632,59 @@ impl SystemOptimizer {
         matches!(installed, Some(false))
     }
 
+    fn power_plan_from_guid(guid: &str) -> Option<PowerPlan> {
+        if guid.eq_ignore_ascii_case(BALANCED_POWER_PLAN_GUID) {
+            Some(PowerPlan::Balanced)
+        } else if guid.eq_ignore_ascii_case(HIGH_PERFORMANCE_POWER_PLAN_GUID) {
+            Some(PowerPlan::HighPerformance)
+        } else if guid.eq_ignore_ascii_case(ULTIMATE_POWER_PLAN_GUID) {
+            Some(PowerPlan::Ultimate)
+        } else if guid.eq_ignore_ascii_case(SWIFTTUNNEL_POWER_PLAN_GUID) {
+            Some(PowerPlan::SwiftTunnel)
+        } else {
+            None
+        }
+    }
+
+    fn fallback_power_plan_config(config: &SystemOptimizationConfig) -> PowerPlan {
+        Self::active_power_plan_guid()
+            .as_deref()
+            .and_then(Self::power_plan_from_guid)
+            .or(config.previous_power_plan)
+            .unwrap_or(PowerPlan::Balanced)
+    }
+
+    fn mark_failed_boost(
+        applied_config: &mut SystemOptimizationConfig,
+        toggle: SystemBoostToggle,
+        fallback_power_plan: PowerPlan,
+    ) {
+        match toggle {
+            SystemBoostToggle::HighPriority => applied_config.set_high_priority = false,
+            SystemBoostToggle::CpuAffinity => applied_config.set_cpu_affinity = false,
+            SystemBoostToggle::GameBar => applied_config.disable_game_bar = false,
+            SystemBoostToggle::FullscreenOptimization => {
+                applied_config.disable_fullscreen_optimization = false;
+            }
+            SystemBoostToggle::PowerPlan => applied_config.power_plan = fallback_power_plan,
+            SystemBoostToggle::TimerResolution => applied_config.timer_resolution_1ms = false,
+            SystemBoostToggle::MmcssGamingProfile => applied_config.mmcss_gaming_profile = false,
+            SystemBoostToggle::GameMode => applied_config.game_mode_enabled = false,
+        }
+    }
+
+    fn record_failure(
+        applied_config: &mut SystemOptimizationConfig,
+        warnings: &mut Vec<String>,
+        toggle: SystemBoostToggle,
+        label: &str,
+        error: impl std::fmt::Display,
+        fallback_power_plan: PowerPlan,
+    ) {
+        Self::mark_failed_boost(applied_config, toggle, fallback_power_plan);
+        warnings.push(format!("{}: {}", label, error));
+    }
+
     fn capture_system_state_snapshots(&mut self, config: &SystemOptimizationConfig) {
         if config.disable_game_bar {
             Self::capture_dword_snapshot(&mut self.game_bar_snapshot, GAME_BAR_KEY, GAME_BAR_VALUE);
@@ -558,16 +752,41 @@ impl SystemOptimizer {
         );
     }
 
-    /// Apply all system optimizations
+    /// Apply all system optimizations.
     pub fn apply_optimizations(
         &mut self,
         config: &SystemOptimizationConfig,
         process_id: u32,
     ) -> Result<()> {
+        let outcome = self.apply_optimizations_checked(config, process_id);
+        if !outcome.warnings.is_empty() {
+            warn!(
+                "System optimizations applied with warnings: {}",
+                outcome.warnings.join("; ")
+            );
+        }
+        Ok(())
+    }
+
+    /// Apply system optimizations and return the config that actually applied.
+    ///
+    /// Retryable process-local states such as "Roblox is not running yet" keep
+    /// the requested toggle enabled so a later runtime monitor can apply it.
+    /// Hard backing failures clear the affected toggle before the config is
+    /// persisted.
+    pub fn apply_optimizations_checked(
+        &mut self,
+        config: &SystemOptimizationConfig,
+        process_id: u32,
+    ) -> SystemApplyOutcome {
         info!(
             "Applying system optimizations for process ID: {}",
             process_id
         );
+
+        let mut applied_config = config.clone();
+        let mut warnings = Vec::new();
+        let fallback_power_plan = Self::fallback_power_plan_config(config);
 
         self.capture_system_state_snapshots(config);
 
@@ -575,50 +794,131 @@ impl SystemOptimizer {
             if process_id == 0 {
                 info!("Skipping process priority boost: no active game process detected yet");
             } else if let Err(e) = self.set_process_priority(process_id) {
-                // Process-specific boosts can legitimately fail during restart flows.
-                // Keep applying all other boosts; priority will be retried by runtime monitors.
-                warn!(
-                    "Could not set process priority for PID {} (will retry later): {}",
-                    process_id, e
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::HighPriority,
+                    "Set process priority",
+                    e,
+                    fallback_power_plan,
                 );
             }
         }
 
-        if config.set_cpu_affinity && !config.cpu_cores.is_empty() {
-            if process_id == 0 {
+        if config.set_cpu_affinity {
+            if config.cpu_cores.is_empty() {
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::CpuAffinity,
+                    "Set CPU affinity",
+                    "no CPU cores selected",
+                    fallback_power_plan,
+                );
+            } else if let Err(e) = Self::validate_cpu_cores(&config.cpu_cores) {
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::CpuAffinity,
+                    "Set CPU affinity",
+                    e,
+                    fallback_power_plan,
+                );
+            } else if process_id == 0 {
                 info!("Skipping CPU affinity boost: no active game process detected yet");
             } else if let Err(e) = self.set_cpu_affinity(process_id, &config.cpu_cores) {
-                warn!(
-                    "Could not set CPU affinity for PID {} (will retry later): {}",
-                    process_id, e
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::CpuAffinity,
+                    "Set CPU affinity",
+                    e,
+                    fallback_power_plan,
                 );
             }
         }
 
         if config.disable_game_bar {
-            self.disable_game_bar()?;
+            if let Err(e) = self.disable_game_bar() {
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::GameBar,
+                    "Disable Game Bar",
+                    e,
+                    fallback_power_plan,
+                );
+            }
         }
 
         if config.disable_fullscreen_optimization {
-            self.disable_fullscreen_optimizations()?;
+            if let Err(e) = self.disable_fullscreen_optimizations() {
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::FullscreenOptimization,
+                    "Disable fullscreen optimizations",
+                    e,
+                    fallback_power_plan,
+                );
+            }
         }
 
-        self.set_power_plan(&config.power_plan)?;
+        if let Err(e) = self.set_power_plan(&config.power_plan) {
+            Self::record_failure(
+                &mut applied_config,
+                &mut warnings,
+                SystemBoostToggle::PowerPlan,
+                "Set power plan",
+                e,
+                fallback_power_plan,
+            );
+        }
 
         // Tier 1 (Safe) Boosts
         if config.timer_resolution_1ms {
-            self.set_timer_resolution(true)?;
+            if let Err(e) = self.set_timer_resolution(true) {
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::TimerResolution,
+                    "Set timer resolution",
+                    e,
+                    fallback_power_plan,
+                );
+            }
         }
 
         if config.mmcss_gaming_profile {
-            self.apply_mmcss_profile()?;
+            if let Err(e) = self.apply_mmcss_profile() {
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::MmcssGamingProfile,
+                    "Apply MMCSS gaming profile",
+                    e,
+                    fallback_power_plan,
+                );
+            }
         }
 
         if config.game_mode_enabled {
-            self.enable_game_mode()?;
+            if let Err(e) = self.enable_game_mode() {
+                Self::record_failure(
+                    &mut applied_config,
+                    &mut warnings,
+                    SystemBoostToggle::GameMode,
+                    "Enable Game Mode",
+                    e,
+                    fallback_power_plan,
+                );
+            }
         }
 
-        Ok(())
+        SystemApplyOutcome {
+            applied_config,
+            warnings,
+        }
     }
 
     /// Set Roblox process to high priority
@@ -794,7 +1094,10 @@ impl SystemOptimizer {
                     stderr.trim()
                 ))
             }
-            Err(e) => Err(anyhow::anyhow!("Game Bar disable: reg invoke failed: {}", e)),
+            Err(e) => Err(anyhow::anyhow!(
+                "Game Bar disable: reg invoke failed: {}",
+                e
+            )),
         }
     }
 
@@ -891,6 +1194,7 @@ impl SystemOptimizer {
     pub fn set_timer_resolution(&mut self, enable: bool) -> Result<()> {
         if enable && !self.timer_resolution_active {
             info!("Setting timer resolution to 0.5ms");
+            let mut timer_applied = false;
             unsafe {
                 // Try NtSetTimerResolution for 0.5ms (5000 * 100ns = 0.5ms)
                 let mut current: u32 = 0;
@@ -898,6 +1202,7 @@ impl SystemOptimizer {
                 if status == 0 {
                     // STATUS_SUCCESS
                     self.timer_resolution_active = true;
+                    timer_applied = true;
                     info!(
                         "Timer resolution set to 0.5ms via NtSetTimerResolution (actual: {:.3}ms)",
                         current as f64 / 10000.0
@@ -911,6 +1216,7 @@ impl SystemOptimizer {
                     let result = timeBeginPeriod(1);
                     if result == 0 {
                         self.timer_resolution_active = true;
+                        timer_applied = true;
                         info!("Timer resolution set to 1ms via timeBeginPeriod (fallback)");
                     } else {
                         warn!("Failed to set timer resolution: error code {}", result);
@@ -918,77 +1224,114 @@ impl SystemOptimizer {
                 }
             }
 
+            if !timer_applied {
+                return Err(anyhow::anyhow!(
+                    "NtSetTimerResolution and timeBeginPeriod both failed"
+                ));
+            }
+
             // Make sure the system-wide override is on so the per-process
             // resolution we just set is honored for other processes too on
             // Win11 22H2+. Snapshot the prior value so restore() can revert.
-            self.enable_global_timer_resolution_override();
+            if let Err(e) = self.enable_global_timer_resolution_override() {
+                self.clear_timer_resolution_request();
+                let _ = self.restore_global_timer_resolution_override();
+                return Err(e);
+            }
         } else if !enable && self.timer_resolution_active {
             info!("Restoring default timer resolution");
-            unsafe {
-                // Undo NtSetTimerResolution
-                let mut current: u32 = 0;
-                let _ = NtSetTimerResolution(5000, 0, &mut current);
-                // Also undo timeBeginPeriod in case fallback was used
-                let _ = timeEndPeriod(1);
-                self.timer_resolution_active = false;
-            }
-            self.restore_global_timer_resolution_override();
+            self.clear_timer_resolution_request();
+            self.restore_global_timer_resolution_override()?;
         }
         Ok(())
     }
 
-    fn enable_global_timer_resolution_override(&mut self) {
+    fn clear_timer_resolution_request(&mut self) {
+        if !self.timer_resolution_active {
+            return;
+        }
+
+        unsafe {
+            // Undo NtSetTimerResolution
+            let mut current: u32 = 0;
+            let _ = NtSetTimerResolution(5000, 0, &mut current);
+            // Also undo timeBeginPeriod in case fallback was used
+            let _ = timeEndPeriod(1);
+            self.timer_resolution_active = false;
+        }
+    }
+
+    fn enable_global_timer_resolution_override(&mut self) -> Result<()> {
         Self::capture_dword_snapshot(
             &mut self.global_timer_snapshot,
             GLOBAL_TIMER_RESOLUTION_KEY,
             GLOBAL_TIMER_RESOLUTION_VALUE,
         );
+        self.persist_snapshot();
 
         // Skip the write if it's already 1 — avoids an unnecessary reg call
         // and prevents spurious "needs reboot" telemetry on repeat applies.
-        if Self::query_registry_dword(
-            GLOBAL_TIMER_RESOLUTION_KEY,
-            GLOBAL_TIMER_RESOLUTION_VALUE,
-        ) == Some(1)
+        if Self::query_registry_dword(GLOBAL_TIMER_RESOLUTION_KEY, GLOBAL_TIMER_RESOLUTION_VALUE)
+            == Some(1)
         {
-            return;
+            return Ok(());
         }
 
-        Self::set_registry_dword(
+        Self::set_registry_dword_checked(
             GLOBAL_TIMER_RESOLUTION_KEY,
             GLOBAL_TIMER_RESOLUTION_VALUE,
             1,
-        );
+        )?;
 
-        // `set_registry_dword` is fire-and-forget (it only warns on failure)
-        // because most callers in this module want best-effort semantics.
-        // For this HKLM write we actually care: a non-admin session will be
-        // rejected by Windows, and logging "Wrote …=1" anyway leaves users
-        // chasing a phantom reboot prompt. Verify via readback before
-        // claiming success, and downgrade to warn! when the write was
-        // dropped so the failure shows up in user logs.
-        match Self::query_registry_dword(
-            GLOBAL_TIMER_RESOLUTION_KEY,
-            GLOBAL_TIMER_RESOLUTION_VALUE,
-        ) {
-            Some(1) => info!(
-                "Wrote {}\\{}=1; reboot required for the global override to take effect on Windows 11 22H2+",
-                GLOBAL_TIMER_RESOLUTION_KEY, GLOBAL_TIMER_RESOLUTION_VALUE
-            ),
-            other => warn!(
-                "GlobalTimerResolutionRequests write was not visible after apply (read back {:?}); admin rights may be required for HKLM\\…\\kernel — the 0.5ms timer boost will remain process-scoped on Windows 11",
+        // Verify via readback before claiming success. A non-admin session can
+        // reject the HKLM write; persisting the toggle anyway would leave users
+        // chasing a phantom reboot prompt.
+        match Self::query_registry_dword(GLOBAL_TIMER_RESOLUTION_KEY, GLOBAL_TIMER_RESOLUTION_VALUE)
+        {
+            Some(1) => {
+                info!(
+                    "Wrote {}\\{}=1; reboot required for the global override to take effect on Windows 11 22H2+",
+                    GLOBAL_TIMER_RESOLUTION_KEY, GLOBAL_TIMER_RESOLUTION_VALUE
+                );
+                Ok(())
+            }
+            other => Err(anyhow::anyhow!(
+                "GlobalTimerResolutionRequests write was not visible after apply (read back {:?}); admin rights may be required for HKLM\\…\\kernel",
                 other
-            ),
+            )),
         }
     }
 
-    fn restore_global_timer_resolution_override(&mut self) {
+    fn restore_global_timer_resolution_override(&mut self) -> Result<()> {
         if let Some(snapshot) = self.global_timer_snapshot.take() {
-            Self::restore_registry_dword(
+            if let Err(e) = Self::restore_registry_dword_checked(
                 GLOBAL_TIMER_RESOLUTION_KEY,
                 GLOBAL_TIMER_RESOLUTION_VALUE,
                 snapshot,
-            );
+            ) {
+                self.global_timer_snapshot = Some(snapshot);
+                self.persist_snapshot();
+                return Err(e);
+            }
+            self.persist_snapshot();
+        }
+        Ok(())
+    }
+
+    /// Recover persistent system optimizer changes after a forced app exit.
+    pub fn recover_from_snapshot(&mut self) {
+        let Some(snapshot) = Self::load_persistent_snapshot() else {
+            return;
+        };
+
+        if snapshot.global_timer_snapshot.is_some() {
+            self.global_timer_snapshot = snapshot.global_timer_snapshot;
+            if let Err(e) = self.restore_global_timer_resolution_override() {
+                warn!(
+                    "Failed to recover GlobalTimerResolutionRequests from snapshot: {}",
+                    e
+                );
+            }
         }
     }
 
@@ -1017,7 +1360,7 @@ impl SystemOptimizer {
         ];
 
         for (key_path, value_name, value_data) in mmcss_keys.iter() {
-            Self::set_registry_string(key_path, value_name, value_data);
+            Self::set_registry_string_checked(key_path, value_name, value_data)?;
         }
 
         // Set DWORD values separately
@@ -1041,7 +1384,7 @@ impl SystemOptimizer {
 
         for (key_path, value_name, value_data) in dword_keys.iter() {
             if let Ok(value) = value_data.parse::<u32>() {
-                Self::set_registry_dword(key_path, value_name, value);
+                Self::set_registry_dword_checked(key_path, value_name, value)?;
             }
         }
 
@@ -1078,7 +1421,7 @@ impl SystemOptimizer {
 
         for (key_path, value_name, value_data) in game_mode_keys.iter() {
             if let Ok(value) = value_data.parse::<u32>() {
-                Self::set_registry_dword(key_path, value_name, value);
+                Self::set_registry_dword_checked(key_path, value_name, value)?;
             }
         }
 
@@ -1097,7 +1440,7 @@ impl SystemOptimizer {
 
         for (key_path, value_name, value_data) in game_mode_keys.iter() {
             if let Ok(value) = value_data.parse::<u32>() {
-                Self::set_registry_dword(key_path, value_name, value);
+                Self::set_registry_dword_checked(key_path, value_name, value)?;
             }
         }
 
@@ -1184,14 +1527,19 @@ impl SystemOptimizer {
     /// Restore original system settings
     pub fn restore(&mut self, process_id: u32) -> Result<()> {
         info!("Restoring original system settings");
+        let mut restore_errors = Vec::new();
 
         // Restore timer resolution if active
         if self.timer_resolution_active {
-            self.set_timer_resolution(false)?;
+            if let Err(e) = self.set_timer_resolution(false) {
+                restore_errors.push(format!("timer resolution: {}", e));
+            }
         }
         // Safety net: clean up the global timer override snapshot even if
         // `timer_resolution_active` was already false (e.g., crash recovery).
-        self.restore_global_timer_resolution_override();
+        if let Err(e) = self.restore_global_timer_resolution_override() {
+            restore_errors.push(format!("global timer override: {}", e));
+        }
 
         if let Some(priority) = self.original_priority.take() {
             unsafe {
@@ -1259,7 +1607,14 @@ impl SystemOptimizer {
             }
         }
 
-        Ok(())
+        if restore_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "some system optimizer restore operations failed: {}",
+                restore_errors.join("; ")
+            ))
+        }
     }
 
     /// Check if timer resolution is currently active
@@ -1484,6 +1839,57 @@ mod tests {
         }
         let mask = SystemOptimizer::validate_cpu_cores(&[0, 1]).unwrap();
         assert_eq!(mask, 0b11);
+    }
+
+    #[test]
+    fn failed_system_boosts_clear_only_the_failed_toggle() {
+        let mut config = SystemOptimizationConfig {
+            set_high_priority: true,
+            set_cpu_affinity: true,
+            disable_game_bar: true,
+            disable_fullscreen_optimization: true,
+            power_plan: PowerPlan::SwiftTunnel,
+            timer_resolution_1ms: true,
+            mmcss_gaming_profile: true,
+            game_mode_enabled: true,
+            ..Default::default()
+        };
+
+        SystemOptimizer::mark_failed_boost(
+            &mut config,
+            SystemBoostToggle::TimerResolution,
+            PowerPlan::HighPerformance,
+        );
+        assert!(!config.timer_resolution_1ms);
+        assert!(config.set_high_priority);
+        assert!(config.set_cpu_affinity);
+        assert_eq!(config.power_plan, PowerPlan::SwiftTunnel);
+
+        SystemOptimizer::mark_failed_boost(
+            &mut config,
+            SystemBoostToggle::PowerPlan,
+            PowerPlan::HighPerformance,
+        );
+        assert_eq!(config.power_plan, PowerPlan::HighPerformance);
+    }
+
+    #[test]
+    fn persistent_system_snapshot_preserves_absent_and_present_timer_values() {
+        let absent = PersistentSystemSnapshot {
+            global_timer_snapshot: Some(None),
+        };
+        let absent_json = serde_json::to_string(&absent).unwrap();
+        let absent_roundtrip: PersistentSystemSnapshot =
+            serde_json::from_str(&absent_json).unwrap();
+        assert_eq!(absent_roundtrip.global_timer_snapshot, Some(None));
+
+        let present = PersistentSystemSnapshot {
+            global_timer_snapshot: Some(Some(1)),
+        };
+        let present_json = serde_json::to_string(&present).unwrap();
+        let present_roundtrip: PersistentSystemSnapshot =
+            serde_json::from_str(&present_json).unwrap();
+        assert_eq!(present_roundtrip.global_timer_snapshot, Some(Some(1)));
     }
 
     #[test]

--- a/swifttunnel-core/src/system_optimizer.rs
+++ b/swifttunnel-core/src/system_optimizer.rs
@@ -8,6 +8,8 @@ use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::Media::{timeBeginPeriod, timeEndPeriod};
 use windows::Win32::System::Threading::*;
 
+const ALL_CORES_AFFINITY_MASK: usize = usize::MAX;
+
 // ntdll.dll functions for low-level system control
 unsafe extern "system" {
     // Sub-millisecond timer resolution (0.5ms)
@@ -29,6 +31,15 @@ const MMCSS_GAMES_KEY: &str =
     r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games";
 const MMCSS_SYSTEM_PROFILE_KEY: &str =
     r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile";
+// Windows 11 22H2+ scopes `NtSetTimerResolution` / `timeBeginPeriod` to the
+// calling process only. Without this registry override, a 0.5ms resolution
+// request from SwiftTunnel does not propagate to Roblox — the boost becomes
+// effectively a no-op for the game. Setting this key to 1 restores the
+// Windows 10 global-timer behavior. The kernel reads it at boot, so a reboot
+// is required for changes to take effect.
+const GLOBAL_TIMER_RESOLUTION_KEY: &str =
+    r"HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\kernel";
+const GLOBAL_TIMER_RESOLUTION_VALUE: &str = "GlobalTimerResolutionRequests";
 const BALANCED_POWER_PLAN_GUID: &str = "381b4222-f694-41f0-9685-ff5bb260df2e";
 const HIGH_PERFORMANCE_POWER_PLAN_GUID: &str = "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c";
 const ULTIMATE_POWER_PLAN_GUID: &str = "e9a42b02-d5df-448d-aa00-03f14749eb61";
@@ -58,7 +69,9 @@ struct MmcssSnapshot {
 
 pub struct SystemOptimizer {
     original_priority: Option<u32>,
+    original_affinity: Option<usize>,
     timer_resolution_active: bool,
+    global_timer_snapshot: Option<Option<u32>>,
     original_power_plan_guid: Option<Option<String>>,
     game_bar_snapshot: Option<Option<u32>>,
     fullscreen_optimization_snapshot: Option<Option<u32>>,
@@ -72,7 +85,9 @@ impl SystemOptimizer {
     pub fn new() -> Self {
         Self {
             original_priority: None,
+            original_affinity: None,
             timer_resolution_active: false,
+            global_timer_snapshot: None,
             original_power_plan_guid: None,
             game_bar_snapshot: None,
             fullscreen_optimization_snapshot: None,
@@ -81,6 +96,45 @@ impl SystemOptimizer {
             mmcss_snapshot: None,
             swifttunnel_power_plan_imported: false,
         }
+    }
+
+    /// Validate that every requested core index is reachable on this CPU.
+    ///
+    /// Returns the affinity mask on success. Rejects an empty list (no cores
+    /// would mean "no CPU allowed to run the process" — Windows rejects this
+    /// but `SetProcessAffinityMask` returns success on some kernels, leaving
+    /// the process unrunnable).
+    pub(crate) fn validate_cpu_cores(cores: &[usize]) -> Result<usize> {
+        if cores.is_empty() {
+            return Err(anyhow::anyhow!(
+                "CPU affinity requires at least one core; got empty list"
+            ));
+        }
+
+        let max_cores = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(64);
+
+        let max_bit = (std::mem::size_of::<usize>() * 8) - 1;
+        let mut mask: usize = 0;
+        for &core in cores {
+            if core >= max_cores {
+                return Err(anyhow::anyhow!(
+                    "CPU affinity core {} is out of range; system has {} logical core(s)",
+                    core,
+                    max_cores
+                ));
+            }
+            if core > max_bit {
+                return Err(anyhow::anyhow!(
+                    "CPU affinity core {} exceeds usize width ({} bits) on this platform",
+                    core,
+                    max_bit + 1
+                ));
+            }
+            mask |= 1usize << core;
+        }
+        Ok(mask)
     }
 
     fn parse_registry_dword(token: &str) -> Option<u32> {
@@ -604,11 +658,13 @@ impl SystemOptimizer {
         }
     }
 
-    /// Set CPU affinity for Roblox process
+    /// Set CPU affinity for Roblox process. Captures the existing affinity
+    /// mask on first apply so `restore` can undo it cleanly.
     fn set_cpu_affinity(&mut self, process_id: u32, cores: &[usize]) -> Result<()> {
+        let affinity_mask = Self::validate_cpu_cores(cores)?;
         info!(
-            "Setting CPU affinity for PID: {} to cores: {:?}",
-            process_id, cores
+            "Setting CPU affinity for PID: {} to cores: {:?} (mask 0x{:X})",
+            process_id, cores, affinity_mask
         );
 
         unsafe {
@@ -622,10 +678,29 @@ impl SystemOptimizer {
                 return Err(anyhow::anyhow!("Failed to open process"));
             }
 
-            // Calculate affinity mask
-            let mut affinity_mask: usize = 0;
-            for &core in cores {
-                affinity_mask |= 1 << core;
+            // Capture pre-apply mask once per boost cycle so restore returns
+            // the process to its original state, not to "all cores".
+            if self.original_affinity.is_none() {
+                let mut process_mask: usize = 0;
+                let mut system_mask: usize = 0;
+                if GetProcessAffinityMask(handle, &mut process_mask, &mut system_mask).is_ok()
+                    && process_mask != 0
+                {
+                    self.original_affinity = Some(process_mask);
+                } else {
+                    // Fall back to "all cores in the system" if we can't read
+                    // the current mask — better than leaving the process
+                    // pinned forever after disable.
+                    self.original_affinity = Some(if system_mask != 0 {
+                        system_mask
+                    } else {
+                        ALL_CORES_AFFINITY_MASK
+                    });
+                    warn!(
+                        "Could not read original affinity for PID {}; restore will use system mask",
+                        process_id
+                    );
+                }
             }
 
             let result = SetProcessAffinityMask(handle, affinity_mask);
@@ -637,6 +712,53 @@ impl SystemOptimizer {
             } else {
                 Err(anyhow::anyhow!("Failed to set CPU affinity"))
             }
+        }
+    }
+
+    /// Restore CPU affinity to the snapshot taken on first apply.
+    /// Best-effort: a vanished PID is logged, not an error.
+    fn restore_cpu_affinity(&mut self, process_id: u32) {
+        let Some(mask) = self.original_affinity.take() else {
+            return;
+        };
+
+        if process_id == 0 {
+            info!("Skipping CPU affinity restore: no active game process");
+            return;
+        }
+
+        unsafe {
+            let handle = match OpenProcess(
+                PROCESS_SET_INFORMATION | PROCESS_QUERY_INFORMATION,
+                false,
+                process_id,
+            ) {
+                Ok(h) if !h.is_invalid() => h,
+                Ok(_) => {
+                    info!("CPU affinity restore: PID {} has no handle", process_id);
+                    return;
+                }
+                Err(e) => {
+                    info!(
+                        "CPU affinity restore: PID {} unreachable (likely exited): {}",
+                        process_id, e
+                    );
+                    return;
+                }
+            };
+
+            if let Err(e) = SetProcessAffinityMask(handle, mask) {
+                warn!(
+                    "Failed to restore CPU affinity for PID {} to mask 0x{:X}: {}",
+                    process_id, mask, e
+                );
+            } else {
+                info!(
+                    "Restored CPU affinity for PID {} to mask 0x{:X}",
+                    process_id, mask
+                );
+            }
+            let _ = CloseHandle(handle);
         }
     }
 
@@ -659,14 +781,18 @@ impl SystemOptimizer {
             .output();
 
         match output {
-            Ok(_) => {
+            Ok(result) if result.status.success() => {
                 info!("Game Bar disabled successfully");
                 Ok(())
             }
-            Err(e) => {
-                warn!("Failed to disable Game Bar: {}", e);
-                Ok(()) // Non-critical
+            Ok(result) => {
+                let stderr = String::from_utf8_lossy(&result.stderr);
+                Err(anyhow::anyhow!(
+                    "Game Bar disable failed: {}",
+                    stderr.trim()
+                ))
             }
+            Err(e) => Err(anyhow::anyhow!("Game Bar disable: reg invoke failed: {}", e)),
         }
     }
 
@@ -674,8 +800,6 @@ impl SystemOptimizer {
     fn disable_fullscreen_optimizations(&self) -> Result<()> {
         info!("Disabling fullscreen optimizations");
 
-        // This would typically be done by modifying the Roblox executable properties
-        // For now, we'll use registry approach
         let output = hidden_command("reg")
             .args([
                 "add",
@@ -691,18 +815,27 @@ impl SystemOptimizer {
             .output();
 
         match output {
-            Ok(_) => {
+            Ok(result) if result.status.success() => {
                 info!("Fullscreen optimizations disabled");
                 Ok(())
             }
-            Err(e) => {
-                warn!("Failed to disable fullscreen optimizations: {}", e);
-                Ok(())
+            Ok(result) => {
+                let stderr = String::from_utf8_lossy(&result.stderr);
+                Err(anyhow::anyhow!(
+                    "Fullscreen optimization disable failed: {}",
+                    stderr.trim()
+                ))
             }
+            Err(e) => Err(anyhow::anyhow!(
+                "Fullscreen optimization disable: reg invoke failed: {}",
+                e
+            )),
         }
     }
 
-    /// Set Windows power plan
+    /// Set Windows power plan. Returns Err on import or activation failure
+    /// so the caller can surface the failure to the user instead of falsely
+    /// reporting "boost applied".
     fn set_power_plan(&mut self, plan: &PowerPlan) -> Result<()> {
         let guid = Self::power_plan_guid(plan);
 
@@ -710,9 +843,10 @@ impl SystemOptimizer {
 
         if matches!(plan, PowerPlan::SwiftTunnel) {
             if let Err(e) = self.ensure_swifttunnel_power_plan() {
-                warn!("Could not prepare SwiftTunnel power plan: {}", e);
-                warn!("Skipping SwiftTunnel power plan activation because setup did not complete");
-                return Ok(());
+                return Err(anyhow::anyhow!(
+                    "SwiftTunnel power plan import failed: {}",
+                    e
+                ));
             }
         }
 
@@ -721,27 +855,37 @@ impl SystemOptimizer {
             .output();
 
         match output {
-            Ok(result) => {
-                if result.status.success() {
-                    info!("Power plan set successfully");
-                    Ok(())
-                } else {
-                    warn!("Failed to set power plan (may require admin)");
-                    Ok(())
-                }
-            }
-            Err(e) => {
-                warn!("Failed to set power plan: {}", e);
+            Ok(result) if result.status.success() => {
+                info!("Power plan set successfully");
                 Ok(())
             }
+            Ok(result) => {
+                let stderr = String::from_utf8_lossy(&result.stderr);
+                Err(anyhow::anyhow!(
+                    "powercfg /setactive {} failed (admin may be required): {}",
+                    guid,
+                    stderr.trim()
+                ))
+            }
+            Err(e) => Err(anyhow::anyhow!(
+                "powercfg /setactive {} invocation failed: {}",
+                guid,
+                e
+            )),
         }
     }
 
     // ===== TIER 1 (SAFE) BOOSTS =====
 
-    /// Set system timer resolution to 0.5ms for smoother frame pacing
-    /// Uses NtSetTimerResolution for sub-millisecond precision (5000 = 0.5ms in 100ns units)
-    /// Falls back to timeBeginPeriod(1) if NtSetTimerResolution fails
+    /// Set system timer resolution to 0.5ms for smoother frame pacing.
+    /// Uses NtSetTimerResolution for sub-millisecond precision (5000 = 0.5ms
+    /// in 100ns units), with timeBeginPeriod(1) as a fallback.
+    ///
+    /// On Windows 11 22H2+ the timer resolution call is per-process scoped,
+    /// so we also write `GlobalTimerResolutionRequests=1` to restore the
+    /// system-wide behavior that lets Roblox benefit from our request.
+    /// The kernel reads that key only at boot, so the global half of this
+    /// boost takes effect after the next reboot.
     pub fn set_timer_resolution(&mut self, enable: bool) -> Result<()> {
         if enable && !self.timer_resolution_active {
             info!("Setting timer resolution to 0.5ms");
@@ -771,6 +915,11 @@ impl SystemOptimizer {
                     }
                 }
             }
+
+            // Make sure the system-wide override is on so the per-process
+            // resolution we just set is honored for other processes too on
+            // Win11 22H2+. Snapshot the prior value so restore() can revert.
+            self.enable_global_timer_resolution_override();
         } else if !enable && self.timer_resolution_active {
             info!("Restoring default timer resolution");
             unsafe {
@@ -781,8 +930,50 @@ impl SystemOptimizer {
                 let _ = timeEndPeriod(1);
                 self.timer_resolution_active = false;
             }
+            self.restore_global_timer_resolution_override();
         }
         Ok(())
+    }
+
+    fn enable_global_timer_resolution_override(&mut self) {
+        Self::capture_dword_snapshot(
+            &mut self.global_timer_snapshot,
+            GLOBAL_TIMER_RESOLUTION_KEY,
+            GLOBAL_TIMER_RESOLUTION_VALUE,
+        );
+
+        // Skip the write if it's already 1 — avoids an unnecessary reg call
+        // and prevents spurious "needs reboot" telemetry on repeat applies.
+        if Self::query_registry_dword(
+            GLOBAL_TIMER_RESOLUTION_KEY,
+            GLOBAL_TIMER_RESOLUTION_VALUE,
+        ) == Some(1)
+        {
+            return;
+        }
+
+        Self::set_registry_dword(
+            GLOBAL_TIMER_RESOLUTION_KEY,
+            GLOBAL_TIMER_RESOLUTION_VALUE,
+            1,
+        );
+
+        // The kernel reads this key only at boot — log so users grepping for
+        // "why isn't my timer boost working" get a useful breadcrumb.
+        info!(
+            "Wrote {}\\{}=1; reboot required for the global override to take effect on Windows 11 22H2+",
+            GLOBAL_TIMER_RESOLUTION_KEY, GLOBAL_TIMER_RESOLUTION_VALUE
+        );
+    }
+
+    fn restore_global_timer_resolution_override(&mut self) {
+        if let Some(snapshot) = self.global_timer_snapshot.take() {
+            Self::restore_registry_dword(
+                GLOBAL_TIMER_RESOLUTION_KEY,
+                GLOBAL_TIMER_RESOLUTION_VALUE,
+                snapshot,
+            );
+        }
     }
 
     /// Apply MMCSS (Multimedia Class Scheduler Service) gaming profile
@@ -982,6 +1173,9 @@ impl SystemOptimizer {
         if self.timer_resolution_active {
             self.set_timer_resolution(false)?;
         }
+        // Safety net: clean up the global timer override snapshot even if
+        // `timer_resolution_active` was already false (e.g., crash recovery).
+        self.restore_global_timer_resolution_override();
 
         if let Some(priority) = self.original_priority.take() {
             unsafe {
@@ -993,6 +1187,10 @@ impl SystemOptimizer {
                 }
             }
         }
+
+        // Affinity is restored independently of priority because the boost can
+        // be enabled with affinity-only or priority-only configs.
+        self.restore_cpu_affinity(process_id);
 
         if let Some(snapshot) = self.mmcss_snapshot.take() {
             Self::restore_mmcss_snapshot(snapshot);
@@ -1228,5 +1426,69 @@ mod tests {
     fn embedded_swifttunnel_power_plan_resource_is_present() {
         assert!(SWIFTTUNNEL_POWER_PLAN_BYTES.starts_with(b"regf"));
         assert!(SWIFTTUNNEL_POWER_PLAN_BYTES.len() > 1024);
+    }
+
+    #[test]
+    fn validate_cpu_cores_rejects_empty_list() {
+        let err = SystemOptimizer::validate_cpu_cores(&[]).unwrap_err();
+        assert!(
+            err.to_string().contains("at least one core"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_cpu_cores_rejects_core_beyond_available_parallelism() {
+        // Pick a core id well past any realistic machine. This is the negative
+        // test for the prior bug where impossible cores were silently OR'd into
+        // an unrunnable mask.
+        let err = SystemOptimizer::validate_cpu_cores(&[10_000]).unwrap_err();
+        assert!(
+            err.to_string().contains("out of range")
+                || err.to_string().contains("exceeds usize width"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_cpu_cores_builds_correct_mask_for_known_core_zero() {
+        // Every machine has at least core 0.
+        let mask = SystemOptimizer::validate_cpu_cores(&[0]).unwrap();
+        assert_eq!(mask, 0b1);
+    }
+
+    #[test]
+    fn validate_cpu_cores_combines_bits_for_multiple_cores() {
+        if std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+            < 2
+        {
+            return; // skip on single-core CI
+        }
+        let mask = SystemOptimizer::validate_cpu_cores(&[0, 1]).unwrap();
+        assert_eq!(mask, 0b11);
+    }
+
+    #[test]
+    fn restore_cpu_affinity_with_no_snapshot_is_noop() {
+        let mut optimizer = SystemOptimizer::new();
+        // No state captured — must not panic and must not contact a process.
+        optimizer.restore_cpu_affinity(0);
+        optimizer.restore_cpu_affinity(u32::MAX);
+        assert!(optimizer.original_affinity.is_none());
+    }
+
+    #[test]
+    fn restore_cpu_affinity_with_dead_pid_clears_snapshot_without_panic() {
+        let mut optimizer = SystemOptimizer::new();
+        optimizer.original_affinity = Some(0b1);
+        // u32::MAX is an unreachable PID; OpenProcess should fail and the
+        // restore path must classify it as "process gone" without panic.
+        optimizer.restore_cpu_affinity(u32::MAX);
+        assert!(
+            optimizer.original_affinity.is_none(),
+            "snapshot should be consumed even when restore can't reach the process"
+        );
     }
 }

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -977,7 +977,6 @@ impl VpnConnection {
         tunnel_apps: Vec<String>,
         custom_relay_server: Option<String>,
         auto_routing_enabled: bool,
-        relay_qos_enabled: bool,
         available_servers: Vec<(String, std::net::SocketAddr, Option<u32>)>,
         whitelisted_regions: Vec<String>,
         forced_servers: std::collections::HashMap<String, String>,
@@ -1116,7 +1115,6 @@ impl VpnConnection {
                     custom_relay_server,
                     forced_for_region,
                     auto_routing_enabled,
-                    relay_qos_enabled,
                     available_servers,
                     relay_candidates,
                     whitelisted_regions,
@@ -1182,7 +1180,6 @@ impl VpnConnection {
         custom_relay_server: Option<String>,
         forced_for_region: Option<String>,
         auto_routing_enabled: bool,
-        relay_qos_enabled: bool,
         available_servers: Vec<(String, std::net::SocketAddr, Option<u32>)>,
         relay_candidates: Vec<(String, std::net::SocketAddr, Option<u32>)>,
         whitelisted_regions: Vec<String>,
@@ -1310,20 +1307,18 @@ impl VpnConnection {
             log::info!("V3: PPP/point-to-point default route detected; enabling relay MTU clamp");
         }
 
-        let relay = match super::udp_relay::UdpRelay::new_with_path_context(
-            relay_addr,
-            relay_qos_enabled,
-            relay_path_context,
-        ) {
-            Ok(r) => std::sync::Arc::new(r),
-            Err(e) => {
-                let _ = driver.close();
-                return Err(VpnError::SplitTunnelSetupFailed(format!(
-                    "Failed to create V3 relay: {}",
-                    e
-                )));
-            }
-        };
+        let relay =
+            match super::udp_relay::UdpRelay::new_with_path_context(relay_addr, relay_path_context)
+            {
+                Ok(r) => std::sync::Arc::new(r),
+                Err(e) => {
+                    let _ = driver.close();
+                    return Err(VpnError::SplitTunnelSetupFailed(format!(
+                        "Failed to create V3 relay: {}",
+                        e
+                    )));
+                }
+            };
 
         let mut relay_auth_mode = if custom_relay_server.is_some() {
             "custom_legacy".to_string()

--- a/swifttunnel-core/src/vpn/udp_relay.rs
+++ b/swifttunnel-core/src/vpn/udp_relay.rs
@@ -573,13 +573,12 @@ impl UdpRelay {
     /// Create a new UDP relay connection to the specified server
     ///
     /// relay_addr should already be resolved (use tokio::net::lookup_host for DNS)
-    pub fn new(relay_addr: SocketAddr, relay_qos_enabled: bool) -> Result<Self> {
-        Self::new_with_path_context(relay_addr, relay_qos_enabled, RelayPathContext::default())
+    pub fn new(relay_addr: SocketAddr) -> Result<Self> {
+        Self::new_with_path_context(relay_addr, RelayPathContext::default())
     }
 
     pub fn new_with_path_context(
         relay_addr: SocketAddr,
-        relay_qos_enabled: bool,
         path_context: RelayPathContext,
     ) -> Result<Self> {
         // Bind to any available port
@@ -624,35 +623,6 @@ impl UdpRelay {
                 );
                 if result != 0 {
                     log::warn!("UDP Relay: Failed to set SO_SNDBUF to 256KB, using default");
-                }
-            }
-
-            if relay_qos_enabled {
-                // DSCP EF (46) => TOS byte 184. This prioritizes relay traffic if the path
-                // honors DSCP (router + ISP + relay uplink policy dependent).
-                let tos: i32 = 46 << 2;
-                unsafe {
-                    let tos_bytes = std::slice::from_raw_parts(&tos as *const i32 as *const u8, 4);
-                    let result = windows::Win32::Networking::WinSock::setsockopt(
-                        sock,
-                        windows::Win32::Networking::WinSock::IPPROTO_IP.0,
-                        windows::Win32::Networking::WinSock::IP_TOS,
-                        Some(tos_bytes),
-                    );
-                    if result != 0 {
-                        log::warn!("UDP Relay: Failed to set IP_TOS DSCP EF; continuing");
-                    }
-
-                    // Best-effort for IPv6 traffic class when dual-stack is used.
-                    let result = windows::Win32::Networking::WinSock::setsockopt(
-                        sock,
-                        windows::Win32::Networking::WinSock::IPPROTO_IPV6.0,
-                        windows::Win32::Networking::WinSock::IPV6_TCLASS,
-                        Some(tos_bytes),
-                    );
-                    if result != 0 {
-                        log::debug!("UDP Relay: Could not set IPV6_TCLASS DSCP EF");
-                    }
                 }
             }
         }
@@ -844,10 +814,9 @@ impl UdpRelay {
             .context("Failed to spawn udp-relay-sender thread")?;
 
         log::info!(
-            "UDP Relay: Created session {:016x} to {} (relay_qos={})",
+            "UDP Relay: Created session {:016x} to {}",
             u64::from_be_bytes(session_id),
-            relay_addr,
-            relay_qos_enabled
+            relay_addr
         );
 
         let detected_mtu = detect_relay_path_mtu(relay_addr);
@@ -2336,7 +2305,7 @@ mod tests {
 
     #[test]
     fn test_forward_outbound_drops_oversize_payload() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay.set_relay_path_mtu_for_test(1500);
         let max_payload = relay.max_inner_packet_len_for_addr("127.0.0.1:51821".parse().unwrap());
         let payload = vec![0u8; max_payload + 1];
@@ -2347,7 +2316,7 @@ mod tests {
 
     #[test]
     fn test_forward_outbound_allows_max_payload() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay.set_relay_path_mtu_for_test(1500);
         let max_payload = relay.max_inner_packet_len_for_addr("127.0.0.1:51821".parse().unwrap());
         let payload = vec![0u8; max_payload];
@@ -2360,7 +2329,7 @@ mod tests {
 
     #[test]
     fn test_forward_outbound_respects_lower_path_mtu() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay.set_relay_path_mtu_for_test(1400);
         let max_payload = relay.max_inner_packet_len_for_addr("127.0.0.1:51821".parse().unwrap());
         assert_eq!(
@@ -2406,7 +2375,7 @@ mod tests {
 
     #[test]
     fn test_valid_current_pong_is_liveness_evidence() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay.set_ping_enabled(true);
         let fake_relay = bind_fake_relay(&relay);
         relay
@@ -2430,7 +2399,7 @@ mod tests {
 
     #[test]
     fn test_malformed_current_pong_is_not_liveness_evidence() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         let fake_relay = bind_fake_relay(&relay);
         relay
             .unanswered_keepalives
@@ -2455,7 +2424,7 @@ mod tests {
 
     #[test]
     fn test_wrong_source_pong_is_not_liveness_evidence() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         let _expected_relay = bind_fake_relay(&relay);
         relay
             .unanswered_keepalives
@@ -2479,7 +2448,7 @@ mod tests {
 
     #[test]
     fn test_never_sent_session_does_not_false_die_at_startup() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay
             .unanswered_keepalives
             .store(RELAY_DEAD_KEEPALIVE_THRESHOLD, Ordering::Relaxed);
@@ -2491,7 +2460,7 @@ mod tests {
 
     #[test]
     fn test_real_silence_still_reaches_dead() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay
             .unanswered_keepalives
             .store(RELAY_DEAD_KEEPALIVE_THRESHOLD, Ordering::Relaxed);
@@ -2508,7 +2477,7 @@ mod tests {
         // Reproduces the tokyo-02 scenario: pongs keep `last_receive_time` fresh and
         // `unanswered_keepalives` at zero, so the keepalive-based health checks would
         // call this Healthy. The inject streak must override that.
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay
             .relay_health
             .store(RelayHealthState::Healthy as u8, Ordering::Relaxed);
@@ -2525,7 +2494,7 @@ mod tests {
 
     #[test]
     fn test_inject_failure_streak_escalates_to_dead() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay
             .relay_health
             .store(RelayHealthState::Healthy as u8, Ordering::Relaxed);
@@ -2543,7 +2512,7 @@ mod tests {
     fn test_inject_success_resets_streak_and_does_not_flip_health() {
         // Negative test: a relay producing some bad packets but mostly good ones must NOT
         // be flagged as Stale. Only sustained, no-recovery failure triggers the override.
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         relay
             .relay_health
             .store(RelayHealthState::Healthy as u8, Ordering::Relaxed);
@@ -2567,7 +2536,7 @@ mod tests {
 
     #[test]
     fn test_inject_streak_resets_on_relay_switch() {
-        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap(), false).unwrap();
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
         for _ in 0..(INJECT_STALE_STREAK + 2) {
             relay.record_inject_outcome(false);
         }
@@ -2585,7 +2554,7 @@ mod tests {
         relay_socket
             .set_read_timeout(Some(Duration::from_millis(250)))
             .unwrap();
-        let relay = UdpRelay::new(relay_socket.local_addr().unwrap(), false).unwrap();
+        let relay = UdpRelay::new(relay_socket.local_addr().unwrap()).unwrap();
         relay.last_activity_ms.store(0, Ordering::Relaxed);
 
         relay

--- a/swifttunnel-desktop/UI_REDESIGN_SPEC.md
+++ b/swifttunnel-desktop/UI_REDESIGN_SPEC.md
@@ -148,7 +148,6 @@ Every affordance currently in the UI. The rebuild must preserve every capability
 **Network group**
 - Disable Nagle (bool).
 - Disable Network Throttling (bool).
-- Gaming QoS (bool).
 
 **Process Scheduling group**
 - High-Performance GPU Binding (bool).

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -280,19 +280,10 @@ pub async fn boost_sync_effective_config(
                 "Network booster: Disable network throttling was not active on Windows".to_string(),
             );
         }
-        if current_config.network_settings.gaming_qos && !applied_config.network_settings.gaming_qos
-        {
-            warnings.push("Network booster: Gaming QoS was not active on Windows".to_string());
-        }
-
         if applied_config.network_settings.disable_nagle
             != current_config.network_settings.disable_nagle
             || applied_config.network_settings.disable_network_throttling
                 != current_config.network_settings.disable_network_throttling
-            || applied_config.network_settings.gaming_qos
-                != current_config.network_settings.gaming_qos
-            || applied_config.network_settings.prioritize_roblox_traffic
-                != current_config.network_settings.prioritize_roblox_traffic
         {
             let mut s = settings.lock();
             s.config = applied_config.clone();

--- a/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/optimizer.rs
@@ -182,9 +182,15 @@ pub async fn boost_update_config(
                 if let Err(e) = so.restore(roblox_pid) {
                     warn_list.push(format!("System optimizer restore: {}", e));
                 }
-                if let Err(e) = so.apply_optimizations(&config.system_optimization, roblox_pid) {
-                    warn_list.push(format!("System optimizer: {}", e));
-                }
+                let outcome =
+                    so.apply_optimizations_checked(&config.system_optimization, roblox_pid);
+                applied_config.system_optimization = outcome.applied_config;
+                warn_list.extend(
+                    outcome
+                        .warnings
+                        .into_iter()
+                        .map(|warning| format!("System optimizer: {}", warning)),
+                );
             }
 
             {

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -393,7 +393,6 @@ pub async fn vpn_connect(
     let (
         custom_relay,
         mut auto_routing,
-        relay_qos_enabled,
         whitelisted_regions,
         forced_servers,
         game_process_performance,
@@ -405,7 +404,6 @@ pub async fn vpn_connect(
             Some(settings_snapshot.custom_relay_server.clone())
         },
         settings_snapshot.auto_routing_enabled,
-        settings_snapshot.config.network_settings.gaming_qos,
         settings_snapshot.whitelisted_regions.clone(),
         settings_snapshot.forced_servers.clone(),
         settings_snapshot.game_process_performance,
@@ -461,7 +459,6 @@ pub async fn vpn_connect(
             tunnel_apps,
             custom_relay,
             auto_routing,
-            relay_qos_enabled,
             available_servers,
             whitelisted_regions,
             forced_servers,

--- a/swifttunnel-desktop/src-tauri/src/harness.rs
+++ b/swifttunnel-desktop/src-tauri/src/harness.rs
@@ -460,7 +460,6 @@ async fn run_connect_flow(state: &AppState, cli: &HarnessCli) -> Result<ConnectS
     let (
         custom_relay,
         auto_routing,
-        relay_qos_enabled,
         whitelisted_regions,
         forced_servers,
         binding_preference,
@@ -490,7 +489,6 @@ async fn run_connect_flow(state: &AppState, cli: &HarnessCli) -> Result<ConnectS
                 }
             }),
             snapshot.auto_routing_enabled,
-            snapshot.config.network_settings.gaming_qos,
             snapshot.whitelisted_regions.clone(),
             snapshot.forced_servers.clone(),
             binding_preference,
@@ -520,7 +518,6 @@ async fn run_connect_flow(state: &AppState, cli: &HarnessCli) -> Result<ConnectS
             tunnel_apps,
             custom_relay,
             auto_routing,
-            relay_qos_enabled,
             available_servers,
             whitelisted_regions,
             forced_servers,

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -515,7 +515,7 @@ pub fn run() {
                 tauri::RunEvent::Exit => {
                     disconnect_vpn_on_exit(_app);
                     recover_stale_network_state();
-                    // Restore network booster modifications (registry, MTU, firewall, QoS)
+                    // Restore network booster modifications (registry, MTU, firewall)
                     if let Some(state) = _app.try_state::<crate::state::AppState>() {
                         let roblox_pid = {
                             let mut monitor = state.performance_monitor.lock();

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -371,6 +371,8 @@ pub fn run() {
             let app_state = AppState::new(runtime.clone(), launched_from_startup)
                 .expect("Failed to initialize app state");
 
+            app_state.system_optimizer.lock().recover_from_snapshot();
+
             let account_is_banned = runtime.block_on(async {
                 let auth = app_state.auth_manager.lock().await;
                 if matches!(

--- a/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
+++ b/swifttunnel-desktop/src/components/auth/LoginScreen.tsx
@@ -17,7 +17,7 @@ const FEATURES = [
   {
     icon: "M13 2L3 14h9l-1 8 10-12h-9l1-8z",
     title: "Boost suite",
-    desc: "FPS unlock, RAM cleaner, gaming QoS",
+    desc: "FPS unlock, RAM cleaner, latency tweaks",
   },
   {
     icon: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM2 12h20",

--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -326,7 +326,6 @@ export function BoostTab() {
   const netCount = [
     draft.network_settings.disable_nagle,
     draft.network_settings.disable_network_throttling,
-    draft.network_settings.gaming_qos,
   ].filter(Boolean).length;
   const rblxCount = [
     draft.roblox_settings.unlock_fps,
@@ -471,7 +470,10 @@ export function BoostTab() {
 
       {/* ── System + Network side-by-side ── */}
       <div className="grid gap-4 lg:grid-cols-2">
-        <Section title="System" tag={`${sysCount} / ${systemBoostFlags.length} on`}>
+        <Section
+          title="System"
+          tag={`${sysCount} / ${systemBoostFlags.length} on`}
+        >
           <SettingRow
             title="High Priority Mode"
             desc="Boost game process priority (+5-15 FPS)"
@@ -507,7 +509,7 @@ export function BoostTab() {
           />
         </Section>
 
-        <Section title="Network" tag={`${netCount} / 3 on`}>
+        <Section title="Network" tag={`${netCount} / 2 on`}>
           <SettingRow
             title="Disable Nagle's Algorithm"
             desc="Faster packet delivery (-5-15ms)"
@@ -524,14 +526,6 @@ export function BoostTab() {
             onChange={(v) =>
               void applyNetworkOpt({ disable_network_throttling: v })
             }
-            disabled={networkApplying}
-          />
-          <SettingRow
-            title="Gaming QoS"
-            desc="Prioritize game UDP (-5-20ms)"
-            tooltip="QoS marks game UDP packets as high priority so routers handle them before downloads / streaming."
-            enabled={draft.network_settings.gaming_qos}
-            onChange={(v) => void applyNetworkOpt({ gaming_qos: v })}
             disabled={networkApplying}
           />
         </Section>

--- a/swifttunnel-desktop/src/components/boost/boostConfig.test.ts
+++ b/swifttunnel-desktop/src/components/boost/boostConfig.test.ts
@@ -20,7 +20,6 @@ describe("boost config helpers", () => {
     expect(result.network_settings.enable_network_boost).toBe(true);
     expect(result.network_settings.disable_nagle).toBe(true);
     expect(result.network_settings.disable_network_throttling).toBe(true);
-    expect(result.network_settings.gaming_qos).toBe(true);
     expect(result.auto_start_with_roblox).toBe(false);
   });
 

--- a/swifttunnel-desktop/src/components/boost/boostConfig.ts
+++ b/swifttunnel-desktop/src/components/boost/boostConfig.ts
@@ -72,7 +72,6 @@ export function getPresetConfig(
           ...current.network_settings,
           disable_nagle: true,
           disable_network_throttling: true,
-          gaming_qos: true,
         }),
       };
     case "Balanced":
@@ -101,7 +100,6 @@ export function getPresetConfig(
           ...current.network_settings,
           disable_nagle: true,
           disable_network_throttling: true,
-          gaming_qos: true,
         }),
       };
     case "HighEnd":
@@ -130,7 +128,6 @@ export function getPresetConfig(
           ...current.network_settings,
           disable_nagle: true,
           disable_network_throttling: true,
-          gaming_qos: true,
         }),
       };
     default:

--- a/swifttunnel-desktop/src/components/network/NetworkTab.tsx
+++ b/swifttunnel-desktop/src/components/network/NetworkTab.tsx
@@ -379,7 +379,7 @@ export function NetworkTab() {
                       ? "Good — minimal latency increase, no impact on gaming."
                       : net.bufferbloatResult.bufferbloat_ms <= 50
                         ? "Fair — noticeable latency increase during heavy use."
-                        : "Poor — significant latency spikes. Consider SQM/QoS on your router."}
+                        : "Poor — significant latency spikes. Consider router queue management."}
                 </p>
               </ResultReveal>
             )

--- a/swifttunnel-desktop/src/lib/settings.ts
+++ b/swifttunnel-desktop/src/lib/settings.ts
@@ -28,10 +28,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
     },
     network_settings: {
       enable_network_boost: false,
-      prioritize_roblox_traffic: false,
       disable_nagle: false,
       disable_network_throttling: false,
-      gaming_qos: false,
       firewall_fix: false,
     },
     auto_start_with_roblox: false,
@@ -72,8 +70,13 @@ export const DEFAULT_SETTINGS: AppSettings = {
   enable_api_tunneling: false,
 };
 
+type LegacyNetworkConfig = Partial<NetworkConfig> & {
+  prioritize_roblox_traffic?: boolean;
+  gaming_qos?: boolean;
+};
+
 function isLegacyMasterOnlyNetworkConfig(
-  raw: Partial<NetworkConfig> | undefined,
+  raw: LegacyNetworkConfig | undefined,
 ): boolean {
   return Boolean(
     raw?.enable_network_boost &&
@@ -86,16 +89,17 @@ function isLegacyMasterOnlyNetworkConfig(
 }
 
 export function normalizeNetworkBoostConfig(
-  config: NetworkConfig,
+  config: LegacyNetworkConfig,
   options: { legacyMasterOnly?: boolean } = {},
 ): NetworkConfig {
-  const next = { ...config };
+  const next: NetworkConfig = {
+    enable_network_boost: Boolean(config.enable_network_boost),
+    disable_nagle: Boolean(config.disable_nagle),
+    disable_network_throttling: Boolean(config.disable_network_throttling),
+    firewall_fix: Boolean(config.firewall_fix),
+  };
   const hasSpecificBoost =
-    next.prioritize_roblox_traffic ||
-    next.disable_nagle ||
-    next.disable_network_throttling ||
-    next.gaming_qos ||
-    next.firewall_fix;
+    next.disable_nagle || next.disable_network_throttling || next.firewall_fix;
 
   if (
     options.legacyMasterOnly &&
@@ -107,11 +111,7 @@ export function normalizeNetworkBoostConfig(
   }
 
   next.enable_network_boost =
-    next.prioritize_roblox_traffic ||
-    next.disable_nagle ||
-    next.disable_network_throttling ||
-    next.gaming_qos ||
-    next.firewall_fix;
+    next.disable_nagle || next.disable_network_throttling || next.firewall_fix;
 
   return next;
 }
@@ -119,7 +119,9 @@ export function normalizeNetworkBoostConfig(
 export function mergeAppSettings(
   raw: Partial<AppSettings> | undefined,
 ): AppSettings {
-  const rawNetworkSettings = raw?.config?.network_settings;
+  const rawNetworkSettings = raw?.config?.network_settings as
+    | LegacyNetworkConfig
+    | undefined;
   const settings = {
     ...DEFAULT_SETTINGS,
     ...raw,

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -244,10 +244,8 @@ export interface RobloxSettingsConfig {
 
 export interface NetworkConfig {
   enable_network_boost: boolean;
-  prioritize_roblox_traffic: boolean;
   disable_nagle: boolean;
   disable_network_throttling: boolean;
-  gaming_qos: boolean;
   firewall_fix: boolean;
 }
 

--- a/swifttunnel-desktop/src/mocks/tauri-core.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-core.ts
@@ -30,10 +30,8 @@ const MOCK_SETTINGS: AppSettings = {
     },
     network_settings: {
       enable_network_boost: true,
-      prioritize_roblox_traffic: true,
       disable_nagle: true,
       disable_network_throttling: true,
-      gaming_qos: true,
       firewall_fix: false,
     },
     auto_start_with_roblox: false,

--- a/swifttunnel-desktop/src/stores/settingsStore.test.ts
+++ b/swifttunnel-desktop/src/stores/settingsStore.test.ts
@@ -82,11 +82,10 @@ describe("stores/settingsStore", () => {
     expect(network.enable_network_boost).toBe(true);
     expect(network.disable_nagle).toBe(true);
     expect(network.disable_network_throttling).toBe(true);
-    expect(network.gaming_qos).toBe(false);
     expect(network.firewall_fix).toBe(false);
   });
 
-  it("preserves explicit all-off network boosts even with a stale master flag", async () => {
+  it("drops removed QoS fields without enabling replacement boosts", async () => {
     settingsLoad.mockResolvedValue({
       ...DEFAULT_SETTINGS,
       config: {
@@ -96,8 +95,8 @@ describe("stores/settingsStore", () => {
           enable_network_boost: true,
           disable_nagle: false,
           disable_network_throttling: false,
-          gaming_qos: false,
-          prioritize_roblox_traffic: false,
+          gaming_qos: true,
+          prioritize_roblox_traffic: true,
           firewall_fix: false,
         },
       },
@@ -111,7 +110,8 @@ describe("stores/settingsStore", () => {
     expect(network.enable_network_boost).toBe(false);
     expect(network.disable_nagle).toBe(false);
     expect(network.disable_network_throttling).toBe(false);
-    expect(network.gaming_qos).toBe(false);
+    expect("gaming_qos" in network).toBe(false);
+    expect("prioritize_roblox_traffic" in network).toBe(false);
   });
 
   it("does not enable network boosts when legacy master is off", async () => {
@@ -134,7 +134,6 @@ describe("stores/settingsStore", () => {
     expect(network.enable_network_boost).toBe(false);
     expect(network.disable_nagle).toBe(false);
     expect(network.disable_network_throttling).toBe(false);
-    expect(network.gaming_qos).toBe(false);
   });
 
   it("defaults minimize_to_tray to true when load fails", async () => {


### PR DESCRIPTION
## Summary

This keeps the Windows 11 PC boost fixes, removes QoS from the app, and keeps only best-effort cleanup for SwiftTunnel-owned QoS policies from older releases.

- CPU affinity restore is now wired through `GetProcessAffinityMask`, so disabling boosts restores the original mask instead of leaving Roblox pinned to selected cores. Dead PIDs are logged and cleared without panics.
- Power plan, Game Bar, and fullscreen optimization failures now surface as errors instead of reporting a successful apply when Windows rejected the operation.
- The app no longer exposes or applies QoS: removed the `Gaming QoS` UI toggle, removed `prioritize_roblox_traffic` / `gaming_qos` from current config and presets, removed relay socket DSCP marking, and removed QoS verification/warning paths.
- Legacy saved QoS keys are accepted only for migration and then dropped, so older settings do not re-enable unrelated boosts. Cleanup still removes old SwiftTunnel-owned QoS policy names, including `SwiftTunnel_QoS_Windows10Universal`, so upgrades do not strand stale DSCP rules.
- Firewall apply still removes stale SwiftTunnel Roblox rules before adding current Roblox executable rules, scoped by the `SwiftTunnel -` rule prefix.
- Current boost improvements remain: global timer-resolution registry support with readback, per-app dGPU preference snapshot/restore, FRM quality lowered to 1, and the new allowlisted Ultraboost FFlags.

## Failure-mode plan

- Primary success: QoS is no longer a user/app feature; no current config serialization, UI control, preset, VPN connect path, relay socket option, or network-boost apply path can enable it.
- Repairable cleanup: old SwiftTunnel-owned QoS policy keys are deleted best-effort during network reconciliation, restore, and full cleanup.
- Fatal/retryable boost failures: registry/power-plan/firewall failures for remaining boosts still surface through the existing checked apply flow.
- Structured signals: legacy QoS migration is keyed by exact JSON fields and exact policy names, not broad substring matching.
- Partial-success/races: old QoS cleanup failure is logged but does not block remaining boost apply; persisted QoS registry snapshots from older builds are restored if present.
- Negative tests: legacy `gaming_qos` / `prioritize_roblox_traffic` settings are dropped without enabling replacement boosts, and cleanup coverage pins the removed SwiftTunnel QoS policy names.

## Test plan

- [x] `cargo fmt --check`
- [x] `npm test -- --run`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `git diff --check`
- [ ] `cargo test -p swifttunnel-core network_config --lib` locally is blocked by the known macOS `windows-future` / `windows-core` dependency mismatch before crate tests run; GitHub Windows CI is the Rust gate.
- [x] Prior Windows testbench proof from this PR still covers the timer/MMCSS apply -> readback -> restore path.
- [ ] Manual QA before merge: install the resulting NSIS build on a clean Windows 10/11 box, toggle remaining boosts, confirm UI matches verified registry/affinity state, then disable and re-verify cleanup.
- [ ] Greptile re-review on the latest head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)