### PR TITLE
Add NVIDIA Ultraboost potato profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,9 +430,9 @@ jobs:
           # Ultraboost's NVIDIA-only Roblox potato profile is imported through
           # NVIDIA Profile Inspector. Ship the helper in updater/MSI resources
           # so existing Ultraboost users receive it with the app update.
-          $npiTag = "2.4.0.31"
-          $expectedZipSha256 = "5d692e812a701627edd6d165d0b60175ff4f772c758a7dac869d613e1beb8063"
-          $expectedExeSha256 = "7d5510deeaacb50c88a49bbf1d894dae44c5ce58c00d5a88392346646b14e8f3"
+          $npiTag = "v3.0.1.12"
+          $expectedZipSha256 = "494065af4ac3e9ce672c95e51e6b8a5301c208b6fed777ee6bbfe755081ba308"
+          $expectedExeSha256 = "61452518fdd2464313e08589dd6b6e9d00d3fd36c1622e1105884ab1ad7334d4"
           $toolsDir = "swifttunnel-desktop/src-tauri/resources/tools/nvidiaProfileInspector"
           $downloadDir = Join-Path $env:RUNNER_TEMP "nvidiaProfileInspector-download"
           $extractDir = Join-Path $env:RUNNER_TEMP "nvidiaProfileInspector-extract"
@@ -460,7 +460,7 @@ jobs:
             throw "nvidiaProfileInspector.zip did not contain nvidiaProfileInspector.exe"
           }
 
-          Copy-Item -LiteralPath $exe.FullName -Destination (Join-Path $toolsDir "nvidiaProfileInspector.exe") -Force
+          Copy-Item -Path (Join-Path $exe.Directory.FullName "*") -Destination $toolsDir -Recurse -Force
 
           $bundledExe = Join-Path $toolsDir "nvidiaProfileInspector.exe"
           $actualExeSha256 = (Get-FileHash -Path $bundledExe -Algorithm SHA256).Hash.ToLower()
@@ -469,7 +469,7 @@ jobs:
           }
 
           $size = (Get-Item $bundledExe).Length
-          if ($size -lt 400000) {
+          if ($size -lt 900000) {
             throw "nvidiaProfileInspector.exe is suspiciously small ($size bytes)"
           }
           Write-Host "Bundled NVIDIA Profile Inspector $npiTag helper ($size bytes, sha256=$actualExeSha256)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,6 +422,58 @@ jobs:
           Expand-WinpkFilterPackage -MsiPath $x64Path -Arch "x64"
           Expand-WinpkFilterPackage -MsiPath $arm64Path -Arch "arm64"
 
+      - name: Prepare bundled NVIDIA Profile Inspector helper
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Ultraboost's NVIDIA-only Roblox potato profile is imported through
+          # NVIDIA Profile Inspector. Ship the helper in updater/MSI resources
+          # so existing Ultraboost users receive it with the app update.
+          $npiTag = "2.4.0.31"
+          $expectedZipSha256 = "5d692e812a701627edd6d165d0b60175ff4f772c758a7dac869d613e1beb8063"
+          $expectedExeSha256 = "7d5510deeaacb50c88a49bbf1d894dae44c5ce58c00d5a88392346646b14e8f3"
+          $toolsDir = "swifttunnel-desktop/src-tauri/resources/tools/nvidiaProfileInspector"
+          $downloadDir = Join-Path $env:RUNNER_TEMP "nvidiaProfileInspector-download"
+          $extractDir = Join-Path $env:RUNNER_TEMP "nvidiaProfileInspector-extract"
+          Remove-Item -Path $toolsDir -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path $downloadDir -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $toolsDir -Force | Out-Null
+          New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+          New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+          gh release download $npiTag --repo Orbmu2k/nvidiaProfileInspector --pattern "nvidiaProfileInspector.zip" --dir $downloadDir --clobber
+          $zipPath = Join-Path $downloadDir "nvidiaProfileInspector.zip"
+          if (-not (Test-Path $zipPath)) {
+            throw "Missing nvidiaProfileInspector.zip after release download"
+          }
+          $actualZipSha256 = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+          if ($actualZipSha256 -ne $expectedZipSha256) {
+            throw "nvidiaProfileInspector.zip failed SHA-256 check: expected $expectedZipSha256, got $actualZipSha256"
+          }
+
+          Expand-Archive -LiteralPath $zipPath -DestinationPath $extractDir -Force
+          $exe = Get-ChildItem -Path $extractDir -Recurse -Filter "nvidiaProfileInspector.exe" -File |
+            Select-Object -First 1
+          if (-not $exe) {
+            throw "nvidiaProfileInspector.zip did not contain nvidiaProfileInspector.exe"
+          }
+
+          Copy-Item -LiteralPath $exe.FullName -Destination (Join-Path $toolsDir "nvidiaProfileInspector.exe") -Force
+
+          $bundledExe = Join-Path $toolsDir "nvidiaProfileInspector.exe"
+          $actualExeSha256 = (Get-FileHash -Path $bundledExe -Algorithm SHA256).Hash.ToLower()
+          if ($actualExeSha256 -ne $expectedExeSha256) {
+            throw "nvidiaProfileInspector.exe failed SHA-256 check: expected $expectedExeSha256, got $actualExeSha256"
+          }
+
+          $size = (Get-Item $bundledExe).Length
+          if ($size -lt 400000) {
+            throw "nvidiaProfileInspector.exe is suspiciously small ($size bytes)"
+          }
+          Write-Host "Bundled NVIDIA Profile Inspector $npiTag helper ($size bytes, sha256=$actualExeSha256)"
+
       - name: Verify updater signing secrets
         shell: powershell
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "swifttunnel-desktop"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Built-in performance optimizations:
 - **FPS Unlocker** — Remove the 60 FPS cap
 - **Network Tweaks** — Optimize TCP/UDP settings, DNS, and adapter config
 - **System Boosts** — Process priority, timer resolution, memory management
-- **Roblox FFlags** — Ultraboost writes every valid Roblox `version-*` folder with curated allowlisted FPS flags, cleans up retired SwiftTunnel flags such as high-DPI sharpness overrides, and re-applies saved flags on startup so Roblox updates do not drop the settings.
+- **Roblox Ultraboost** — writes every valid Roblox `version-*` folder with curated allowlisted FPS flags, cleans up retired SwiftTunnel flags such as high-DPI sharpness overrides, re-applies saved flags on startup so Roblox updates do not drop the settings, and adds a reversible NVIDIA-only Profile Inspector potato graphics profile when an NVIDIA GPU is detected.
 
 ### 🔒 Lightweight & Safe
 - No kernel drivers required for basic operation

--- a/release-notes/v2.1.7.md
+++ b/release-notes/v2.1.7.md
@@ -1,0 +1,8 @@
+## What's changed
+
+- Improved Ultraboost's Roblox potato preset by forcing the allowlisted 1x MSAA value instead of the ignored 0x override.
+- Added a reversible NVIDIA-only Profile Inspector texture-filtering profile for extra potato graphics on systems with NVIDIA GPUs.
+- Pinned the bundled NVIDIA Profile Inspector helper to version 2.4.0.31 with SHA-256 verification.
+- Existing users with Ultraboost enabled are upgraded automatically when SwiftTunnel reapplies saved Roblox FastFlags on startup.
+
+**Release**: https://github.com/Swift-tunnel/swifttunnel-app/releases/tag/v2.1.7

--- a/release-notes/v2.1.7.md
+++ b/release-notes/v2.1.7.md
@@ -2,7 +2,7 @@
 
 - Improved Ultraboost's Roblox potato preset by forcing the allowlisted 1x MSAA value instead of the ignored 0x override.
 - Added a reversible NVIDIA-only Profile Inspector texture-filtering profile for extra potato graphics on systems with NVIDIA GPUs.
-- Pinned the bundled NVIDIA Profile Inspector helper to version 2.4.0.31 with SHA-256 verification.
+- Pinned the bundled NVIDIA Profile Inspector helper to version v3.0.1.12 with SHA-256 verification.
 - Existing users with Ultraboost enabled are upgraded automatically when SwiftTunnel reapplies saved Roblox FastFlags on startup.
 
 **Release**: https://github.com/Swift-tunnel/swifttunnel-app/releases/tag/v2.1.7

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -2,8 +2,10 @@ use crate::hidden_command;
 use crate::structs::*;
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 #[cfg(windows)]
@@ -425,6 +427,12 @@ impl RobloxOptimizer {
             warnings.push(msg);
         }
 
+        if let Err(e) = Self::sync_nvidia_profile(config.ultraboost) {
+            let msg = format!("Could not sync NVIDIA Roblox potato profile: {}", e);
+            warn!("{}", msg);
+            warnings.push(msg);
+        }
+
         info!("Roblox optimizations applied successfully");
         Ok(warnings)
     }
@@ -703,6 +711,425 @@ impl RobloxOptimizer {
             }
         }
         out
+    }
+
+    // NVIDIA Profile Inspector integration used by Ultraboost. This is
+    // deliberately gated to machines that actually report an NVIDIA GPU.
+    const NPI_EXE_NAME: &'static str = "nvidiaProfileInspector.exe";
+    const NPI_RELEASE_TAG: &'static str = "2.4.0.31";
+    const NPI_RELEASE_ZIP_URL: &'static str = "https://github.com/Orbmu2k/nvidiaProfileInspector/releases/download/2.4.0.31/nvidiaProfileInspector.zip";
+    const NPI_RELEASE_ZIP_SHA256: &'static str =
+        "5d692e812a701627edd6d165d0b60175ff4f772c758a7dac869d613e1beb8063";
+    const NPI_EXE_SHA256: &'static str =
+        "7d5510deeaacb50c88a49bbf1d894dae44c5ce58c00d5a88392346646b14e8f3";
+    const NPI_PROFILE_NAME: &'static str = "Roblox";
+    const NPI_ROBLOX_EXE: &'static str = "RobloxPlayerBeta.exe";
+
+    fn sync_nvidia_profile(enable: bool) -> Result<()> {
+        if !Self::has_nvidia_gpu() {
+            info!("Skipping NVIDIA Roblox profile: no NVIDIA GPU detected");
+            return Ok(());
+        }
+
+        if enable && !crate::is_administrator() {
+            return Err(anyhow::anyhow!(
+                "NVIDIA Profile Inspector requires SwiftTunnel to run as administrator"
+            ));
+        }
+
+        let Some(inspector) = Self::resolve_nvidia_profile_inspector(enable)? else {
+            info!("Skipping NVIDIA Roblox profile reset: helper is not installed");
+            return Ok(());
+        };
+
+        let profile_path = Self::write_nvidia_potato_profile(enable)?;
+        let output = std::process::Command::new(&inspector)
+            .arg("-silentImport")
+            .arg(&profile_path)
+            .output()?;
+
+        if output.status.success() {
+            info!(
+                "NVIDIA Roblox potato profile {} via {}",
+                if enable { "applied" } else { "reset" },
+                inspector.display()
+            );
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            Err(anyhow::anyhow!(
+                "NVIDIA Profile Inspector exited with {}: {}{}{}",
+                output.status,
+                stderr.trim(),
+                if stderr.trim().is_empty() || stdout.trim().is_empty() {
+                    ""
+                } else {
+                    " / "
+                },
+                stdout.trim()
+            ))
+        }
+    }
+
+    fn has_nvidia_gpu() -> bool {
+        let mut names = Vec::new();
+        if let Some(output) = Self::run_nvidia_smi_query() {
+            names.extend(output.lines().map(str::to_string));
+        }
+        if names.is_empty() {
+            if let Some(output) = Self::run_video_controller_query() {
+                names.extend(output.lines().map(str::to_string));
+            }
+        }
+        Self::parse_has_nvidia_gpu(&names.join("\n"))
+    }
+
+    fn run_nvidia_smi_query() -> Option<String> {
+        let mut candidates = Vec::new();
+        if let Some(root) = std::env::var_os("SystemRoot").or_else(|| std::env::var_os("WINDIR")) {
+            candidates.push(PathBuf::from(root).join("System32").join("nvidia-smi.exe"));
+        }
+        candidates.push(PathBuf::from("nvidia-smi.exe"));
+
+        for candidate in candidates {
+            let output = std::process::Command::new(candidate)
+                .args(["--query-gpu=name", "--format=csv,noheader"])
+                .output();
+            if let Ok(output) = output {
+                if output.status.success() {
+                    return Some(String::from_utf8_lossy(&output.stdout).to_string());
+                }
+            }
+        }
+        None
+    }
+
+    fn run_video_controller_query() -> Option<String> {
+        let output = hidden_command("powershell")
+            .args([
+                "-Command",
+                "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name",
+            ])
+            .output()
+            .ok()?;
+        if output.status.success() {
+            Some(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            None
+        }
+    }
+
+    fn parse_has_nvidia_gpu(output: &str) -> bool {
+        output
+            .lines()
+            .any(|line| line.to_ascii_lowercase().contains("nvidia"))
+    }
+
+    fn resolve_nvidia_profile_inspector(install_if_missing: bool) -> Result<Option<PathBuf>> {
+        if let Some(path) = Self::installed_nvidia_profile_inspector_path()? {
+            return Ok(Some(path));
+        }
+
+        if let Some(staged) = Self::staged_nvidia_profile_inspector_path()? {
+            let target_dir = Self::nvidia_profile_inspector_install_dir()?;
+            Self::copy_directory_contents(
+                staged.parent().ok_or_else(|| {
+                    anyhow::anyhow!("staged NVIDIA Profile Inspector has no parent")
+                })?,
+                &target_dir,
+            )?;
+            let installed = target_dir.join(Self::NPI_EXE_NAME);
+            if installed.is_file() && Self::verify_nvidia_profile_inspector_exe(&installed).is_ok()
+            {
+                return Ok(Some(installed));
+            }
+        }
+
+        if !install_if_missing {
+            return Ok(None);
+        }
+
+        Self::download_nvidia_profile_inspector()?;
+        Self::installed_nvidia_profile_inspector_path()
+    }
+
+    fn installed_nvidia_profile_inspector_path() -> Result<Option<PathBuf>> {
+        let dir = Self::nvidia_profile_inspector_install_dir()?;
+        let exe = dir.join(Self::NPI_EXE_NAME);
+        if !exe.is_file() {
+            return Ok(None);
+        }
+
+        match Self::verify_nvidia_profile_inspector_exe(&exe) {
+            Ok(()) => Ok(Some(exe)),
+            Err(e) => {
+                warn!(
+                    "Ignoring NVIDIA Profile Inspector helper at {}: {}",
+                    exe.display(),
+                    e
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    fn nvidia_profile_inspector_install_dir() -> Result<PathBuf> {
+        dirs::data_local_dir()
+            .map(|path| {
+                path.join("SwiftTunnel")
+                    .join("tools")
+                    .join("nvidiaProfileInspector")
+            })
+            .ok_or_else(|| anyhow::anyhow!("could not resolve local app data directory"))
+    }
+
+    fn staged_nvidia_profile_inspector_path() -> Result<Option<PathBuf>> {
+        let exe_dir = std::env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(|parent| parent.to_path_buf()));
+        let Some(exe_dir) = exe_dir else {
+            return Ok(None);
+        };
+
+        for path in [
+            exe_dir
+                .join("tools")
+                .join("nvidiaProfileInspector")
+                .join(Self::NPI_EXE_NAME),
+            exe_dir
+                .join("resources")
+                .join("tools")
+                .join("nvidiaProfileInspector")
+                .join(Self::NPI_EXE_NAME),
+            exe_dir
+                .join("nvidiaProfileInspector")
+                .join(Self::NPI_EXE_NAME),
+        ] {
+            if !path.is_file() {
+                continue;
+            }
+            match Self::verify_nvidia_profile_inspector_exe(&path) {
+                Ok(()) => return Ok(Some(path)),
+                Err(e) => warn!(
+                    "Ignoring staged NVIDIA Profile Inspector helper at {}: {}",
+                    path.display(),
+                    e
+                ),
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn copy_directory_contents(source: &Path, destination: &Path) -> Result<()> {
+        fs::create_dir_all(destination)?;
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            let source_path = entry.path();
+            let destination_path = destination.join(entry.file_name());
+            if source_path.is_dir() {
+                Self::copy_directory_contents(&source_path, &destination_path)?;
+            } else {
+                fs::copy(&source_path, &destination_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn download_nvidia_profile_inspector() -> Result<()> {
+        let install_dir = Self::nvidia_profile_inspector_install_dir()?;
+        let zip_path = install_dir.with_extension("zip");
+        fs::create_dir_all(&install_dir)?;
+        let install_dir_str = Self::escape_powershell_single_quoted(&install_dir.to_string_lossy());
+        let zip_path_str = Self::escape_powershell_single_quoted(&zip_path.to_string_lossy());
+        let url = Self::NPI_RELEASE_ZIP_URL;
+
+        let script = format!(
+            "$ErrorActionPreference='Stop'; \
+             $ProgressPreference='SilentlyContinue'; \
+             $zip='{zip_path_str}'; \
+             Remove-Item -LiteralPath $zip -Force -ErrorAction SilentlyContinue; \
+             Invoke-WebRequest -Uri '{url}' -OutFile $zip -UseBasicParsing",
+            zip_path_str = zip_path_str,
+            url = url,
+        );
+
+        let output = hidden_command("powershell")
+            .args(["-Command", &script])
+            .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!(
+                "download failed with {}: {}",
+                output.status,
+                stderr.trim()
+            ));
+        }
+
+        Self::verify_file_sha256(
+            &zip_path,
+            Self::NPI_RELEASE_ZIP_SHA256,
+            "NVIDIA Profile Inspector release zip",
+        )?;
+
+        let script = format!(
+            "$ErrorActionPreference='Stop'; \
+             $dest='{install_dir_str}'; \
+             $zip='{zip_path_str}'; \
+             Expand-Archive -LiteralPath $zip -DestinationPath $dest -Force; \
+             Remove-Item -LiteralPath $zip -Force -ErrorAction SilentlyContinue; \
+             $rootExe = Join-Path $dest '{exe}'; \
+             if (-not (Test-Path -LiteralPath $rootExe)) {{ \
+               $found = Get-ChildItem -Path $dest -Recurse -Filter '{exe}' -File | Select-Object -First 1; \
+               if ($found) {{ Copy-Item -LiteralPath $found.FullName -Destination $rootExe -Force }} \
+             }}; \
+             if (-not (Test-Path -LiteralPath $rootExe)) {{ throw 'nvidiaProfileInspector.exe missing after extraction' }}",
+            install_dir_str = install_dir_str,
+            zip_path_str = zip_path_str,
+            exe = Self::NPI_EXE_NAME
+        );
+
+        let output = hidden_command("powershell")
+            .args(["-Command", &script])
+            .output()?;
+        if output.status.success() {
+            Self::verify_nvidia_profile_inspector_exe(&install_dir.join(Self::NPI_EXE_NAME))?;
+            info!(
+                "Installed NVIDIA Profile Inspector {} helper to {}",
+                Self::NPI_RELEASE_TAG,
+                install_dir.display()
+            );
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(anyhow::anyhow!(
+                "extract failed with {}: {}",
+                output.status,
+                stderr.trim()
+            ))
+        }
+    }
+
+    fn verify_nvidia_profile_inspector_exe(path: &Path) -> Result<()> {
+        Self::verify_file_sha256(
+            path,
+            Self::NPI_EXE_SHA256,
+            "NVIDIA Profile Inspector executable",
+        )
+    }
+
+    fn verify_file_sha256(path: &Path, expected: &str, label: &str) -> Result<()> {
+        let actual = Self::sha256_file(path)?;
+        if actual.eq_ignore_ascii_case(expected) {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "{} SHA-256 mismatch for {}: expected {}, got {}",
+                label,
+                path.display(),
+                expected,
+                actual
+            ))
+        }
+    }
+
+    fn sha256_file(path: &Path) -> Result<String> {
+        let mut file = fs::File::open(path)?;
+        let mut hasher = Sha256::new();
+        let mut buffer = [0u8; 8192];
+
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+
+    fn write_nvidia_potato_profile(enable: bool) -> Result<PathBuf> {
+        let dir = dirs::data_local_dir()
+            .map(|path| path.join("SwiftTunnel").join("nvidia-profiles"))
+            .ok_or_else(|| anyhow::anyhow!("could not resolve local app data directory"))?;
+        fs::create_dir_all(&dir)?;
+        let path = dir.join(if enable {
+            "roblox-potato-mode.nip"
+        } else {
+            "roblox-potato-mode-reset.nip"
+        });
+        let xml = Self::nvidia_potato_profile_xml(enable);
+        Self::write_utf16le(&path, &xml)?;
+        Ok(path)
+    }
+
+    fn nvidia_potato_profile_xml(enable: bool) -> String {
+        let settings = if enable {
+            vec![
+                ("Texture Filtering - LOD Bias (DX)", 7_573_135, 120),
+                (
+                    "Texture Filtering - LOD Bias Auto-Adjust (for SGSSAA)",
+                    6_524_559,
+                    0,
+                ),
+                ("Anisotropic Filtering - Mode", 282_245_910, 1),
+                ("Anisotropic Filtering - Setting", 270_426_537, 0),
+                ("Anisotropic Filter - Optimization", 8_703_344, 1),
+                ("Anisotropic Filter - Sample Optimization", 15_151_633, 1),
+                ("Texture Filtering - Negative LOD bias", 1_686_376, 0),
+                ("Texture Filtering - Quality", 13_510_289, 20),
+                ("Texture Filtering - Trilinear Optimization", 3_066_610, 1),
+            ]
+        } else {
+            vec![
+                ("Texture Filtering - LOD Bias (DX)", 7_573_135, 0),
+                (
+                    "Texture Filtering - LOD Bias Auto-Adjust (for SGSSAA)",
+                    6_524_559,
+                    1,
+                ),
+                ("Anisotropic Filtering - Mode", 282_245_910, 0),
+                ("Anisotropic Filtering - Setting", 270_426_537, 1),
+                ("Anisotropic Filter - Optimization", 8_703_344, 0),
+                ("Anisotropic Filter - Sample Optimization", 15_151_633, 0),
+                ("Texture Filtering - Negative LOD bias", 1_686_376, 0),
+                ("Texture Filtering - Quality", 13_510_289, 0),
+                ("Texture Filtering - Trilinear Optimization", 3_066_610, 0),
+            ]
+        };
+
+        let setting_xml = settings
+            .into_iter()
+            .map(|(name, id, value)| {
+                format!(
+                    "      <ProfileSetting>\r\n        <SettingNameInfo>{name}</SettingNameInfo>\r\n        <SettingID>{id}</SettingID>\r\n        <SettingValue>{value}</SettingValue>\r\n        <ValueType>Dword</ValueType>\r\n      </ProfileSetting>"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\r\n");
+
+        format!(
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfProfile>\r\n  <Profile>\r\n    <ProfileName>{profile}</ProfileName>\r\n    <Executeables>\r\n      <string>{exe}</string>\r\n    </Executeables>\r\n    <Settings>\r\n{settings}\r\n    </Settings>\r\n  </Profile>\r\n</ArrayOfProfile>\r\n",
+            profile = Self::NPI_PROFILE_NAME,
+            exe = Self::NPI_ROBLOX_EXE,
+            settings = setting_xml
+        )
+    }
+
+    fn write_utf16le(path: &Path, content: &str) -> Result<()> {
+        let mut bytes = Vec::with_capacity(2 + content.len() * 2);
+        bytes.extend_from_slice(&[0xFF, 0xFE]);
+        for unit in content.encode_utf16() {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+        fs::write(path, bytes)?;
+        Ok(())
+    }
+
+    fn escape_powershell_single_quoted(value: &str) -> String {
+        value.replace('\'', "''")
     }
 
     fn query_registry_string_value(key_path: &str, value_name: &str) -> Result<Option<String>> {
@@ -1011,6 +1438,13 @@ impl RobloxOptimizer {
             warn!("Could not remove FFlag optimizations during restore: {}", e);
         }
 
+        if let Err(e) = Self::sync_nvidia_profile(false) {
+            warn!(
+                "Could not reset NVIDIA Roblox potato profile during restore: {}",
+                e
+            );
+        }
+
         // Don't set read-only after restore - user is disabling optimizations
         info!("Settings restored successfully");
         Ok(())
@@ -1129,12 +1563,16 @@ impl RobloxOptimizer {
     /// `DFIntDebugFRMQualityLevelOverride` is `1` (lowest) instead of the
     /// prior `4`; Roblox's FRM quality scales 1-21 and community
     /// performance presets use the minimum for maximum FPS.
+    ///
+    /// `FIntDebugForceMSAASamples` is `1` instead of `0` because Roblox's
+    /// client allowlist accepts 1x/2x/4x MSAA samples. A value of `0` can be
+    /// ignored, leaving anti-aliasing at the user's previous/default quality.
     const ULTRABOOST_FFLAGS: &[(&str, &str)] = &[
         ("FFlagHandleAltEnterFullscreenManually", "False"),
         ("FFlagDebugGraphicsPreferD3D11", "True"),
         ("FFlagDebugGraphicsPreferVulkan", "False"),
         ("FFlagDebugGraphicsPreferOpenGL", "False"),
-        ("FIntDebugForceMSAASamples", "0"),
+        ("FIntDebugForceMSAASamples", "1"),
         ("DFFlagTextureQualityOverrideEnabled", "True"),
         ("DFIntTextureQualityOverride", "0"),
         ("DFIntDebugFRMQualityLevelOverride", "1"),
@@ -1742,9 +2180,16 @@ impl RobloxOptimizer {
         self.remove_all_fflags_in_paths(client_settings_paths)
     }
 
-    /// Reapply saved ClientAppSettings FFlags after Roblox creates a new version folder.
+    /// Reapply saved Ultraboost client-side state after Roblox creates a new version folder.
     pub fn reapply_saved_client_fflags(&self, config: &RobloxSettingsConfig) -> Result<()> {
-        self.apply_client_fflags(config).map(|_| ())
+        self.apply_client_fflags(config)?;
+        if let Err(e) = Self::sync_nvidia_profile(config.ultraboost) {
+            warn!(
+                "Could not sync NVIDIA Roblox potato profile on startup reapply: {}",
+                e
+            );
+        }
+        Ok(())
     }
 }
 
@@ -1770,6 +2215,9 @@ impl RobloxOptimizer {
         // Best-effort; missing values are not an error.
         if let Err(e) = Self::sync_gpu_preference(false) {
             warn!("Failed to clear Roblox GPU preference during uninstall: {e}");
+        }
+        if let Err(e) = Self::sync_nvidia_profile(false) {
+            warn!("Failed to clear NVIDIA Roblox profile during uninstall: {e}");
         }
         info!("Roblox optimizer: uninstall cleanup completed");
     }
@@ -2050,9 +2498,18 @@ mod tests {
     }
 
     #[test]
-    fn read_current_settings_errors_if_file_missing() {
-        let opt = optimizer_with_path(PathBuf::from("nonexistent_file.xml"));
+    fn read_current_settings_errors_if_path_is_not_file() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_unreadable_settings_path");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let missing_settings_path = dir.join("missing-settings.xml");
+        fs::create_dir_all(&missing_settings_path).unwrap();
+
+        let opt = optimizer_with_path(missing_settings_path);
         assert!(opt.read_current_settings().is_err());
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -2545,6 +3002,59 @@ mod tests {
         assert_eq!(
             settings.get("FStringUserOwnedFlag"),
             Some(&serde_json::json!("keep-me"))
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fflag_apply_upgrades_existing_ultraboost_texture_preset() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_fflag_upgrade_potato_preset");
+        let _ = fs::remove_dir_all(&dir);
+        let version = dir.join("Roblox").join("Versions").join("version-active");
+        let client_settings = version.join("ClientSettings");
+        fs::create_dir_all(&client_settings).unwrap();
+        fs::write(version.join("RobloxPlayerBeta.exe"), "").unwrap();
+        fs::write(
+            client_settings.join("ClientAppSettings.json"),
+            r#"{
+  "FFlagDebugGraphicsPreferD3D11": "True",
+  "FIntDebugForceMSAASamples": "0",
+  "FStringUserOwnedFlag": "keep-me"
+}"#,
+        )
+        .unwrap();
+
+        let opt = optimizer_with_path(dir.join("settings.xml"));
+        let config = RobloxSettingsConfig {
+            ultraboost: true,
+            ..Default::default()
+        };
+
+        opt.apply_client_fflags_for_local_app_data(&config, &dir)
+            .unwrap();
+
+        let content = fs::read_to_string(client_settings.join("ClientAppSettings.json")).unwrap();
+        let settings: HashMap<String, serde_json::Value> = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            settings.get("DFFlagTextureQualityOverrideEnabled"),
+            Some(&serde_json::json!("True")),
+            "startup reapply must add the low-texture override for existing Ultraboost users"
+        );
+        assert_eq!(
+            settings.get("DFIntTextureQualityOverride"),
+            Some(&serde_json::json!("0")),
+            "startup reapply must pin Roblox to its lowest texture-quality preset"
+        );
+        assert_eq!(
+            settings.get("FIntDebugForceMSAASamples"),
+            Some(&serde_json::json!("1")),
+            "older Ultraboost installs using the ignored 0x MSAA value must migrate to 1x"
+        );
+        assert_eq!(
+            settings.get("FStringUserOwnedFlag"),
+            Some(&serde_json::json!("keep-me")),
+            "user-owned flags must survive the Ultraboost preset upgrade"
         );
 
         let _ = fs::remove_dir_all(&dir);
@@ -3046,5 +3556,82 @@ HKEY_CURRENT_USER\SOFTWARE\Microsoft\DirectX\UserGpuPreferences
             unique.len(),
             "Ultraboost FFlags contain duplicate keys"
         );
+    }
+
+    #[test]
+    fn parse_has_nvidia_gpu_detects_nvidia_names() {
+        let sample = "Intel(R) UHD Graphics\r\nNVIDIA GeForce RTX 4060 Laptop GPU\r\n";
+        assert!(RobloxOptimizer::parse_has_nvidia_gpu(sample));
+    }
+
+    #[test]
+    fn parse_has_nvidia_gpu_ignores_non_nvidia_names() {
+        let sample = "AMD Radeon RX 7800 XT\r\nIntel(R) Arc(TM) Graphics\r\n";
+        assert!(!RobloxOptimizer::parse_has_nvidia_gpu(sample));
+    }
+
+    #[test]
+    fn nvidia_potato_profile_xml_enables_roblox_lod_bias() {
+        let xml = RobloxOptimizer::nvidia_potato_profile_xml(true);
+
+        assert!(xml.contains("<ProfileName>Roblox</ProfileName>"));
+        assert!(xml.contains("<string>RobloxPlayerBeta.exe</string>"));
+        assert!(
+            xml.contains("<SettingNameInfo>Texture Filtering - LOD Bias (DX)</SettingNameInfo>")
+        );
+        assert!(xml.contains(
+            "<SettingID>7573135</SettingID>\r\n        <SettingValue>120</SettingValue>"
+        ));
+        assert!(xml.contains(
+            "<SettingID>13510289</SettingID>\r\n        <SettingValue>20</SettingValue>"
+        ));
+    }
+
+    #[test]
+    fn nvidia_potato_profile_xml_resets_lod_bias() {
+        let xml = RobloxOptimizer::nvidia_potato_profile_xml(false);
+
+        assert!(xml.contains("<ProfileName>Roblox</ProfileName>"));
+        assert!(xml.contains("<string>RobloxPlayerBeta.exe</string>"));
+        assert!(
+            xml.contains(
+                "<SettingID>7573135</SettingID>\r\n        <SettingValue>0</SettingValue>"
+            )
+        );
+        assert!(
+            xml.contains(
+                "<SettingID>13510289</SettingID>\r\n        <SettingValue>0</SettingValue>"
+            )
+        );
+    }
+
+    #[test]
+    fn escape_powershell_single_quoted_doubles_quotes() {
+        assert_eq!(
+            RobloxOptimizer::escape_powershell_single_quoted("C:\\Users\\O'Brien\\file.zip"),
+            "C:\\Users\\O''Brien\\file.zip"
+        );
+    }
+
+    #[test]
+    fn npi_release_url_is_pinned() {
+        assert!(RobloxOptimizer::NPI_RELEASE_ZIP_URL.contains(RobloxOptimizer::NPI_RELEASE_TAG));
+        assert!(!RobloxOptimizer::NPI_RELEASE_ZIP_URL.contains("/latest/"));
+    }
+
+    #[test]
+    fn sha256_file_returns_lowercase_hex() {
+        let dir = std::env::temp_dir().join("roblox_opt_test_sha256_file");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("payload.bin");
+        fs::write(&path, b"abc").unwrap();
+
+        assert_eq!(
+            RobloxOptimizer::sha256_file(&path).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/swifttunnel-core/src/roblox_optimizer.rs
+++ b/swifttunnel-core/src/roblox_optimizer.rs
@@ -48,6 +48,14 @@ enum GpuPreferenceRestoreAction {
     LeaveUntouched,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct NvidiaProfileSnapshot {
+    #[serde(default)]
+    applied: bool,
+    #[serde(default)]
+    roblox_profile_xml: Option<String>,
+}
+
 const GPU_PREFERENCE_SNAPSHOT_FILE: &str = "gpu_preference_snapshots.json";
 
 fn gpu_preference_snapshot_path() -> Option<PathBuf> {
@@ -716,16 +724,33 @@ impl RobloxOptimizer {
     // NVIDIA Profile Inspector integration used by Ultraboost. This is
     // deliberately gated to machines that actually report an NVIDIA GPU.
     const NPI_EXE_NAME: &'static str = "nvidiaProfileInspector.exe";
-    const NPI_RELEASE_TAG: &'static str = "2.4.0.31";
-    const NPI_RELEASE_ZIP_URL: &'static str = "https://github.com/Orbmu2k/nvidiaProfileInspector/releases/download/2.4.0.31/nvidiaProfileInspector.zip";
+    const NPI_RELEASE_TAG: &'static str = "v3.0.1.12";
+    const NPI_RELEASE_ZIP_URL: &'static str = "https://github.com/Orbmu2k/nvidiaProfileInspector/releases/download/v3.0.1.12/nvidiaProfileInspector.zip";
     const NPI_RELEASE_ZIP_SHA256: &'static str =
-        "5d692e812a701627edd6d165d0b60175ff4f772c758a7dac869d613e1beb8063";
+        "494065af4ac3e9ce672c95e51e6b8a5301c208b6fed777ee6bbfe755081ba308";
     const NPI_EXE_SHA256: &'static str =
-        "7d5510deeaacb50c88a49bbf1d894dae44c5ce58c00d5a88392346646b14e8f3";
+        "61452518fdd2464313e08589dd6b6e9d00d3fd36c1622e1105884ab1ad7334d4";
+    const NPI_REFERENCE_XML_SHA256: &'static str =
+        "fb19d0ed9a8f1b95caa3675a94f80e2e14ae891c8fe83f164e0bb62513c2bb3f";
+    const NPI_CONFIG_SHA256: &'static str =
+        "051099983b896673909e01a1f631b6652abb88da95c9f06f3efef4be033091fa";
+    const NPI_PDB_SHA256: &'static str =
+        "68ab6fe22594a906e40bb414a76a30106fa1c8d95f778c910f07e194623e7070";
     const NPI_PROFILE_NAME: &'static str = "Roblox";
     const NPI_ROBLOX_EXE: &'static str = "RobloxPlayerBeta.exe";
+    const NPI_IMPORT_TIMEOUT_SECS: u64 = 15;
+    const NPI_EXPORT_TIMEOUT_SECS: u64 = 20;
+    const NVIDIA_PROFILE_SNAPSHOT_FILE: &'static str = "nvidia_profile_snapshot.json";
 
     fn sync_nvidia_profile(enable: bool) -> Result<()> {
+        Self::sync_nvidia_profile_with_policy(enable, true)
+    }
+
+    fn sync_nvidia_profile_startup(enable: bool) -> Result<()> {
+        Self::sync_nvidia_profile_with_policy(enable, false)
+    }
+
+    fn sync_nvidia_profile_with_policy(enable: bool, allow_download: bool) -> Result<()> {
         if !Self::has_nvidia_gpu() {
             info!("Skipping NVIDIA Roblox profile: no NVIDIA GPU detected");
             return Ok(());
@@ -737,29 +762,113 @@ impl RobloxOptimizer {
             ));
         }
 
-        let Some(inspector) = Self::resolve_nvidia_profile_inspector(enable)? else {
-            info!("Skipping NVIDIA Roblox profile reset: helper is not installed");
-            return Ok(());
+        if enable {
+            Self::apply_nvidia_profile(allow_download)
+        } else {
+            Self::reset_nvidia_profile(allow_download)
+        }
+    }
+
+    fn apply_nvidia_profile(allow_download: bool) -> Result<()> {
+        let inspector = Self::resolve_nvidia_profile_inspector(allow_download)?
+            .ok_or_else(|| anyhow::anyhow!("NVIDIA Profile Inspector helper is not installed"))?;
+        let existing_snapshot = Self::read_nvidia_profile_snapshot()?;
+        let had_existing_marker = existing_snapshot.applied;
+        let original_profile_xml = if had_existing_marker {
+            existing_snapshot.roblox_profile_xml
+        } else {
+            Self::capture_nvidia_profile_snapshot(&inspector)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Could not snapshot existing NVIDIA Roblox profile before Ultraboost apply: {}",
+                        e
+                    )
+                })?
+                .roblox_profile_xml
         };
 
-        let profile_path = Self::write_nvidia_potato_profile(enable)?;
-        let output = std::process::Command::new(&inspector)
-            .arg("-silentImport")
-            .arg(&profile_path)
-            .output()?;
+        let snapshot = NvidiaProfileSnapshot {
+            applied: true,
+            roblox_profile_xml: original_profile_xml,
+        };
+        Self::write_nvidia_profile_snapshot(&snapshot)?;
+
+        let profile_path = Self::write_nvidia_potato_profile(true)?;
+        if let Err(e) = Self::run_nvidia_profile_import(&inspector, &profile_path, "apply") {
+            if !had_existing_marker {
+                let _ = Self::clear_nvidia_profile_snapshot();
+            }
+            return Err(e);
+        }
+        info!(
+            "NVIDIA Roblox potato profile applied via {}",
+            inspector.display()
+        );
+        Ok(())
+    }
+
+    fn reset_nvidia_profile(allow_download: bool) -> Result<()> {
+        let snapshot = match Self::read_nvidia_profile_snapshot() {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                warn!(
+                    "NVIDIA profile snapshot is unreadable; falling back to deterministic reset: {}",
+                    e
+                );
+                NvidiaProfileSnapshot {
+                    applied: true,
+                    roblox_profile_xml: None,
+                }
+            }
+        };
+        if !snapshot.applied {
+            info!("Skipping NVIDIA Roblox profile reset: no SwiftTunnel-applied profile marker");
+            return Ok(());
+        }
+
+        let inspector = Self::resolve_nvidia_profile_inspector(allow_download)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "NVIDIA Profile Inspector helper is unavailable; NVIDIA Roblox profile reset remains pending"
+            )
+        })?;
+
+        if let Some(profile_xml) = snapshot.roblox_profile_xml.as_deref() {
+            let restore_path = Self::write_nvidia_profile_restore(profile_xml)?;
+            Self::run_nvidia_profile_import(&inspector, &restore_path, "restore snapshot")?;
+        } else {
+            let reset_path = Self::write_nvidia_potato_profile(false)?;
+            Self::run_nvidia_profile_import(&inspector, &reset_path, "reset")?;
+        }
+
+        Self::clear_nvidia_profile_snapshot()?;
+        info!(
+            "NVIDIA Roblox potato profile reset via {}",
+            inspector.display()
+        );
+        Ok(())
+    }
+
+    fn run_nvidia_profile_import(
+        inspector: &Path,
+        profile_path: &Path,
+        action: &str,
+    ) -> Result<()> {
+        let mut command = std::process::Command::new(inspector);
+        command.arg("-silentImport").arg(profile_path);
+        let output = Self::run_command_with_timeout(
+            command,
+            Self::NPI_IMPORT_TIMEOUT_SECS,
+            "NVIDIA Profile Inspector import",
+        )?;
 
         if output.status.success() {
-            info!(
-                "NVIDIA Roblox potato profile {} via {}",
-                if enable { "applied" } else { "reset" },
-                inspector.display()
-            );
             Ok(())
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stdout = String::from_utf8_lossy(&output.stdout);
             Err(anyhow::anyhow!(
-                "NVIDIA Profile Inspector exited with {}: {}{}{}",
+                "NVIDIA Profile Inspector {} exited with {}: {}{}{}",
+                action,
                 output.status,
                 stderr.trim(),
                 if stderr.trim().is_empty() || stdout.trim().is_empty() {
@@ -773,46 +882,19 @@ impl RobloxOptimizer {
     }
 
     fn has_nvidia_gpu() -> bool {
-        let mut names = Vec::new();
-        if let Some(output) = Self::run_nvidia_smi_query() {
-            names.extend(output.lines().map(str::to_string));
-        }
-        if names.is_empty() {
-            if let Some(output) = Self::run_video_controller_query() {
-                names.extend(output.lines().map(str::to_string));
-            }
-        }
-        Self::parse_has_nvidia_gpu(&names.join("\n"))
-    }
-
-    fn run_nvidia_smi_query() -> Option<String> {
-        let mut candidates = Vec::new();
-        if let Some(root) = std::env::var_os("SystemRoot").or_else(|| std::env::var_os("WINDIR")) {
-            candidates.push(PathBuf::from(root).join("System32").join("nvidia-smi.exe"));
-        }
-        candidates.push(PathBuf::from("nvidia-smi.exe"));
-
-        for candidate in candidates {
-            let output = std::process::Command::new(candidate)
-                .args(["--query-gpu=name", "--format=csv,noheader"])
-                .output();
-            if let Ok(output) = output {
-                if output.status.success() {
-                    return Some(String::from_utf8_lossy(&output.stdout).to_string());
-                }
-            }
-        }
-        None
+        let Some(output) = Self::run_video_controller_query() else {
+            return false;
+        };
+        Self::parse_has_nvidia_gpu(&output)
     }
 
     fn run_video_controller_query() -> Option<String> {
-        let output = hidden_command("powershell")
-            .args([
-                "-Command",
-                "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name",
-            ])
-            .output()
-            .ok()?;
+        let mut command = hidden_command("powershell");
+        command.args([
+            "-Command",
+            "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name",
+        ]);
+        let output = Self::run_command_with_timeout(command, 5, "PowerShell GPU query").ok()?;
         if output.status.success() {
             Some(String::from_utf8_lossy(&output.stdout).to_string())
         } else {
@@ -826,62 +908,8 @@ impl RobloxOptimizer {
             .any(|line| line.to_ascii_lowercase().contains("nvidia"))
     }
 
-    fn resolve_nvidia_profile_inspector(install_if_missing: bool) -> Result<Option<PathBuf>> {
-        if let Some(path) = Self::installed_nvidia_profile_inspector_path()? {
-            return Ok(Some(path));
-        }
-
-        if let Some(staged) = Self::staged_nvidia_profile_inspector_path()? {
-            let target_dir = Self::nvidia_profile_inspector_install_dir()?;
-            Self::copy_directory_contents(
-                staged.parent().ok_or_else(|| {
-                    anyhow::anyhow!("staged NVIDIA Profile Inspector has no parent")
-                })?,
-                &target_dir,
-            )?;
-            let installed = target_dir.join(Self::NPI_EXE_NAME);
-            if installed.is_file() && Self::verify_nvidia_profile_inspector_exe(&installed).is_ok()
-            {
-                return Ok(Some(installed));
-            }
-        }
-
-        if !install_if_missing {
-            return Ok(None);
-        }
-
-        Self::download_nvidia_profile_inspector()?;
-        Self::installed_nvidia_profile_inspector_path()
-    }
-
-    fn installed_nvidia_profile_inspector_path() -> Result<Option<PathBuf>> {
-        let dir = Self::nvidia_profile_inspector_install_dir()?;
-        let exe = dir.join(Self::NPI_EXE_NAME);
-        if !exe.is_file() {
-            return Ok(None);
-        }
-
-        match Self::verify_nvidia_profile_inspector_exe(&exe) {
-            Ok(()) => Ok(Some(exe)),
-            Err(e) => {
-                warn!(
-                    "Ignoring NVIDIA Profile Inspector helper at {}: {}",
-                    exe.display(),
-                    e
-                );
-                Ok(None)
-            }
-        }
-    }
-
-    fn nvidia_profile_inspector_install_dir() -> Result<PathBuf> {
-        dirs::data_local_dir()
-            .map(|path| {
-                path.join("SwiftTunnel")
-                    .join("tools")
-                    .join("nvidiaProfileInspector")
-            })
-            .ok_or_else(|| anyhow::anyhow!("could not resolve local app data directory"))
+    fn resolve_nvidia_profile_inspector(_allow_download: bool) -> Result<Option<PathBuf>> {
+        Self::staged_nvidia_profile_inspector_path()
     }
 
     fn staged_nvidia_profile_inspector_path() -> Result<Option<PathBuf>> {
@@ -909,7 +937,7 @@ impl RobloxOptimizer {
             if !path.is_file() {
                 continue;
             }
-            match Self::verify_nvidia_profile_inspector_exe(&path) {
+            match Self::verify_nvidia_profile_inspector_bundle(&path) {
                 Ok(()) => return Ok(Some(path)),
                 Err(e) => warn!(
                     "Ignoring staged NVIDIA Profile Inspector helper at {}: {}",
@@ -922,101 +950,63 @@ impl RobloxOptimizer {
         Ok(None)
     }
 
-    fn copy_directory_contents(source: &Path, destination: &Path) -> Result<()> {
-        fs::create_dir_all(destination)?;
-        for entry in fs::read_dir(source)? {
-            let entry = entry?;
-            let source_path = entry.path();
-            let destination_path = destination.join(entry.file_name());
-            if source_path.is_dir() {
-                Self::copy_directory_contents(&source_path, &destination_path)?;
-            } else {
-                fs::copy(&source_path, &destination_path)?;
-            }
-        }
+    fn verify_nvidia_profile_inspector_bundle(exe_path: &Path) -> Result<()> {
+        Self::verify_file_sha256(
+            exe_path,
+            Self::NPI_EXE_SHA256,
+            "NVIDIA Profile Inspector executable",
+        )?;
+        let dir = exe_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("NVIDIA Profile Inspector executable has no parent"))?;
+        Self::verify_file_sha256(
+            &dir.join("Reference.xml"),
+            Self::NPI_REFERENCE_XML_SHA256,
+            "NVIDIA Profile Inspector Reference.xml",
+        )?;
+        Self::verify_file_sha256(
+            &dir.join("nvidiaProfileInspector.exe.config"),
+            Self::NPI_CONFIG_SHA256,
+            "NVIDIA Profile Inspector config",
+        )?;
+        Self::verify_file_sha256(
+            &dir.join("nvidiaProfileInspector.pdb"),
+            Self::NPI_PDB_SHA256,
+            "NVIDIA Profile Inspector PDB",
+        )?;
+        Self::reject_unexpected_nvidia_profile_inspector_files(dir)?;
         Ok(())
     }
 
-    fn download_nvidia_profile_inspector() -> Result<()> {
-        let install_dir = Self::nvidia_profile_inspector_install_dir()?;
-        let zip_path = install_dir.with_extension("zip");
-        fs::create_dir_all(&install_dir)?;
-        let install_dir_str = Self::escape_powershell_single_quoted(&install_dir.to_string_lossy());
-        let zip_path_str = Self::escape_powershell_single_quoted(&zip_path.to_string_lossy());
-        let url = Self::NPI_RELEASE_ZIP_URL;
+    fn reject_unexpected_nvidia_profile_inspector_files(dir: &Path) -> Result<()> {
+        const ALLOWED: &[&str] = &[
+            "README.md",
+            "Reference.xml",
+            "nvidiaProfileInspector.exe",
+            "nvidiaProfileInspector.exe.config",
+            "nvidiaProfileInspector.pdb",
+        ];
 
-        let script = format!(
-            "$ErrorActionPreference='Stop'; \
-             $ProgressPreference='SilentlyContinue'; \
-             $zip='{zip_path_str}'; \
-             Remove-Item -LiteralPath $zip -Force -ErrorAction SilentlyContinue; \
-             Invoke-WebRequest -Uri '{url}' -OutFile $zip -UseBasicParsing",
-            zip_path_str = zip_path_str,
-            url = url,
-        );
-
-        let output = hidden_command("powershell")
-            .args(["-Command", &script])
-            .output()?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!(
-                "download failed with {}: {}",
-                output.status,
-                stderr.trim()
-            ));
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                return Err(anyhow::anyhow!(
+                    "NVIDIA Profile Inspector directory contains a non-UTF-8 entry: {}",
+                    path.display()
+                ));
+            };
+            if !ALLOWED
+                .iter()
+                .any(|allowed| name.eq_ignore_ascii_case(allowed))
+            {
+                return Err(anyhow::anyhow!(
+                    "NVIDIA Profile Inspector directory contains unexpected file {}; refusing elevated helper execution",
+                    path.display()
+                ));
+            }
         }
-
-        Self::verify_file_sha256(
-            &zip_path,
-            Self::NPI_RELEASE_ZIP_SHA256,
-            "NVIDIA Profile Inspector release zip",
-        )?;
-
-        let script = format!(
-            "$ErrorActionPreference='Stop'; \
-             $dest='{install_dir_str}'; \
-             $zip='{zip_path_str}'; \
-             Expand-Archive -LiteralPath $zip -DestinationPath $dest -Force; \
-             Remove-Item -LiteralPath $zip -Force -ErrorAction SilentlyContinue; \
-             $rootExe = Join-Path $dest '{exe}'; \
-             if (-not (Test-Path -LiteralPath $rootExe)) {{ \
-               $found = Get-ChildItem -Path $dest -Recurse -Filter '{exe}' -File | Select-Object -First 1; \
-               if ($found) {{ Copy-Item -LiteralPath $found.FullName -Destination $rootExe -Force }} \
-             }}; \
-             if (-not (Test-Path -LiteralPath $rootExe)) {{ throw 'nvidiaProfileInspector.exe missing after extraction' }}",
-            install_dir_str = install_dir_str,
-            zip_path_str = zip_path_str,
-            exe = Self::NPI_EXE_NAME
-        );
-
-        let output = hidden_command("powershell")
-            .args(["-Command", &script])
-            .output()?;
-        if output.status.success() {
-            Self::verify_nvidia_profile_inspector_exe(&install_dir.join(Self::NPI_EXE_NAME))?;
-            info!(
-                "Installed NVIDIA Profile Inspector {} helper to {}",
-                Self::NPI_RELEASE_TAG,
-                install_dir.display()
-            );
-            Ok(())
-        } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(anyhow::anyhow!(
-                "extract failed with {}: {}",
-                output.status,
-                stderr.trim()
-            ))
-        }
-    }
-
-    fn verify_nvidia_profile_inspector_exe(path: &Path) -> Result<()> {
-        Self::verify_file_sha256(
-            path,
-            Self::NPI_EXE_SHA256,
-            "NVIDIA Profile Inspector executable",
-        )
+        Ok(())
     }
 
     fn verify_file_sha256(path: &Path, expected: &str, label: &str) -> Result<()> {
@@ -1050,10 +1040,142 @@ impl RobloxOptimizer {
         Ok(format!("{:x}", hasher.finalize()))
     }
 
-    fn write_nvidia_potato_profile(enable: bool) -> Result<PathBuf> {
-        let dir = dirs::data_local_dir()
+    fn capture_nvidia_profile_snapshot(inspector: &Path) -> Result<NvidiaProfileSnapshot> {
+        let Some(inspector_dir) = inspector.parent() else {
+            return Ok(NvidiaProfileSnapshot::default());
+        };
+
+        let before = std::time::SystemTime::now();
+        let mut command = std::process::Command::new(inspector);
+        command.arg("-exportCustomized").current_dir(inspector_dir);
+        let output = Self::run_command_with_timeout(
+            command,
+            Self::NPI_EXPORT_TIMEOUT_SECS,
+            "NVIDIA Profile Inspector export",
+        )?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!(
+                "profile export failed with {}: {}",
+                output.status,
+                stderr.trim()
+            ));
+        }
+
+        let Some(export_path) = Self::latest_npi_export(inspector_dir, before)? else {
+            return Err(anyhow::anyhow!(
+                "NVIDIA Profile Inspector export produced no CustomProfiles_*.nip file"
+            ));
+        };
+        let content = Self::read_text_file_lossy(&export_path)?;
+        let roblox_profile_xml = Self::extract_nvidia_profile_xml(&content, Self::NPI_PROFILE_NAME);
+        let _ = fs::remove_file(export_path);
+        Ok(NvidiaProfileSnapshot {
+            applied: false,
+            roblox_profile_xml,
+        })
+    }
+
+    fn latest_npi_export(dir: &Path, since: std::time::SystemTime) -> Result<Option<PathBuf>> {
+        let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if !name.starts_with("CustomProfiles_") || !name.ends_with(".nip") {
+                continue;
+            }
+            let modified = entry.metadata()?.modified()?;
+            if modified < since {
+                continue;
+            }
+            if newest
+                .as_ref()
+                .map(|(best, _)| modified > *best)
+                .unwrap_or(true)
+            {
+                newest = Some((modified, path));
+            }
+        }
+        Ok(newest.map(|(_, path)| path))
+    }
+
+    fn extract_nvidia_profile_xml(content: &str, profile_name: &str) -> Option<String> {
+        let mut search_from = 0;
+        while let Some(relative_start) = content[search_from..].find("<Profile>") {
+            let start = search_from + relative_start;
+            let Some(relative_end) = content[start..].find("</Profile>") else {
+                break;
+            };
+            let end = start + relative_end + "</Profile>".len();
+            let profile = &content[start..end];
+            if profile.contains(&format!("<ProfileName>{}</ProfileName>", profile_name)) {
+                return Some(profile.to_string());
+            }
+            search_from = end;
+        }
+        None
+    }
+
+    fn nvidia_profile_snapshot_path() -> Result<PathBuf> {
+        dirs::data_local_dir()
+            .map(|path| {
+                path.join("SwiftTunnel")
+                    .join(Self::NVIDIA_PROFILE_SNAPSHOT_FILE)
+            })
+            .ok_or_else(|| anyhow::anyhow!("could not resolve local app data directory"))
+    }
+
+    fn read_nvidia_profile_snapshot() -> Result<NvidiaProfileSnapshot> {
+        let path = Self::nvidia_profile_snapshot_path()?;
+        if !path.exists() {
+            return Ok(NvidiaProfileSnapshot::default());
+        }
+        let content = fs::read_to_string(path)?;
+        serde_json::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("Failed to parse NVIDIA profile snapshot: {}", e))
+    }
+
+    fn write_nvidia_profile_snapshot(snapshot: &NvidiaProfileSnapshot) -> Result<()> {
+        let path = Self::nvidia_profile_snapshot_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, serde_json::to_string_pretty(snapshot)?)?;
+        Ok(())
+    }
+
+    fn clear_nvidia_profile_snapshot() -> Result<()> {
+        let path = Self::nvidia_profile_snapshot_path()?;
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn write_nvidia_profile_restore(profile_xml: &str) -> Result<PathBuf> {
+        let dir = Self::nvidia_profile_dir()?;
+        fs::create_dir_all(&dir)?;
+        let path = dir.join("roblox-potato-mode-restore.nip");
+        let xml = format!(
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfProfile>\r\n{}\r\n</ArrayOfProfile>\r\n",
+            profile_xml
+        );
+        Self::write_utf16le(&path, &xml)?;
+        Ok(path)
+    }
+
+    fn nvidia_profile_dir() -> Result<PathBuf> {
+        dirs::data_local_dir()
             .map(|path| path.join("SwiftTunnel").join("nvidia-profiles"))
-            .ok_or_else(|| anyhow::anyhow!("could not resolve local app data directory"))?;
+            .ok_or_else(|| anyhow::anyhow!("could not resolve local app data directory"))
+    }
+
+    fn write_nvidia_potato_profile(enable: bool) -> Result<PathBuf> {
+        let dir = Self::nvidia_profile_dir()?;
         fs::create_dir_all(&dir)?;
         let path = dir.join(if enable {
             "roblox-potato-mode.nip"
@@ -1126,6 +1248,55 @@ impl RobloxOptimizer {
         }
         fs::write(path, bytes)?;
         Ok(())
+    }
+
+    fn read_text_file_lossy(path: &Path) -> Result<String> {
+        let bytes = fs::read(path)?;
+        if bytes.starts_with(&[0xFF, 0xFE]) {
+            let units = bytes[2..]
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .collect::<Vec<_>>();
+            Ok(String::from_utf16_lossy(&units))
+        } else if bytes.starts_with(&[0xFE, 0xFF]) {
+            let units = bytes[2..]
+                .chunks_exact(2)
+                .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+                .collect::<Vec<_>>();
+            Ok(String::from_utf16_lossy(&units))
+        } else {
+            Ok(String::from_utf8_lossy(&bytes).to_string())
+        }
+    }
+
+    fn run_command_with_timeout(
+        mut command: std::process::Command,
+        timeout_secs: u64,
+        label: &str,
+    ) -> Result<std::process::Output> {
+        use std::process::Stdio;
+        use std::time::{Duration, Instant};
+
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = command.spawn()?;
+        let start = Instant::now();
+        let timeout = Duration::from_secs(timeout_secs);
+
+        loop {
+            if child.try_wait()?.is_some() {
+                return Ok(child.wait_with_output()?);
+            }
+            if start.elapsed() >= timeout {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(anyhow::anyhow!(
+                    "{} timed out after {}s",
+                    label,
+                    timeout_secs
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
     }
 
     fn escape_powershell_single_quoted(value: &str) -> String {
@@ -2183,7 +2354,7 @@ impl RobloxOptimizer {
     /// Reapply saved Ultraboost client-side state after Roblox creates a new version folder.
     pub fn reapply_saved_client_fflags(&self, config: &RobloxSettingsConfig) -> Result<()> {
         self.apply_client_fflags(config)?;
-        if let Err(e) = Self::sync_nvidia_profile(config.ultraboost) {
+        if let Err(e) = Self::sync_nvidia_profile_startup(config.ultraboost) {
             warn!(
                 "Could not sync NVIDIA Roblox potato profile on startup reapply: {}",
                 e
@@ -3617,6 +3788,41 @@ HKEY_CURRENT_USER\SOFTWARE\Microsoft\DirectX\UserGpuPreferences
     fn npi_release_url_is_pinned() {
         assert!(RobloxOptimizer::NPI_RELEASE_ZIP_URL.contains(RobloxOptimizer::NPI_RELEASE_TAG));
         assert!(!RobloxOptimizer::NPI_RELEASE_ZIP_URL.contains("/latest/"));
+    }
+
+    #[test]
+    fn extract_nvidia_profile_xml_selects_only_roblox_profile() {
+        let exported = r#"<?xml version="1.0" encoding="utf-16"?>
+<ArrayOfProfile>
+  <Profile>
+    <ProfileName>Other Game</ProfileName>
+    <Settings></Settings>
+  </Profile>
+  <Profile>
+    <ProfileName>Roblox</ProfileName>
+    <Executeables><string>RobloxPlayerBeta.exe</string></Executeables>
+    <Settings><ProfileSetting><SettingID>7573135</SettingID></ProfileSetting></Settings>
+  </Profile>
+</ArrayOfProfile>"#;
+
+        let profile = RobloxOptimizer::extract_nvidia_profile_xml(exported, "Roblox").unwrap();
+        assert!(profile.contains("<ProfileName>Roblox</ProfileName>"));
+        assert!(profile.contains("<SettingID>7573135</SettingID>"));
+        assert!(!profile.contains("Other Game"));
+    }
+
+    #[test]
+    fn nvidia_profile_snapshot_roundtrips_optional_roblox_profile() {
+        let snapshot = NvidiaProfileSnapshot {
+            applied: true,
+            roblox_profile_xml: Some(
+                "<Profile><ProfileName>Roblox</ProfileName></Profile>".to_string(),
+            ),
+        };
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let roundtrip: NvidiaProfileSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip, snapshot);
     }
 
     #[test]

--- a/swifttunnel-core/src/structs.rs
+++ b/swifttunnel-core/src/structs.rs
@@ -439,11 +439,11 @@ pub mod boost_info {
     pub const ULTRABOOST: BoostInfo = BoostInfo {
         id: "ultraboost",
         title: "Ultraboost",
-        short_desc: "Max performance FFlags",
-        long_desc: "Applies curated Roblox-allowlisted performance FFlags for maximum FPS. Forces D3D11 with minimum texture, render quality, anti-aliasing, sky, and grass settings while avoiding high-DPI sharpness flags that can cost frames.",
+        short_desc: "Max performance Roblox preset",
+        long_desc: "Applies curated Roblox-allowlisted performance FFlags for maximum FPS. Forces D3D11 with minimum texture quality, 1x anti-aliasing, lowest render quality, gray sky, and zero grass distance while avoiding high-DPI sharpness flags that can cost frames. On NVIDIA GPUs, also applies a reversible NVIDIA Profile Inspector texture-filtering profile for extra potato graphics.",
         impact: "Maximum FPS preset",
         risk_level: RiskLevel::Safe,
-        requires_admin: false,
+        requires_admin: true,
     };
 
     /// Get all system boost infos
@@ -752,9 +752,13 @@ mod tests {
             !boost_info::GAME_MODE.requires_admin,
             "Game mode writes to HKCU, no admin needed"
         );
+    }
+
+    #[test]
+    fn test_ultraboost_requires_admin_for_nvidia_profile_import() {
         assert!(
-            !boost_info::ULTRABOOST.requires_admin,
-            "Ultraboost writes to user files, no admin needed"
+            boost_info::ULTRABOOST.requires_admin,
+            "Ultraboost imports an NVIDIA Profile Inspector profile on NVIDIA GPUs"
         );
     }
 }

--- a/swifttunnel-core/src/utils.rs
+++ b/swifttunnel-core/src/utils.rs
@@ -46,11 +46,30 @@ fn is_powershell_program(program: &str) -> bool {
 
 #[cfg(windows)]
 fn resolve_windows_command_path(program: &str) -> PathBuf {
-    let system_root = std::env::var_os("SystemRoot")
-        .or_else(|| std::env::var_os("WINDIR"))
-        .map(PathBuf::from);
-
+    // Do not trust SystemRoot/WINDIR from the process environment here. The
+    // desktop app runs elevated, so environment-controlled system-tool
+    // resolution would turn `hidden_command("powershell")` into an elevated
+    // PATH/root hijack. Ask kernel32 for the real System32 directory instead
+    // and derive the Windows root from that trusted path.
+    let system_root = trusted_windows_root();
     resolve_windows_command_path_with_root(program, system_root.as_deref())
+}
+
+#[cfg(windows)]
+fn trusted_windows_root() -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    let mut buffer = [0u16; 260];
+    let len = unsafe { GetSystemDirectoryW(Some(&mut buffer)) } as usize;
+    if len == 0 || len > buffer.len() {
+        return None;
+    }
+
+    PathBuf::from(OsString::from_wide(&buffer[..len]))
+        .parent()
+        .map(|path| path.to_path_buf())
 }
 
 #[cfg(windows)]

--- a/swifttunnel-desktop/package-lock.json
+++ b/swifttunnel-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swifttunnel-desktop",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swifttunnel-desktop",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.0.0",

--- a/swifttunnel-desktop/package.json
+++ b/swifttunnel-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swifttunnel-desktop",
   "private": true,
-  "version": "2.1.6",
+  "version": "2.1.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/swifttunnel-desktop/src-tauri/Cargo.toml
+++ b/swifttunnel-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifttunnel-desktop"
-version = "2.1.6"
+version = "2.1.7"
 default-run = "swifttunnel-desktop"
 edition = "2024"
 authors = ["SwiftTunnel <support@swifttunnel.net>"]

--- a/swifttunnel-desktop/src-tauri/build.rs
+++ b/swifttunnel-desktop/src-tauri/build.rs
@@ -146,6 +146,92 @@ fn check_bundled_driver_msis() {
     }
 }
 
+/// Fail release builds if the NVIDIA Profile Inspector helper was not staged.
+///
+/// Ultraboost can apply its Roblox FastFlags without this helper, but the
+/// NVIDIA-only potato graphics profile depends on
+/// `nvidiaProfileInspector.exe`. The release workflow downloads the helper
+/// into resources/tools before Tauri bundles updater artifacts; this guard
+/// catches skipped downloads before users receive an update without the new
+/// payload.
+fn check_bundled_nvidia_profile_inspector() {
+    const NPI_EXE: &str = "resources/tools/nvidiaProfileInspector/nvidiaProfileInspector.exe";
+    const EXPECTED_NPI_EXE_SHA256: &str =
+        "7d5510deeaacb50c88a49bbf1d894dae44c5ce58c00d5a88392346646b14e8f3";
+    const MIN_NPI_BYTES: u64 = 400_000;
+
+    println!("cargo:rerun-if-changed={}", NPI_EXE);
+    let path = std::path::Path::new(NPI_EXE);
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_file() && meta.len() >= MIN_NPI_BYTES => {
+            let actual_hash = file_sha256_with_powershell(path).unwrap_or_else(|err| {
+                panic!(
+                    "Failed to hash bundled NVIDIA Profile Inspector helper `{}`: {}",
+                    NPI_EXE, err
+                )
+            });
+            if actual_hash != EXPECTED_NPI_EXE_SHA256 {
+                panic!(
+                    "Bundled NVIDIA Profile Inspector helper `{}` failed SHA-256 check: \
+                     expected {}, got {}. Re-run the release workflow's pinned helper download \
+                     step and do not ship an unverified third-party binary.",
+                    NPI_EXE, EXPECTED_NPI_EXE_SHA256, actual_hash
+                );
+            }
+        }
+        Ok(meta) if meta.is_file() => {
+            panic!(
+                "Bundled NVIDIA Profile Inspector helper `{}` is suspiciously small ({} bytes, \
+                 expected >= {}). Re-run the release workflow's helper download step, or fetch \
+                 nvidiaProfileInspector.zip from https://github.com/Orbmu2k/nvidiaProfileInspector/releases",
+                NPI_EXE,
+                meta.len(),
+                MIN_NPI_BYTES
+            );
+        }
+        Ok(_) => {
+            panic!(
+                "Bundled NVIDIA Profile Inspector helper path `{}` exists but is not a file.",
+                NPI_EXE
+            );
+        }
+        Err(err) => {
+            panic!(
+                "Bundled NVIDIA Profile Inspector helper `{}` is missing ({}). The updater must \
+                 ship this helper so existing Ultraboost users receive the NVIDIA potato profile \
+                 without a separate manual install.",
+                NPI_EXE, err
+            );
+        }
+    }
+}
+
+fn file_sha256_with_powershell(path: &std::path::Path) -> Result<String, String> {
+    let path = path
+        .canonicalize()
+        .map_err(|e| format!("failed to canonicalize path: {e}"))?;
+    let quoted = powershell_single_quoted(&path.to_string_lossy());
+    let script = format!("(Get-FileHash -LiteralPath '{quoted}' -Algorithm SHA256).Hash.ToLower()");
+    let output = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .map_err(|e| format!("failed to run powershell: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Get-FileHash exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_ascii_lowercase())
+}
+
+fn powershell_single_quoted(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
 fn main() {
     // Only enforce the MSI payload check for Windows release builds.
     // CARGO_CFG_TARGET_OS gates out macOS/Linux hosts; PROFILE gates out
@@ -155,6 +241,7 @@ fn main() {
         && std::env::var("PROFILE").as_deref() == Ok("release")
     {
         check_bundled_driver_msis();
+        check_bundled_nvidia_profile_inspector();
     }
 
     let attrs = tauri_build::Attributes::new()

--- a/swifttunnel-desktop/src-tauri/build.rs
+++ b/swifttunnel-desktop/src-tauri/build.rs
@@ -155,53 +155,75 @@ fn check_bundled_driver_msis() {
 /// catches skipped downloads before users receive an update without the new
 /// payload.
 fn check_bundled_nvidia_profile_inspector() {
-    const NPI_EXE: &str = "resources/tools/nvidiaProfileInspector/nvidiaProfileInspector.exe";
-    const EXPECTED_NPI_EXE_SHA256: &str =
-        "7d5510deeaacb50c88a49bbf1d894dae44c5ce58c00d5a88392346646b14e8f3";
-    const MIN_NPI_BYTES: u64 = 400_000;
+    const NPI_FILES: &[(&str, u64, Option<&str>)] = &[
+        (
+            "resources/tools/nvidiaProfileInspector/nvidiaProfileInspector.exe",
+            900_000,
+            Some("61452518fdd2464313e08589dd6b6e9d00d3fd36c1622e1105884ab1ad7334d4"),
+        ),
+        (
+            "resources/tools/nvidiaProfileInspector/Reference.xml",
+            800_000,
+            Some("fb19d0ed9a8f1b95caa3675a94f80e2e14ae891c8fe83f164e0bb62513c2bb3f"),
+        ),
+        (
+            "resources/tools/nvidiaProfileInspector/nvidiaProfileInspector.exe.config",
+            100,
+            Some("051099983b896673909e01a1f631b6652abb88da95c9f06f3efef4be033091fa"),
+        ),
+        (
+            "resources/tools/nvidiaProfileInspector/nvidiaProfileInspector.pdb",
+            100_000,
+            Some("68ab6fe22594a906e40bb414a76a30106fa1c8d95f778c910f07e194623e7070"),
+        ),
+    ];
 
-    println!("cargo:rerun-if-changed={}", NPI_EXE);
-    let path = std::path::Path::new(NPI_EXE);
-    match std::fs::metadata(path) {
-        Ok(meta) if meta.is_file() && meta.len() >= MIN_NPI_BYTES => {
-            let actual_hash = file_sha256_with_powershell(path).unwrap_or_else(|err| {
+    for (rel, min_bytes, expected_hash) in NPI_FILES {
+        println!("cargo:rerun-if-changed={}", rel);
+        let path = std::path::Path::new(rel);
+        match std::fs::metadata(path) {
+            Ok(meta) if meta.is_file() && meta.len() >= *min_bytes => {
+                if let Some(expected_hash) = expected_hash {
+                    let actual_hash = file_sha256_with_powershell(path).unwrap_or_else(|err| {
+                        panic!(
+                            "Failed to hash bundled NVIDIA Profile Inspector helper `{}`: {}",
+                            rel, err
+                        )
+                    });
+                    if actual_hash != *expected_hash {
+                        panic!(
+                            "Bundled NVIDIA Profile Inspector helper `{}` failed SHA-256 check: \
+                             expected {}, got {}. Re-run the release workflow's pinned helper download \
+                             step and do not ship an unverified third-party binary.",
+                            rel, expected_hash, actual_hash
+                        );
+                    }
+                }
+            }
+            Ok(meta) if meta.is_file() => {
                 panic!(
-                    "Failed to hash bundled NVIDIA Profile Inspector helper `{}`: {}",
-                    NPI_EXE, err
-                )
-            });
-            if actual_hash != EXPECTED_NPI_EXE_SHA256 {
-                panic!(
-                    "Bundled NVIDIA Profile Inspector helper `{}` failed SHA-256 check: \
-                     expected {}, got {}. Re-run the release workflow's pinned helper download \
-                     step and do not ship an unverified third-party binary.",
-                    NPI_EXE, EXPECTED_NPI_EXE_SHA256, actual_hash
+                    "Bundled NVIDIA Profile Inspector helper `{}` is suspiciously small ({} bytes, \
+                     expected >= {}). Re-run the release workflow's helper download step, or fetch \
+                     nvidiaProfileInspector.zip from https://github.com/Orbmu2k/nvidiaProfileInspector/releases",
+                    rel,
+                    meta.len(),
+                    min_bytes
                 );
             }
-        }
-        Ok(meta) if meta.is_file() => {
-            panic!(
-                "Bundled NVIDIA Profile Inspector helper `{}` is suspiciously small ({} bytes, \
-                 expected >= {}). Re-run the release workflow's helper download step, or fetch \
-                 nvidiaProfileInspector.zip from https://github.com/Orbmu2k/nvidiaProfileInspector/releases",
-                NPI_EXE,
-                meta.len(),
-                MIN_NPI_BYTES
-            );
-        }
-        Ok(_) => {
-            panic!(
-                "Bundled NVIDIA Profile Inspector helper path `{}` exists but is not a file.",
-                NPI_EXE
-            );
-        }
-        Err(err) => {
-            panic!(
-                "Bundled NVIDIA Profile Inspector helper `{}` is missing ({}). The updater must \
-                 ship this helper so existing Ultraboost users receive the NVIDIA potato profile \
-                 without a separate manual install.",
-                NPI_EXE, err
-            );
+            Ok(_) => {
+                panic!(
+                    "Bundled NVIDIA Profile Inspector helper path `{}` exists but is not a file.",
+                    rel
+                );
+            }
+            Err(err) => {
+                panic!(
+                    "Bundled NVIDIA Profile Inspector helper `{}` is missing ({}). The updater must \
+                     ship the complete helper directory so existing Ultraboost users receive the \
+                     NVIDIA potato profile without a separate manual install.",
+                    rel, err
+                );
+            }
         }
     }
 }

--- a/swifttunnel-desktop/src-tauri/resources/tools/nvidiaProfileInspector/README.md
+++ b/swifttunnel-desktop/src-tauri/resources/tools/nvidiaProfileInspector/README.md
@@ -1,0 +1,7 @@
+This directory is populated by the release workflow with the pinned
+`nvidiaProfileInspector.exe` 2.4.0.31 release from upstream NVIDIA Profile
+Inspector.
+
+The binary is intentionally not committed to the repository. Tauri bundles this
+directory when release builds run, and `build.rs` fails Windows release builds if
+the helper was not staged or its SHA-256 does not match the pinned artifact.

--- a/swifttunnel-desktop/src-tauri/resources/tools/nvidiaProfileInspector/README.md
+++ b/swifttunnel-desktop/src-tauri/resources/tools/nvidiaProfileInspector/README.md
@@ -1,5 +1,5 @@
 This directory is populated by the release workflow with the pinned
-`nvidiaProfileInspector.exe` 2.4.0.31 release from upstream NVIDIA Profile
+`nvidiaProfileInspector.exe` v3.0.1.12 release from upstream NVIDIA Profile
 Inspector.
 
 The binary is intentionally not committed to the repository. Tauri bundles this

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -139,6 +139,14 @@ fn sync_runtime_assets(app: &tauri::App) {
             ]),
             exe_dir.join("drivers").join("mullvad-split-tunnel.sys"),
         ),
+        (
+            "nvidiaProfileInspector",
+            first_existing(vec![
+                resource_dir.join("tools").join("nvidiaProfileInspector"),
+                resource_dir.join("nvidiaProfileInspector"),
+            ]),
+            exe_dir.join("tools").join("nvidiaProfileInspector"),
+        ),
     ];
 
     for (name, source, destination) in targets {
@@ -269,13 +277,16 @@ fn reapply_saved_roblox_fflags(state: &AppState) {
         return;
     }
 
-    info!("Reapplying saved Roblox FFlags on startup");
+    info!("Reapplying saved Roblox Ultraboost state on startup");
     if let Err(e) = state
         .roblox_optimizer
         .lock()
         .reapply_saved_client_fflags(&roblox_config)
     {
-        warn!("Failed to reapply saved Roblox FFlags on startup: {}", e);
+        warn!(
+            "Failed to reapply saved Roblox Ultraboost state on startup: {}",
+            e
+        );
     }
 }
 

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
         "componentGroupRefs": ["NsisMigration"]
       }
     },
-    "resources": ["resources/drivers", "resources/swifty.png"],
+    "resources": ["resources/drivers", "resources/tools", "resources/swifty.png"],
     "icon": ["icons/icon.ico"]
   },
   "plugins": {

--- a/swifttunnel-desktop/src-tauri/tauri.conf.json
+++ b/swifttunnel-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "SwiftTunnel",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "identifier": "net.swifttunnel.desktop",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary
- Add NVIDIA-only Profile Inspector integration to Ultraboost, gated by detected NVIDIA GPUs.
- Auto-stage/download nvidiaProfileInspector.exe and apply the Roblox profile during normal Ultraboost apply and startup reapply for existing users.
- Bundle the helper through release resources with a release-build guard, plus docs/release notes for v2.1.7.

## Verification
- cargo fmt --all --check
- cargo test -p swifttunnel-core roblox_optimizer::tests::
- cargo check -p swifttunnel-desktop

Note: NVIDIA Profile Inspector is a separate third-party helper, not part of a default NVIDIA driver install, so this PR bundles it in updater/MSI resources and keeps a runtime fallback download.