### PR TITLE
fix(auto-route): support safe Roblox server handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Built-in performance optimizations:
 - Banned accounts are blocked in-app and trigger best-effort cleanup of saved VPN, Roblox, network, and system boosts.
 
 ### 🌍 Auto Region Detection
-Starts on the lowest-latency region from the in-app ping test, then resolves detected Roblox game-server IPs through SwiftTunnel's IPinfo-backed web resolver. Manual server pins stay respected and still complete the relay-ticket handshake, drained relays are excluded through `/api/vpn/servers`, stale lookups cannot switch after a newer game-server IP, and live ping-test refreshes keep Auto Route's server choices current while connected.
+Starts on the lowest-latency region from the in-app ping test, then resolves detected Roblox game-server IPs through SwiftTunnel's IPinfo-backed web resolver. Manual server pins stay respected and still complete relay-ticket auth, drained relays are excluded through `/api/vpn/servers`, stale lookup results cannot switch after a newer game-server IP or VPN reset, and live ping-test refreshes keep Auto Route's server choices current while connected. During same-session Roblox refreshes/teleports, the current game-server IP stays pinned while traffic is fresh; once it goes quiet, a newly observed game-server IP can be held, resolved, relay-ticket authenticated, and accepted as the active route without reconnecting.
 
 ---
 

--- a/V3-ROUTING.md
+++ b/V3-ROUTING.md
@@ -110,7 +110,8 @@ pub struct UdpRelay {
 - Initial Auto Route connects to the region with the best measured in-app ping-test latency when latency data exists; otherwise it falls back to the requested/last selected region.
 - If the requested region has a manual server pin, Auto Route starts there and uses the pinned server. Pinned regions are scored by the pinned server's latency, not by another sibling server.
 - The periodic server ping test updates the live auto-router candidate snapshot, so relay switches use the same fresh latency data shown in the UI.
-- After Roblox game-server region detection, the auto-router still targets the matching SwiftTunnel region and picks the lowest-latency relay inside that region, honoring any forced server override.
+- After Roblox game-server region detection, the auto-router targets the matching SwiftTunnel region and picks the lowest-latency relay inside that region, honoring any forced server override.
+- The active game-server IP is kept pinned while traffic to it remains fresh. A different Roblox game-server IP is suppressed during active play to avoid route churn; after the prior server is quiet for a short handoff window, the packet-observed candidate is held, resolved, relay-ticket authenticated when the session is in authenticated relay mode, and only then accepted as the active route. Resolver failures, stale generations/session epochs, auth failures, and rate-limited switch commits release the hold and make the candidate retryable instead of pinning a bad route.
 
 ### Roblox Process Identity
 - Win32 Roblox player/studio executables are matched by exact process stem or known Roblox alias only; broad substring matches are not tunnel signals.

--- a/swifttunnel-core/src/geolocation.rs
+++ b/swifttunnel-core/src/geolocation.rs
@@ -179,7 +179,7 @@ pub fn is_roblox_game_server_ip(ip: Ipv4Addr) -> bool {
 }
 
 /// Roblox game server region detected from IP address
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RobloxRegion {
     Singapore,
     Tokyo,

--- a/swifttunnel-core/src/vpn/auto_routing.rs
+++ b/swifttunnel-core/src/vpn/auto_routing.rs
@@ -1,8 +1,9 @@
 //! Auto Routing - Automatic relay server switching based on game server region
 //!
-//! Detects the first structured Roblox game-server region for a VPN session and
-//! switches the relay server for optimal latency. Once a game server is pinned,
-//! later Roblox-owned endpoints cannot change the route until disconnect.
+//! Detects structured Roblox game-server regions for a VPN session and switches
+//! the relay server for optimal latency. A fresh active game-server IP owns the
+//! route, while a different Roblox game-server IP can take over after the active
+//! server has been quiet long enough to indicate a refresh/teleport handoff.
 //!
 //! Similar to GearUp's AIR (Adaptive Intelligent Routing) and ExitLag's
 //! automatic region detection.
@@ -18,9 +19,25 @@ use std::time::{Duration, Instant};
 /// Minimum time between relay switches to prevent flapping
 const MIN_SWITCH_INTERVAL: Duration = Duration::from_secs(10);
 
+/// How long a pinned game-server IP can go quiet before a different Roblox
+/// game-server IP is treated as a same-session handoff/refresh instead of
+/// unrelated mid-game traffic.
+#[cfg(not(test))]
+const ACTIVE_GAME_SERVER_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
+#[cfg(test)]
+const ACTIVE_GAME_SERVER_IDLE_TIMEOUT: Duration = Duration::from_millis(10);
+
 /// Maximum switches per minute
 const MAX_SWITCHES_PER_MINUTE: u32 = 3;
 const SAME_REGION_UPGRADE_THRESHOLD_MS: u32 = 10;
+#[cfg(not(test))]
+const FAILED_LOOKUP_RETRY_DELAY: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const FAILED_LOOKUP_RETRY_DELAY: Duration = Duration::from_millis(10);
+#[cfg(not(test))]
+const SWITCH_REJECTED_LOOKUP_RETRY_DELAY: Duration = MIN_SWITCH_INTERVAL;
+#[cfg(test)]
+const SWITCH_REJECTED_LOOKUP_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 /// Cap on outstanding geolocation lookups. If the lookup backend stalls (API
 /// outage, network down) this keeps the pending set from growing without bound.
@@ -28,6 +45,28 @@ const MAX_PENDING_LOOKUPS: usize = 100;
 
 /// Cap on retained auto-routing events shown in the UI log.
 const MAX_EVENT_LOG_ENTRIES: usize = 20;
+
+#[derive(Debug, Clone, Copy)]
+struct ActiveGameServer {
+    ip: Ipv4Addr,
+    last_seen: Instant,
+    game_region: Option<RobloxRegion>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActiveCandidateDecision {
+    Suppress,
+    Evaluate,
+    EvaluateRetry,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AutoRoutingLookup {
+    pub ip: Ipv4Addr,
+    pub generation: u64,
+    pub session_epoch: u64,
+    pub observed_at: Instant,
+}
 
 /// Auto-routing state
 pub struct AutoRouter {
@@ -45,18 +84,26 @@ pub struct AutoRouter {
     switches_this_minute: RwLock<(u32, Instant)>,
     /// Game server IPs we've already evaluated this session
     seen_game_servers: RwLock<HashSet<Ipv4Addr>>,
-    /// First structured game-server IP accepted for this VPN session.
+    /// Failed resolver/auth/commit attempts that should not be retried from the
+    /// packet hot path until the cooldown expires.
+    failed_lookup_cooldowns: RwLock<HashMap<Ipv4Addr, Instant>>,
+    /// Roblox game-server candidates that must never be sent directly to the
+    /// physical adapter until they are classified or the router resets.
+    fail_closed_candidates: RwLock<HashSet<Ipv4Addr>>,
+    fail_closed_any: AtomicBool,
+    /// Structured game-server IP currently driving relay selection.
     ///
     /// Roblox can contact several Roblox-owned endpoints while a user is already
-    /// playing. Once a real game-server lookup succeeds, later candidate IPs
-    /// must not override that route until disconnect resets the session.
-    active_game_server_ip: RwLock<Option<Ipv4Addr>>,
+    /// playing. A fresh active game server blocks unrelated candidates, but the
+    /// pin expires after a short quiet window so same-session refreshes/teleports
+    /// can select a new relay without requiring a VPN reconnect.
+    active_game_server: RwLock<Option<ActiveGameServer>>,
     /// Callback: list of (region_id, relay_addr, cached_latency_ms) for available servers
     available_servers: RwLock<Vec<(String, SocketAddr, Option<u32>)>>,
     /// Log of auto-routing events for UI display
     event_log: RwLock<VecDeque<AutoRoutingEvent>>,
     /// Channel to send game server IPs for async geolocation lookup
-    lookup_sender: RwLock<Option<tokio::sync::mpsc::UnboundedSender<(Ipv4Addr, u64, u64)>>>,
+    lookup_sender: RwLock<Option<tokio::sync::mpsc::UnboundedSender<AutoRoutingLookup>>>,
     /// Monotonic generation assigned to newly detected game-server lookups.
     latest_lookup_generation: AtomicU64,
     /// Session epoch copied into lookup messages so post-reset results cannot
@@ -113,7 +160,10 @@ impl AutoRouter {
             ),
             switches_this_minute: RwLock::new((0, Instant::now())),
             seen_game_servers: RwLock::new(HashSet::new()),
-            active_game_server_ip: RwLock::new(None),
+            failed_lookup_cooldowns: RwLock::new(HashMap::new()),
+            fail_closed_candidates: RwLock::new(HashSet::new()),
+            fail_closed_any: AtomicBool::new(false),
+            active_game_server: RwLock::new(None),
             available_servers: RwLock::new(Vec::new()),
             event_log: RwLock::new(VecDeque::new()),
             lookup_sender: RwLock::new(None),
@@ -130,7 +180,7 @@ impl AutoRouter {
     /// Set the channel for sending game server IPs to the background lookup task
     pub fn set_lookup_channel(
         &self,
-        sender: tokio::sync::mpsc::UnboundedSender<(Ipv4Addr, u64, u64)>,
+        sender: tokio::sync::mpsc::UnboundedSender<AutoRoutingLookup>,
     ) {
         *self.lookup_sender.write() = Some(sender);
     }
@@ -237,6 +287,98 @@ impl AutoRouter {
         events.iter().rev().take(max).cloned().collect()
     }
 
+    fn lookup_observed_after_active_idle(active: ActiveGameServer, observed_at: Instant) -> bool {
+        observed_at
+            .checked_duration_since(active.last_seen)
+            .is_some_and(|quiet| quiet >= ACTIVE_GAME_SERVER_IDLE_TIMEOUT)
+    }
+
+    fn mark_fail_closed_candidate(&self, ip: Ipv4Addr) {
+        self.fail_closed_candidates.write().insert(ip);
+        self.fail_closed_any.store(true, Ordering::Release);
+    }
+
+    fn clear_fail_closed_candidate(&self, ip: Ipv4Addr) {
+        let mut candidates = self.fail_closed_candidates.write();
+        candidates.remove(&ip);
+        self.fail_closed_any
+            .store(!candidates.is_empty(), Ordering::Release);
+    }
+
+    pub fn must_not_bypass_physical(&self, ip: Ipv4Addr) -> bool {
+        if self.is_lookup_pending(ip) {
+            return true;
+        }
+        if !self.fail_closed_any.load(Ordering::Acquire) {
+            return false;
+        }
+        self.fail_closed_candidates.read().contains(&ip)
+    }
+
+    /// Decides whether a candidate packet belongs to a fresh active session.
+    /// This is called from the packet hot path, so it only uses try-locks and
+    /// never clears the active pin before a replacement lookup has actually
+    /// resolved and been accepted.
+    fn active_game_server_candidate_decision(
+        &self,
+        candidate_ip: Ipv4Addr,
+        observed_at: Instant,
+    ) -> ActiveCandidateDecision {
+        let mut active = match self.active_game_server.try_write() {
+            Some(active) => active,
+            None => {
+                if self.auto_routing_bypassed.load(Ordering::Acquire) {
+                    self.auto_routing_bypassed.store(false, Ordering::Release);
+                    self.mark_fail_closed_candidate(candidate_ip);
+                }
+                return ActiveCandidateDecision::Suppress;
+            }
+        };
+
+        match *active {
+            Some(mut active_server) if active_server.ip == candidate_ip => {
+                active_server.last_seen = observed_at;
+                if active_server
+                    .game_region
+                    .as_ref()
+                    .is_some_and(|region| self.is_region_whitelisted(region))
+                {
+                    self.auto_routing_bypassed.store(true, Ordering::Release);
+                }
+                *active = Some(active_server);
+                ActiveCandidateDecision::Suppress
+            }
+            Some(active_server)
+                if !Self::lookup_observed_after_active_idle(active_server, observed_at) =>
+            {
+                log::debug!(
+                    "Auto-routing: Suppressing candidate {} while active game server {} is fresh",
+                    candidate_ip,
+                    active_server.ip
+                );
+                if self.auto_routing_bypassed.load(Ordering::Acquire) {
+                    // Fail closed while an unclassified different Roblox game-server
+                    // candidate appears during a bypassed match. We would rather route
+                    // temporarily through SwiftTunnel than leak a non-whitelisted handoff
+                    // directly to the physical adapter.
+                    self.auto_routing_bypassed.store(false, Ordering::Release);
+                    self.mark_fail_closed_candidate(candidate_ip);
+                }
+                ActiveCandidateDecision::Suppress
+            }
+            Some(active_server) => {
+                log::info!(
+                    "Auto-routing: Active game server {} had been quiet for {:?} when candidate {} was observed; queueing handoff lookup",
+                    active_server.ip,
+                    observed_at.duration_since(active_server.last_seen),
+                    candidate_ip
+                );
+                ActiveCandidateDecision::EvaluateRetry
+            }
+            None => ActiveCandidateDecision::Evaluate,
+        }
+    }
+
     /// Evaluate a detected game server IP and trigger an async region lookup.
     ///
     /// This is called from the packet processing hot path when a new Roblox game server
@@ -249,6 +391,39 @@ impl AutoRouter {
         if !self.is_enabled() {
             return AutoRoutingAction::NoAction;
         }
+
+        let observed_at = Instant::now();
+        match self.active_game_server_candidate_decision(game_server_ip, observed_at) {
+            ActiveCandidateDecision::Suppress => return AutoRoutingAction::NoAction,
+            ActiveCandidateDecision::EvaluateRetry => {
+                self.seen_game_servers.write().remove(&game_server_ip);
+            }
+            ActiveCandidateDecision::Evaluate => {}
+        }
+
+        match self.failed_lookup_cooldowns.try_read() {
+            Some(cooldowns) => {
+                if cooldowns
+                    .get(&game_server_ip)
+                    .is_some_and(|retry_at| *retry_at > observed_at)
+                {
+                    return AutoRoutingAction::NoAction;
+                }
+            }
+            None => return AutoRoutingAction::NoAction,
+        }
+
+        let sender = match self.lookup_sender.read().as_ref() {
+            Some(s) => s.clone(),
+            None => {
+                log::warn!(
+                    "Auto-routing: Lookup channel not set (auto-routing task not running) — ignoring game server {}",
+                    game_server_ip
+                );
+                self.release_failed_lookup(game_server_ip);
+                return AutoRoutingAction::NoAction;
+            }
+        };
 
         // Fast path: bail if we've already seen this IP.
         // Use try_read() to avoid blocking the hot path. If contended, retry on a
@@ -278,16 +453,7 @@ impl AutoRouter {
             return AutoRoutingAction::NoAction;
         }
 
-        let sender = match self.lookup_sender.read().as_ref() {
-            Some(s) => s.clone(),
-            None => {
-                log::warn!(
-                    "Auto-routing: Lookup channel not set (auto-routing task not running) — ignoring game server {}",
-                    game_server_ip
-                );
-                return AutoRoutingAction::NoAction;
-            }
-        };
+        self.failed_lookup_cooldowns.write().remove(&game_server_ip);
 
         // New IP detected — add to pending set and send to background lookup task.
         // While pending, packets to this IP will be held (dropped) by the interceptor
@@ -319,15 +485,19 @@ impl AutoRouter {
         let generation = self.latest_lookup_generation.fetch_add(1, Ordering::AcqRel) + 1;
         let session_epoch = self.lookup_session_epoch.load(Ordering::Acquire);
 
-        if sender
-            .send((game_server_ip, generation, session_epoch))
-            .is_err()
-        {
+        let lookup = AutoRoutingLookup {
+            ip: game_server_ip,
+            generation,
+            session_epoch,
+            observed_at,
+        };
+
+        if sender.send(lookup).is_err() {
             log::warn!(
                 "Auto-routing: Lookup channel closed — releasing packets for {} and disabling holding behavior",
                 game_server_ip
             );
-            self.clear_pending_lookup(game_server_ip);
+            self.release_failed_lookup(game_server_ip);
             return AutoRoutingAction::NoAction;
         }
         log::info!(
@@ -364,6 +534,40 @@ impl AutoRouter {
         );
     }
 
+    /// Release a lookup result that was intentionally ignored because another
+    /// fresh game server owned routing. Unlike successful lookups, ignored IPs
+    /// must be retryable later after the active server goes quiet.
+    pub fn release_ignored_lookup(&self, ip: Ipv4Addr) {
+        self.clear_pending_lookup(ip);
+        self.seen_game_servers.write().remove(&ip);
+        log::info!(
+            "Auto-routing: Ignored lookup for {} released and marked retryable",
+            ip
+        );
+    }
+
+    pub fn release_failed_lookup(&self, ip: Ipv4Addr) {
+        self.release_lookup_with_cooldown(ip, FAILED_LOOKUP_RETRY_DELAY);
+    }
+
+    pub fn release_switch_rejected_lookup(&self, ip: Ipv4Addr) {
+        self.release_lookup_with_cooldown(ip, SWITCH_REJECTED_LOOKUP_RETRY_DELAY);
+    }
+
+    fn release_lookup_with_cooldown(&self, ip: Ipv4Addr, delay: Duration) {
+        self.release_ignored_lookup(ip);
+        self.failed_lookup_cooldowns
+            .write()
+            .insert(ip, Instant::now() + delay);
+        if !self.is_active_game_server(ip) {
+            self.mark_fail_closed_candidate(ip);
+            // Fail closed after an unclassified handoff candidate. If a previous
+            // whitelisted match enabled direct bypass, don't keep bypassing a
+            // different server whose region we failed to classify.
+            self.auto_routing_bypassed.store(false, Ordering::Release);
+        }
+    }
+
     /// Check whether a lookup result is still allowed to change relay state.
     pub fn is_current_lookup_generation(&self, generation: u64) -> bool {
         self.latest_lookup_generation.load(Ordering::Acquire) == generation
@@ -373,48 +577,163 @@ impl AutoRouter {
         self.lookup_session_epoch.load(Ordering::Acquire) == session_epoch
     }
 
-    /// Whether a completed lookup result is allowed to affect routing.
-    ///
-    /// Before the first structured lookup succeeds, candidates may resolve in
-    /// channel order. After one IP is accepted, superficially similar Roblox
-    /// traffic cannot flip the relay mid-game.
-    pub fn should_process_lookup_result(&self, ip: Ipv4Addr) -> bool {
-        match *self.active_game_server_ip.read() {
-            Some(active_ip) => active_ip == ip,
+    fn lookup_is_acceptable_locked(
+        &self,
+        active: Option<ActiveGameServer>,
+        lookup: AutoRoutingLookup,
+    ) -> bool {
+        if !self.is_current_lookup_session(lookup.session_epoch)
+            || !self.is_current_lookup_generation(lookup.generation)
+        {
+            return false;
+        }
+
+        match active {
+            Some(active_server) if active_server.ip == lookup.ip => true,
+            Some(active_server) => {
+                Self::lookup_observed_after_active_idle(active_server, lookup.observed_at)
+            }
             None => true,
         }
     }
 
-    /// Pin the first structured game-server lookup accepted for this session.
-    /// Returns false when another IP already owns the active session.
-    pub fn pin_active_game_server(&self, ip: Ipv4Addr) -> bool {
-        let session_epoch = self.lookup_session_epoch.load(Ordering::Acquire);
-        self.pin_active_game_server_for_session(ip, session_epoch)
+    /// Whether a completed lookup result is allowed to affect routing.
+    ///
+    /// Candidates are judged by when their packet was observed, not by when the
+    /// resolver happened to finish. This prevents slow resolver responses from
+    /// manufacturing handoff eligibility after the fact.
+    pub fn should_process_lookup_result(&self, lookup: AutoRoutingLookup) -> bool {
+        let active = *self.active_game_server.read();
+        self.lookup_is_acceptable_locked(active, lookup)
     }
 
-    /// Pin only if the lookup belongs to the currently active session.
-    ///
-    /// The session check happens while holding the active-IP lock so reset()
-    /// cannot clear the pin between a stale lookup's session check and pin.
+    /// Pin the structured game-server lookup accepted for this active match.
+    /// Returns false when another fresh IP already owns the active session.
+    pub fn pin_active_game_server(&self, ip: Ipv4Addr) -> bool {
+        let session_epoch = self.lookup_session_epoch.load(Ordering::Acquire);
+        let generation = self.latest_lookup_generation.load(Ordering::Acquire);
+        self.pin_active_game_server_for_lookup(AutoRoutingLookup {
+            ip,
+            generation,
+            session_epoch,
+            observed_at: Instant::now(),
+        })
+    }
+
+    /// Pin only if the lookup belongs to the currently active session and was
+    /// observed after any previous active server had already gone quiet.
     pub fn pin_active_game_server_for_session(&self, ip: Ipv4Addr, session_epoch: u64) -> bool {
-        let mut active = self.active_game_server_ip.write();
-        if !self.is_current_lookup_session(session_epoch) {
+        let generation = self.latest_lookup_generation.load(Ordering::Acquire);
+        self.pin_active_game_server_for_lookup(AutoRoutingLookup {
+            ip,
+            generation,
+            session_epoch,
+            observed_at: Instant::now(),
+        })
+    }
+
+    pub fn pin_active_game_server_for_lookup(&self, lookup: AutoRoutingLookup) -> bool {
+        let mut active = self.active_game_server.write();
+        if !self.lookup_is_acceptable_locked(*active, lookup) {
             return false;
         }
+
+        let now = Instant::now();
         match *active {
-            Some(active_ip) => active_ip == ip,
-            None => {
-                *active = Some(ip);
-                log::info!("Auto-routing: Active game server pinned to {}", ip);
-                true
+            Some(mut active_server) if active_server.ip == lookup.ip => {
+                active_server.last_seen = now;
+                *active = Some(active_server);
+                self.clear_fail_closed_candidate(lookup.ip);
             }
+            Some(active_server) => {
+                log::info!(
+                    "Auto-routing: Replacing idle active game server {} with {}",
+                    active_server.ip,
+                    lookup.ip
+                );
+                *active = Some(ActiveGameServer {
+                    ip: lookup.ip,
+                    last_seen: now,
+                    game_region: None,
+                });
+                self.clear_fail_closed_candidate(lookup.ip);
+            }
+            None => {
+                *active = Some(ActiveGameServer {
+                    ip: lookup.ip,
+                    last_seen: now,
+                    game_region: None,
+                });
+                self.clear_fail_closed_candidate(lookup.ip);
+                log::info!("Auto-routing: Active game server pinned to {}", lookup.ip);
+            }
+        }
+        true
+    }
+
+    pub fn clear_active_game_server_if(&self, ip: Ipv4Addr) {
+        let mut active = self.active_game_server.write();
+        if (*active).is_some_and(|active_server| active_server.ip == ip) {
+            *active = None;
+        }
+    }
+
+    pub fn accept_lookup_without_switch(
+        &self,
+        lookup: AutoRoutingLookup,
+        game_region: RobloxRegion,
+    ) -> bool {
+        let mut active = self.active_game_server.write();
+        if !self.lookup_is_acceptable_locked(*active, lookup) {
+            return false;
+        }
+        *active = Some(ActiveGameServer {
+            ip: lookup.ip,
+            last_seen: Instant::now(),
+            game_region: Some(game_region.clone()),
+        });
+        self.clear_fail_closed_candidate(lookup.ip);
+        *self.current_game_region.write() = Some(game_region);
+        true
+    }
+
+    pub fn commit_switch_for_lookup(
+        &self,
+        lookup: AutoRoutingLookup,
+        game_region: RobloxRegion,
+        selected_region: String,
+        selected_addr: SocketAddr,
+        latency_improvement_ms: Option<u32>,
+    ) -> Option<(SocketAddr, String)> {
+        let mut active = self.active_game_server.write();
+        if !self.lookup_is_acceptable_locked(*active, lookup) {
+            return None;
+        }
+
+        let current_st_region = self.current_st_region.read().clone();
+        if self.record_switch(
+            &current_st_region,
+            &selected_region,
+            &game_region,
+            selected_addr,
+            latency_improvement_ms,
+        ) {
+            *active = Some(ActiveGameServer {
+                ip: lookup.ip,
+                last_seen: Instant::now(),
+                game_region: Some(game_region.clone()),
+            });
+            self.clear_fail_closed_candidate(lookup.ip);
+            Some((selected_addr, selected_region))
+        } else {
+            None
         }
     }
 
     pub fn is_active_game_server(&self, ip: Ipv4Addr) -> bool {
-        self.active_game_server_ip
+        self.active_game_server
             .read()
-            .is_some_and(|active_ip| active_ip == ip)
+            .is_some_and(|active_server| active_server.ip == ip)
     }
 
     /// Resolve the best relay server for a game region.
@@ -424,6 +743,32 @@ impl AutoRouter {
     /// - the region is whitelisted (VPN bypass),
     /// - already on the desired server,
     /// - or no matching server exists.
+    pub fn can_accept_lookup_without_switch(&self, game_region: &RobloxRegion) -> bool {
+        if *game_region == RobloxRegion::Unknown {
+            return false;
+        }
+        if self.is_region_whitelisted(game_region) {
+            return true;
+        }
+
+        let Some(best_st_region) = game_region.best_swifttunnel_region() else {
+            return false;
+        };
+        let pinned_server = self.forced_servers.read().get(best_st_region).cloned();
+        let servers = self.available_servers.read();
+        let candidates = super::connection::relay_candidates_for_region(
+            best_st_region,
+            &servers,
+            pinned_server.as_deref(),
+        );
+        let current_st_region = self.current_st_region.read().clone();
+        let current_relay_addr = *self.current_relay_addr.read();
+
+        candidates.len() == 1
+            && current_st_region == candidates[0].0
+            && current_relay_addr == Some(candidates[0].1)
+    }
+
     pub fn get_best_server_for_region(
         &self,
         game_region: &RobloxRegion,
@@ -635,11 +980,15 @@ impl AutoRouter {
 
     /// Reset state (call on disconnect)
     pub fn reset(&self) {
+        let mut active = self.active_game_server.write();
         *self.current_game_region.write() = None;
         *self.current_relay_addr.write() = None;
         self.seen_game_servers.write().clear();
+        self.failed_lookup_cooldowns.write().clear();
+        self.fail_closed_candidates.write().clear();
+        self.fail_closed_any.store(false, Ordering::Release);
         self.lookup_session_epoch.fetch_add(1, Ordering::AcqRel);
-        *self.active_game_server_ip.write() = None;
+        *active = None;
         self.pending_lookups.write().clear();
         self.latest_lookup_generation.store(0, Ordering::Release);
         self.pending_any.store(false, Ordering::Release);
@@ -827,6 +1176,15 @@ mod tests {
         assert!(best.is_none());
     }
 
+    fn current_lookup(router: &AutoRouter, ip: Ipv4Addr) -> AutoRoutingLookup {
+        AutoRoutingLookup {
+            ip,
+            generation: router.latest_lookup_generation.load(Ordering::Acquire),
+            session_epoch: router.lookup_session_epoch.load(Ordering::Acquire),
+            observed_at: Instant::now(),
+        }
+    }
+
     #[test]
     fn test_auto_router_deduplicates_ips() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -837,11 +1195,10 @@ mod tests {
 
         // First call sends to channel
         router.evaluate_game_server(ip);
-        let (received_ip, generation, session_epoch) =
-            rx.try_recv().expect("first lookup should be sent");
-        assert_eq!(received_ip, ip);
-        assert_eq!(generation, 1);
-        assert!(router.is_current_lookup_session(session_epoch));
+        let lookup = rx.try_recv().expect("first lookup should be sent");
+        assert_eq!(lookup.ip, ip);
+        assert_eq!(lookup.generation, 1);
+        assert!(router.is_current_lookup_session(lookup.session_epoch));
 
         // Second call with same IP should NOT send again
         router.evaluate_game_server(ip);
@@ -855,16 +1212,16 @@ mod tests {
         router.set_lookup_channel(tx);
 
         router.evaluate_game_server(Ipv4Addr::new(128, 116, 50, 1));
-        let (_, first_generation, first_session_epoch) = rx.try_recv().expect("first lookup");
-        assert!(router.is_current_lookup_generation(first_generation));
-        assert!(router.is_current_lookup_session(first_session_epoch));
+        let first_lookup = rx.try_recv().expect("first lookup");
+        assert!(router.is_current_lookup_generation(first_lookup.generation));
+        assert!(router.is_current_lookup_session(first_lookup.session_epoch));
 
         router.evaluate_game_server(Ipv4Addr::new(128, 116, 55, 1));
-        let (_, second_generation, second_session_epoch) = rx.try_recv().expect("second lookup");
-        assert!(!router.is_current_lookup_generation(first_generation));
-        assert!(router.is_current_lookup_generation(second_generation));
-        assert_eq!(first_session_epoch, second_session_epoch);
-        assert!(router.is_current_lookup_session(second_session_epoch));
+        let second_lookup = rx.try_recv().expect("second lookup");
+        assert!(!router.is_current_lookup_generation(first_lookup.generation));
+        assert!(router.is_current_lookup_generation(second_lookup.generation));
+        assert_eq!(first_lookup.session_epoch, second_lookup.session_epoch);
+        assert!(router.is_current_lookup_session(second_lookup.session_epoch));
     }
 
     #[test]
@@ -874,15 +1231,15 @@ mod tests {
         router.set_lookup_channel(tx);
 
         router.evaluate_game_server(Ipv4Addr::new(128, 116, 50, 1));
-        let (_, _generation, session_epoch) = rx.try_recv().expect("lookup");
-        assert!(router.is_current_lookup_session(session_epoch));
+        let lookup = rx.try_recv().expect("lookup");
+        assert!(router.is_current_lookup_session(lookup.session_epoch));
 
         router.reset();
-        assert!(!router.is_current_lookup_session(session_epoch));
-        assert!(
-            !router
-                .pin_active_game_server_for_session(Ipv4Addr::new(128, 116, 50, 1), session_epoch)
-        );
+        assert!(!router.is_current_lookup_session(lookup.session_epoch));
+        assert!(!router.pin_active_game_server_for_session(
+            Ipv4Addr::new(128, 116, 50, 1),
+            lookup.session_epoch
+        ));
     }
 
     #[test]
@@ -891,12 +1248,12 @@ mod tests {
         let first_ip = Ipv4Addr::new(128, 116, 50, 1);
         let later_ip = Ipv4Addr::new(128, 116, 55, 1);
 
-        assert!(router.should_process_lookup_result(first_ip));
-        assert!(router.should_process_lookup_result(later_ip));
+        assert!(router.should_process_lookup_result(current_lookup(&router, first_ip)));
+        assert!(router.should_process_lookup_result(current_lookup(&router, later_ip)));
         assert!(router.pin_active_game_server(first_ip));
 
-        assert!(router.should_process_lookup_result(first_ip));
-        assert!(!router.should_process_lookup_result(later_ip));
+        assert!(router.should_process_lookup_result(current_lookup(&router, first_ip)));
+        assert!(!router.should_process_lookup_result(current_lookup(&router, later_ip)));
         assert!(router.is_active_game_server(first_ip));
         assert!(!router.pin_active_game_server(later_ip));
     }
@@ -907,11 +1264,134 @@ mod tests {
         let failed_ip = Ipv4Addr::new(128, 116, 50, 1);
         let retry_ip = Ipv4Addr::new(128, 116, 55, 1);
 
-        assert!(router.should_process_lookup_result(failed_ip));
-        assert!(router.should_process_lookup_result(retry_ip));
+        assert!(router.should_process_lookup_result(current_lookup(&router, failed_ip)));
+        assert!(router.should_process_lookup_result(current_lookup(&router, retry_ip)));
 
         assert!(router.pin_active_game_server(retry_ip));
-        assert!(!router.should_process_lookup_result(failed_ip));
+        assert!(!router.should_process_lookup_result(current_lookup(&router, failed_ip)));
+    }
+
+    #[test]
+    fn test_active_game_server_suppresses_fresh_different_ip_without_holding() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = AutoRouter::new(true, "singapore");
+        router.set_lookup_channel(tx);
+
+        let active_ip = Ipv4Addr::new(128, 116, 50, 1);
+        let candidate_ip = Ipv4Addr::new(128, 116, 55, 1);
+        assert!(router.pin_active_game_server(active_ip));
+
+        router.evaluate_game_server(candidate_ip);
+
+        assert!(
+            rx.try_recv().is_err(),
+            "fresh active game server should suppress a different candidate without lookup churn"
+        );
+        assert!(
+            !router.is_lookup_pending(candidate_ip),
+            "suppressed candidates must not hold packets"
+        );
+    }
+
+    #[test]
+    fn test_active_game_server_can_be_replaced_after_idle_window() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = AutoRouter::new(true, "singapore");
+        router.set_lookup_channel(tx);
+
+        let active_ip = Ipv4Addr::new(128, 116, 50, 1);
+        let next_ip = Ipv4Addr::new(128, 116, 55, 1);
+        assert!(router.pin_active_game_server(active_ip));
+
+        std::thread::sleep(Duration::from_millis(20));
+
+        router.evaluate_game_server(next_ip);
+
+        let lookup = rx
+            .try_recv()
+            .expect("stale active game server should allow a new lookup");
+        assert_eq!(lookup.ip, next_ip);
+        assert!(
+            router.should_process_lookup_result(lookup),
+            "a quiet active game server should not pin the route forever"
+        );
+        assert!(router.is_lookup_pending(next_ip));
+    }
+
+    #[test]
+    fn test_ignored_lookup_is_retryable_after_active_server_goes_idle() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = AutoRouter::new(true, "singapore");
+        router.set_lookup_channel(tx);
+
+        let active_ip = Ipv4Addr::new(128, 116, 50, 1);
+        let ignored_ip = Ipv4Addr::new(128, 116, 55, 1);
+
+        router.evaluate_game_server(ignored_ip);
+        let ignored_lookup = rx.try_recv().expect("lookup queued");
+        assert_eq!(ignored_lookup.ip, ignored_ip);
+        assert!(router.pin_active_game_server(active_ip));
+        assert!(!router.should_process_lookup_result(ignored_lookup));
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(
+            !router.should_process_lookup_result(ignored_lookup),
+            "a stale resolver result must not become acceptable just because the active server later went idle"
+        );
+
+        router.release_ignored_lookup(ignored_ip);
+
+        router.evaluate_game_server(ignored_ip);
+        let retried_lookup = rx
+            .try_recv()
+            .expect("ignored lookup should become retryable");
+        assert!(router.should_process_lookup_result(retried_lookup));
+        assert_eq!(retried_lookup.ip, ignored_ip);
+    }
+
+    #[test]
+    fn test_failed_lookup_uses_cooldown_before_retry() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = AutoRouter::new(true, "singapore");
+        router.set_lookup_channel(tx);
+
+        let ip = Ipv4Addr::new(128, 116, 50, 1);
+        router.evaluate_game_server(ip);
+        let _ = rx.try_recv().expect("first lookup should be queued");
+
+        router.release_failed_lookup(ip);
+        router.evaluate_game_server(ip);
+        assert!(
+            rx.try_recv().is_err(),
+            "failed lookups should not retry on the next packet immediately"
+        );
+
+        std::thread::sleep(Duration::from_millis(20));
+        router.evaluate_game_server(ip);
+        let retry_lookup = rx.try_recv().expect("lookup should retry after cooldown");
+        assert_eq!(retry_lookup.ip, ip);
+    }
+
+    #[test]
+    fn test_switch_rejected_lookup_uses_cooldown_before_retry() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = AutoRouter::new(true, "singapore");
+        router.set_lookup_channel(tx);
+
+        let ip = Ipv4Addr::new(128, 116, 55, 1);
+        router.evaluate_game_server(ip);
+        let _ = rx.try_recv().expect("first lookup should be queued");
+
+        router.release_switch_rejected_lookup(ip);
+        router.evaluate_game_server(ip);
+        assert!(
+            rx.try_recv().is_err(),
+            "rate-limited switch rejects should not spin resolver/auth immediately"
+        );
+
+        std::thread::sleep(Duration::from_millis(20));
+        router.evaluate_game_server(ip);
+        let retry_lookup = rx.try_recv().expect("lookup should retry after cooldown");
+        assert_eq!(retry_lookup.ip, ip);
     }
 
     #[test]
@@ -935,6 +1415,15 @@ mod tests {
 
         router.evaluate_game_server(ip);
         assert!(!router.is_lookup_pending(ip));
+    }
+
+    #[test]
+    fn test_no_server_region_cannot_be_accepted_without_switch() {
+        let router = AutoRouter::new(true, "singapore");
+        router.set_available_servers(vec![]);
+        router.set_current_relay("54.255.205.216:51821".parse().unwrap(), "singapore");
+
+        assert!(!router.can_accept_lookup_without_switch(&RobloxRegion::Tokyo));
     }
 
     #[test]
@@ -1000,7 +1489,12 @@ mod tests {
 
         router.reset();
         assert!(!router.is_bypassed());
-        assert!(router.should_process_lookup_result(Ipv4Addr::new(128, 116, 55, 1)));
+        assert!(
+            router.should_process_lookup_result(current_lookup(
+                &router,
+                Ipv4Addr::new(128, 116, 55, 1)
+            ))
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -291,7 +291,6 @@ fn select_candidate_after_preflight(
     let fallback = attempts
         .iter()
         .find(|attempt| attempt.policy_known)
-        .or_else(|| attempts.first())
         .ok_or(CONNECT_FAIL_CANDIDATE_EXHAUSTED)?;
 
     if attempts.iter().any(|attempt| attempt.auth_required) {
@@ -776,7 +775,9 @@ async fn authenticate_auto_routing_relay_switch(
     let auth_result = tokio::time::timeout(AUTO_ROUTING_RELAY_AUTH_TIMEOUT, auth_join).await;
 
     match auth_result {
-        Ok(Ok(Ok(Some(RelayAuthAckStatus::Ok)))) => RuntimeRelayAuthResult::Authenticated,
+        Ok(Ok(Ok(Some(RelayAuthAckStatus::Ok | RelayAuthAckStatus::AuthDisabled)))) => {
+            RuntimeRelayAuthResult::Authenticated
+        }
         Ok(Ok(Ok(Some(RelayAuthAckStatus::Replay)))) => {
             log::warn!(
                 "Auto-routing: relay auth replay rejected runtime switch to '{}' (session {})",
@@ -1833,7 +1834,7 @@ impl VpnConnection {
                             lookup.generation,
                             newer_lookup.generation
                         );
-                        router_for_lookup.release_failed_lookup(lookup.ip);
+                        router_for_lookup.release_ignored_lookup(lookup.ip);
                         lookup = newer_lookup;
                     }
 

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -15,6 +15,7 @@ use super::parallel_interceptor::{
 use super::process_performance::{GameProcessPerformanceManager, GameProcessPerformancePolicy};
 use super::process_watcher::{ProcessStartEvent, ProcessWatcher};
 use super::split_tunnel::{SplitTunnelConfig, SplitTunnelDriver};
+use super::udp_relay::{RelayAuthAckStatus, UdpRelay};
 use super::{VpnError, VpnResult};
 use crate::auth::http_client::AuthClient;
 use crate::auth::types::{AuthError, RelayPreflightMode, RelayQueueFullMode, VpnConfig};
@@ -63,12 +64,14 @@ const ETW_CONNECTION_READY_TIMEOUT_MS: u64 = 150;
 const ETW_CONNECTION_READY_POLL_MS: u64 = 5;
 /// Number of ICMP samples to collect per relay candidate when probing.
 const AUTO_ROUTING_PING_SAMPLES: usize = 5;
+const AUTO_ROUTING_RELAY_AUTH_TIMEOUT: Duration = Duration::from_secs(4);
 const CONNECT_FAIL_HANDSHAKE_TIMEOUT: &str = "ST_CONNECT_HANDSHAKE_TIMEOUT";
 const CONNECT_FAIL_CANDIDATE_EXHAUSTED: &str = "ST_CONNECT_CANDIDATE_EXHAUSTED";
 const CONNECT_FAIL_PREFLIGHT_ENFORCED: &str = "ST_CONNECT_PREFLIGHT_ENFORCED";
 const CONNECT_FAIL_AUTH_REQUIRED: &str = "ST_CONNECT_AUTH_REQUIRED";
 const CONNECT_FAIL_POLICY_UNAVAILABLE: &str = "ST_CONNECT_POLICY_UNAVAILABLE";
 const CONNECT_FAIL_REGION_UNAVAILABLE: &str = "ST_CONNECT_REGION_UNAVAILABLE";
+const CONNECT_FAIL_AUTH_REPLAY: &str = "ST_CONNECT_AUTH_REPLAY";
 
 /// Relay UDP port used *only* as a last-resort fallback when the resolved
 /// server list carried no relay candidate (and no custom relay is configured)
@@ -83,6 +86,14 @@ static PREFLIGHT_ENFORCED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static AUTH_REQUIRED_EVENTS: AtomicU64 = AtomicU64::new(0);
 static POLICY_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
 static REGION_UNAVAILABLE_EVENTS: AtomicU64 = AtomicU64::new(0);
+static AUTH_REPLAY_EVENTS: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuntimeRelayAuthResult {
+    Authenticated,
+    RetryableFailure,
+    Fatal(String),
+}
 
 #[derive(Debug, Clone)]
 struct RelayCandidateAttempt {
@@ -273,7 +284,15 @@ fn select_candidate_after_preflight(
         ));
     }
 
-    let fallback = attempts.first().ok_or(CONNECT_FAIL_CANDIDATE_EXHAUSTED)?;
+    if attempts.iter().all(|attempt| !attempt.policy_known) {
+        return Err(CONNECT_FAIL_POLICY_UNAVAILABLE);
+    }
+
+    let fallback = attempts
+        .iter()
+        .find(|attempt| attempt.policy_known)
+        .or_else(|| attempts.first())
+        .ok_or(CONNECT_FAIL_CANDIDATE_EXHAUSTED)?;
 
     if attempts.iter().any(|attempt| attempt.auth_required) {
         return Err(CONNECT_FAIL_AUTH_REQUIRED);
@@ -689,6 +708,129 @@ fn compute_latency_improvement(
     let best_latency_ms = best_candidate.probed_latency_ms?;
     let current_latency_ms = current_candidate.probed_latency_ms?;
     (current_latency_ms > best_latency_ms).then_some(current_latency_ms - best_latency_ms)
+}
+
+async fn authenticate_auto_routing_relay_switch(
+    access_token: &str,
+    relay: &Arc<UdpRelay>,
+    selected_region: &str,
+    selected_addr: SocketAddr,
+) -> RuntimeRelayAuthResult {
+    if relay.relay_addr() == selected_addr {
+        return RuntimeRelayAuthResult::Authenticated;
+    }
+
+    let session_id_hex = relay.session_id_hex();
+    let auth_client = AuthClient::new();
+    let ticket_result = tokio::time::timeout(
+        AUTO_ROUTING_RELAY_AUTH_TIMEOUT,
+        auth_client.get_relay_ticket(access_token, selected_region, &session_id_hex),
+    )
+    .await;
+    let ticket = match ticket_result {
+        Ok(Ok(ticket)) => ticket,
+        Ok(Err(e)) => {
+            if let Some(reason) = relay_ticket_ban_reason(&e) {
+                log::warn!(
+                    "Auto-routing: relay ticket rejected as banned while switching to '{}' (session {})",
+                    selected_region,
+                    session_id_hex
+                );
+                return RuntimeRelayAuthResult::Fatal(format!(
+                    "Relay ticket rejected because this account is banned: {}",
+                    reason
+                ));
+            } else {
+                log::warn!(
+                    "Auto-routing: relay ticket unavailable for runtime switch to '{}' (session {}, {})",
+                    selected_region,
+                    session_id_hex,
+                    e
+                );
+            }
+            return RuntimeRelayAuthResult::RetryableFailure;
+        }
+        Err(_) => {
+            log::warn!(
+                "Auto-routing: relay ticket timed out for runtime switch to '{}' (session {})",
+                selected_region,
+                session_id_hex
+            );
+            return RuntimeRelayAuthResult::RetryableFailure;
+        }
+    };
+
+    log::info!(
+        "Auto-routing: authenticating relay switch to '{}' at {} (session {}, key_id={})",
+        selected_region,
+        selected_addr,
+        session_id_hex,
+        ticket.key_id
+    );
+
+    let relay_for_auth = Arc::clone(relay);
+    let token = ticket.token;
+    let auth_join = tokio::task::spawn_blocking(move || {
+        relay_for_auth.authenticate_relay_addr_with_observed_ack(selected_addr, &token)
+    });
+    let auth_result = tokio::time::timeout(AUTO_ROUTING_RELAY_AUTH_TIMEOUT, auth_join).await;
+
+    match auth_result {
+        Ok(Ok(Ok(Some(RelayAuthAckStatus::Ok)))) => RuntimeRelayAuthResult::Authenticated,
+        Ok(Ok(Ok(Some(RelayAuthAckStatus::Replay)))) => {
+            log::warn!(
+                "Auto-routing: relay auth replay rejected runtime switch to '{}' (session {})",
+                selected_region,
+                session_id_hex
+            );
+            RuntimeRelayAuthResult::Fatal(
+                "Relay authentication rejected a replayed ticket".to_string(),
+            )
+        }
+        Ok(Ok(Ok(Some(status)))) => {
+            log::warn!(
+                "Auto-routing: relay auth ack '{}' rejected runtime switch to '{}' (session {})",
+                status.as_str(),
+                selected_region,
+                session_id_hex
+            );
+            RuntimeRelayAuthResult::RetryableFailure
+        }
+        Ok(Ok(Ok(None))) => {
+            log::warn!(
+                "Auto-routing: relay auth timed out for runtime switch to '{}' (session {})",
+                selected_region,
+                session_id_hex
+            );
+            RuntimeRelayAuthResult::RetryableFailure
+        }
+        Ok(Ok(Err(e))) => {
+            log::warn!(
+                "Auto-routing: relay auth handshake failed for runtime switch to '{}' (session {}, {})",
+                selected_region,
+                session_id_hex,
+                e
+            );
+            RuntimeRelayAuthResult::RetryableFailure
+        }
+        Ok(Err(e)) => {
+            log::warn!(
+                "Auto-routing: relay auth worker failed for runtime switch to '{}' (session {}, {})",
+                selected_region,
+                session_id_hex,
+                e
+            );
+            RuntimeRelayAuthResult::RetryableFailure
+        }
+        Err(_) => {
+            log::warn!(
+                "Auto-routing: relay auth worker timed out for runtime switch to '{}' (session {})",
+                selected_region,
+                session_id_hex
+            );
+            RuntimeRelayAuthResult::RetryableFailure
+        }
+    }
 }
 
 /// Probe candidate relay servers in parallel using ICMP and return their
@@ -1328,7 +1470,54 @@ impl VpnConnection {
         let mut queue_full_mode = RelayQueueFullMode::Bypass;
 
         if custom_relay_server.is_some() {
-            log::warn!("V3: Custom relay enabled, skipping authenticated relay ticket bootstrap");
+            log::warn!(
+                "V3: Custom relay enabled, performing relay-ticket policy check without relay auth handshake"
+            );
+            let auth_client = AuthClient::new();
+            let session_id_hex = relay.session_id_hex();
+            let ticket = match auth_client
+                .get_relay_ticket(access_token, &config.region, &session_id_hex)
+                .await
+            {
+                Ok(ticket) => ticket,
+                Err(e) => {
+                    if let Some(reason) = relay_ticket_ban_reason(&e) {
+                        log::warn!(
+                            "V3: Custom relay ticket rejected because the current account is banned"
+                        );
+                        let _ = driver.close();
+                        return Err(VpnError::UserBanned(reason));
+                    }
+                    log_sampled_connect_event(
+                        &POLICY_UNAVAILABLE_EVENTS,
+                        CONNECT_FAIL_POLICY_UNAVAILABLE,
+                        format!(
+                            "Custom relay policy unavailable for '{}' (session {})",
+                            config.region, session_id_hex
+                        ),
+                    );
+                    let _ = driver.close();
+                    return Err(VpnError::Connection(
+                        "Relay policy unavailable; refusing custom relay connection".to_string(),
+                    ));
+                }
+            };
+            if ticket.auth_required || ticket.preflight_mode() == RelayPreflightMode::Enforce {
+                log_sampled_connect_event(
+                    &AUTH_REQUIRED_EVENTS,
+                    CONNECT_FAIL_AUTH_REQUIRED,
+                    format!(
+                        "Custom relay rejected because authenticated relay policy is required for '{}' (session {})",
+                        config.region, session_id_hex
+                    ),
+                );
+                let _ = driver.close();
+                return Err(VpnError::Connection(
+                    "Relay authentication required; custom relay cannot use legacy mode"
+                        .to_string(),
+                ));
+            }
+            queue_full_mode = ticket.queue_full_mode();
         } else {
             let auth_client = AuthClient::new();
             let session_id_hex = relay.session_id_hex();
@@ -1424,6 +1613,20 @@ impl VpnConnection {
                             candidate_region,
                             session_id_hex
                         );
+                        if status == RelayAuthAckStatus::Replay {
+                            log_sampled_connect_event(
+                                &AUTH_REPLAY_EVENTS,
+                                CONNECT_FAIL_AUTH_REPLAY,
+                                format!(
+                                    "Relay ticket replay rejected for candidate '{}' (session {})",
+                                    candidate_region, session_id_hex
+                                ),
+                            );
+                            let _ = driver.close();
+                            return Err(VpnError::Connection(
+                                "Relay authentication rejected a replayed ticket".to_string(),
+                            ));
+                        }
                         attempt_results.push(RelayCandidateAttempt {
                             region: candidate_region.clone(),
                             addr: *candidate_addr,
@@ -1607,46 +1810,64 @@ impl VpnConnection {
             auto_router.set_forced_servers(forced_servers);
         }
 
+        let runtime_auth_fatal_error = Arc::new(parking_lot::Mutex::new(None::<String>));
+
         // Spawn background task for async ipinfo.io region lookups
         if auto_routing_enabled {
             let (lookup_tx, mut lookup_rx) =
-                tokio::sync::mpsc::unbounded_channel::<(std::net::Ipv4Addr, u64, u64)>();
+                tokio::sync::mpsc::unbounded_channel::<super::auto_routing::AutoRoutingLookup>();
             auto_router.set_lookup_channel(lookup_tx);
 
             let router_for_lookup = Arc::clone(&auto_router);
             let state_for_lookup = Arc::clone(&self.state);
+            let access_token_for_lookup = access_token.to_string();
+            let relay_auth_required_for_lookup = relay_auth_mode == "authenticated";
+            let relay_auth_lock_for_lookup = Arc::new(tokio::sync::Mutex::new(()));
+            let runtime_auth_fatal_for_lookup = Arc::clone(&runtime_auth_fatal_error);
             let lookup_handle = tokio::spawn(async move {
-                while let Some((ip, generation, session_epoch)) = lookup_rx.recv().await {
+                while let Some(mut lookup) = lookup_rx.recv().await {
+                    while let Ok(newer_lookup) = lookup_rx.try_recv() {
+                        log::info!(
+                            "Auto-routing: Draining stale queued lookup for {} (generation {}) in favor of newer generation {}",
+                            lookup.ip,
+                            lookup.generation,
+                            newer_lookup.generation
+                        );
+                        router_for_lookup.release_failed_lookup(lookup.ip);
+                        lookup = newer_lookup;
+                    }
+
+                    let ip = lookup.ip;
+                    let generation = lookup.generation;
+                    let session_epoch = lookup.session_epoch;
                     match crate::geolocation::lookup_game_server_region(ip).await {
                         Some((region, location)) => {
                             if !router_for_lookup.is_current_lookup_session(session_epoch) {
                                 log::info!(
-                                    "Auto-routing: Ignoring stale lookup for {} (generation {}, session {}) after router reset",
+                                    "Auto-routing: Ignoring lookup for {} (generation {}, session {}) after router reset",
                                     ip,
                                     generation,
                                     session_epoch
                                 );
-                                router_for_lookup.clear_pending_lookup(ip);
+                                router_for_lookup.release_ignored_lookup(ip);
                                 continue;
                             }
-                            if !router_for_lookup.should_process_lookup_result(ip) {
+                            if !router_for_lookup.is_current_lookup_generation(generation) {
+                                log::info!(
+                                    "Auto-routing: Ignoring stale lookup for {} (generation {}) after newer lookup",
+                                    ip,
+                                    generation
+                                );
+                                router_for_lookup.release_failed_lookup(ip);
+                                continue;
+                            }
+                            if !router_for_lookup.should_process_lookup_result(lookup) {
                                 log::info!(
                                     "Auto-routing: Ignoring lookup for {} (generation {}) because another game server is active",
                                     ip,
                                     generation
                                 );
-                                router_for_lookup.clear_pending_lookup(ip);
-                                continue;
-                            }
-                            if !router_for_lookup
-                                .pin_active_game_server_for_session(ip, session_epoch)
-                            {
-                                log::info!(
-                                    "Auto-routing: Ignoring lookup for {} (generation {}) after active game server changed",
-                                    ip,
-                                    generation
-                                );
-                                router_for_lookup.clear_pending_lookup(ip);
+                                router_for_lookup.release_ignored_lookup(ip);
                                 continue;
                             }
 
@@ -1659,174 +1880,311 @@ impl VpnConnection {
                             let old_region = router_for_lookup.current_region();
 
                             // Step 1: Resolve relay using cached latency (instant, no probing).
-                            // Switch immediately so packets can be released ASAP.
-                            let step1_switched = if let Some((selected_region, selected_addr)) =
+                            // Switch immediately so packets can be released ASAP, but only after
+                            // the lookup is still current and the observed packet qualified as a
+                            // real handoff. Failed/rate-limited switches stay retryable.
+                            let run_probe_refinement = if let Some((
+                                selected_region,
+                                selected_addr,
+                            )) =
                                 router_for_lookup.get_best_server_for_region(&region)
                             {
-                                // Compute cached latency delta so same-region upgrades are not
-                                // silently rejected by the rate-limiter in commit_switch.
-                                let cached_improvement =
-                                    router_for_lookup.current_relay().and_then(|current| {
-                                        let servers =
-                                            router_for_lookup.available_servers_snapshot();
-                                        compute_cached_latency_improvement(
-                                            &servers,
-                                            selected_addr,
-                                            current.1,
-                                        )
-                                    });
-
-                                if let Some((new_addr, new_region)) = router_for_lookup
-                                    .commit_switch(
-                                        region.clone(),
-                                        selected_region,
-                                        selected_addr,
-                                        cached_improvement,
-                                    )
-                                {
-                                    log::info!(
-                                        "Auto-routing: SWITCHING relay {} -> {} (addr: {}) [cached latency, pre-probe]",
-                                        old_region,
-                                        new_region,
-                                        new_addr
-                                    );
-                                    relay_for_lookup.switch_relay(new_addr);
-                                    state_for_lookup.send_if_modified(|state| {
-                                        if let ConnectionState::Connected {
-                                            ref mut server_region,
-                                            ref mut server_endpoint,
-                                            ..
-                                        } = *state
-                                        {
-                                            *server_region = new_region.clone();
-                                            *server_endpoint = new_addr.to_string();
-                                            true
-                                        } else {
-                                            false
-                                        }
-                                    });
-                                    if let Err(e) =
-                                        relay_for_lookup.send_keepalive_burst_async().await
+                                if router_for_lookup.current_relay().is_some_and(|current| {
+                                    current.0 == selected_region && current.1 == selected_addr
+                                }) {
+                                    if router_for_lookup
+                                        .accept_lookup_without_switch(lookup, region.clone())
                                     {
-                                        log::warn!(
-                                            "Auto-routing: Failed to send keepalive burst to new relay: {}",
-                                            e
+                                        log::info!(
+                                            "Auto-routing: Already on selected relay {} for {}",
+                                            selected_region,
+                                            location
                                         );
+                                        router_for_lookup.clear_pending_lookup(ip);
+                                        true
+                                    } else {
+                                        router_for_lookup.release_ignored_lookup(ip);
+                                        continue;
                                     }
-                                    log::info!(
-                                        "Auto-routing: Relay addr is now {}",
-                                        relay_for_lookup.relay_addr()
-                                    );
-                                    crate::notification::show_relay_switch(
-                                        &old_region,
-                                        &new_region,
-                                        &location,
-                                    );
+                                } else {
+                                    // Compute cached latency delta so same-region upgrades are not
+                                    // silently rejected by the rate-limiter in commit_switch.
+                                    let cached_improvement =
+                                        router_for_lookup.current_relay().and_then(|current| {
+                                            let servers =
+                                                router_for_lookup.available_servers_snapshot();
+                                            compute_cached_latency_improvement(
+                                                &servers,
+                                                selected_addr,
+                                                current.1,
+                                            )
+                                        });
+
+                                    let relay_auth_needed = relay_auth_required_for_lookup
+                                        && relay_for_lookup.relay_addr() != selected_addr;
+                                    if relay_auth_needed {
+                                        let _auth_guard = relay_auth_lock_for_lookup.lock().await;
+                                        if !router_for_lookup
+                                            .is_current_lookup_session(session_epoch)
+                                            || !router_for_lookup
+                                                .is_current_lookup_generation(generation)
+                                            || !router_for_lookup
+                                                .should_process_lookup_result(lookup)
+                                        {
+                                            router_for_lookup.release_ignored_lookup(ip);
+                                            continue;
+                                        }
+
+                                        match authenticate_auto_routing_relay_switch(
+                                            &access_token_for_lookup,
+                                            &relay_for_lookup,
+                                            &selected_region,
+                                            selected_addr,
+                                        )
+                                        .await
+                                        {
+                                            RuntimeRelayAuthResult::Authenticated => {}
+                                            RuntimeRelayAuthResult::RetryableFailure => {
+                                                router_for_lookup.release_failed_lookup(ip);
+                                                continue;
+                                            }
+                                            RuntimeRelayAuthResult::Fatal(error_message) => {
+                                                router_for_lookup.release_failed_lookup(ip);
+                                                *runtime_auth_fatal_for_lookup.lock() =
+                                                    Some(error_message);
+                                                relay_for_lookup.stop();
+                                                continue;
+                                            }
+                                        }
+                                    }
+
+                                    if let Some((new_addr, new_region)) = router_for_lookup
+                                        .commit_switch_for_lookup(
+                                            lookup,
+                                            region.clone(),
+                                            selected_region,
+                                            selected_addr,
+                                            cached_improvement,
+                                        )
+                                    {
+                                        log::info!(
+                                            "Auto-routing: SWITCHING relay {} -> {} (addr: {}) [cached latency, pre-probe]",
+                                            old_region,
+                                            new_region,
+                                            new_addr
+                                        );
+                                        if relay_for_lookup.relay_addr() != new_addr {
+                                            relay_for_lookup.switch_relay(new_addr);
+                                        }
+                                        state_for_lookup.send_if_modified(|state| {
+                                            if let ConnectionState::Connected {
+                                                ref mut server_region,
+                                                ref mut server_endpoint,
+                                                ..
+                                            } = *state
+                                            {
+                                                *server_region = new_region.clone();
+                                                *server_endpoint = new_addr.to_string();
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        });
+                                        if let Err(e) =
+                                            relay_for_lookup.send_keepalive_burst_async().await
+                                        {
+                                            log::warn!(
+                                                "Auto-routing: Failed to send keepalive burst to new relay: {}",
+                                                e
+                                            );
+                                        }
+                                        log::info!(
+                                            "Auto-routing: Relay addr is now {}",
+                                            relay_for_lookup.relay_addr()
+                                        );
+                                        crate::notification::show_relay_switch(
+                                            &old_region,
+                                            &new_region,
+                                            &location,
+                                        );
+                                        router_for_lookup.clear_pending_lookup(ip);
+                                        true
+                                    } else {
+                                        log::info!(
+                                            "Auto-routing: Lookup for {} resolved but switch was rejected/rate-limited; leaving retryable after cooldown",
+                                            ip
+                                        );
+                                        router_for_lookup.release_switch_rejected_lookup(ip);
+                                        continue;
+                                    }
                                 }
-                                true
-                            } else {
+                            } else if router_for_lookup.can_accept_lookup_without_switch(&region)
+                                && router_for_lookup
+                                    .accept_lookup_without_switch(lookup, region.clone())
+                            {
                                 log::info!(
-                                    "Auto-routing: No switch needed (already on best region for {})",
+                                    "Auto-routing: No switch needed (already on best region or bypassing for {})",
                                     location
                                 );
+                                router_for_lookup.clear_pending_lookup(ip);
                                 false
+                            } else {
+                                router_for_lookup.release_failed_lookup(ip);
+                                continue;
                             };
 
-                            // Step 2: Release held packets NOW — relay is set to best-known server
-                            // via cached latency. Don't wait for probing.
-                            router_for_lookup.clear_pending_lookup(ip);
-
-                            // Step 3: Deferred probe refinement — packets are already flowing,
-                            // probe candidates in the background and switch if a better one is found.
-                            // Skip when Step 1 returned None (bypass/whitelisted) to avoid
-                            // unexpected relay switches during VPN bypass.
-                            if step1_switched {
+                            // Step 2: Deferred probe refinement — packets are already flowing,
+                            // so probe candidates in a separate task. The lookup receiver must
+                            // stay free to resolve later handoff IPs; otherwise pending packet
+                            // holds can queue behind slow ICMP probing.
+                            if run_probe_refinement {
                                 if let Some(target_region) = region.best_swifttunnel_region() {
                                     let forced_server =
                                         router_for_lookup.forced_server_for_region(target_region);
                                     let available_servers =
                                         router_for_lookup.available_servers_snapshot();
+                                    let router_for_probe = Arc::clone(&router_for_lookup);
+                                    let relay_for_probe = Arc::clone(&relay_for_lookup);
+                                    let state_for_probe = Arc::clone(&state_for_lookup);
+                                    let runtime_auth_fatal_for_probe =
+                                        Arc::clone(&runtime_auth_fatal_for_lookup);
+                                    let relay_auth_lock_for_probe =
+                                        Arc::clone(&relay_auth_lock_for_lookup);
+                                    let access_token_for_probe = access_token_for_lookup.clone();
+                                    let relay_auth_required_for_probe =
+                                        relay_auth_required_for_lookup;
+                                    let region_for_probe = region.clone();
+                                    let location_for_probe = location.clone();
+                                    let target_region = target_region.to_string();
 
-                                    // Always probe in the deferred phase to detect degraded servers,
-                                    // even when all candidates have cached latency from Step 1.
-                                    let ranked_candidates = ranked_relay_candidates_for_region(
-                                        target_region,
-                                        &available_servers,
-                                        forced_server.as_deref(),
-                                        true,
-                                    )
-                                    .await;
+                                    tokio::spawn(async move {
+                                        let ranked_candidates = ranked_relay_candidates_for_region(
+                                            &target_region,
+                                            &available_servers,
+                                            forced_server.as_deref(),
+                                            true,
+                                        )
+                                        .await;
 
-                                    if !router_for_lookup.is_current_lookup_session(session_epoch)
-                                        || !router_for_lookup.is_active_game_server(ip)
-                                    {
-                                        log::info!(
-                                            "Auto-routing: Ignoring probe refinement for {} (generation {}) because it is stale or no longer active",
-                                            ip,
-                                            generation
-                                        );
-                                        continue;
-                                    }
-
-                                    if let Some(best_candidate) = ranked_candidates.first() {
-                                        if let Some(current_relay) =
-                                            router_for_lookup.current_relay()
+                                        if !router_for_probe
+                                            .is_current_lookup_session(session_epoch)
+                                            || !router_for_probe
+                                                .is_current_lookup_generation(generation)
+                                            || !router_for_probe.is_active_game_server(ip)
                                         {
-                                            if best_candidate.region != current_relay.0
-                                                || best_candidate.addr != current_relay.1
+                                            log::info!(
+                                                "Auto-routing: Ignoring probe refinement for {} (generation {}) because it is stale or no longer active",
+                                                ip,
+                                                generation
+                                            );
+                                            return;
+                                        }
+
+                                        if let Some(best_candidate) = ranked_candidates.first() {
+                                            if let Some(current_relay) =
+                                                router_for_probe.current_relay()
                                             {
-                                                let latency_improvement_ms =
-                                                    compute_latency_improvement(
-                                                        &ranked_candidates,
-                                                        &current_relay,
-                                                    );
-                                                if let Some((new_addr, new_region)) =
-                                                    router_for_lookup.commit_switch(
-                                                        region,
-                                                        best_candidate.region.clone(),
-                                                        best_candidate.addr,
-                                                        latency_improvement_ms,
-                                                    )
+                                                if best_candidate.region != current_relay.0
+                                                    || best_candidate.addr != current_relay.1
                                                 {
-                                                    log::info!(
-                                                        "Auto-routing: Probe refinement {} -> {} ({}ms improvement)",
-                                                        current_relay.0,
-                                                        new_region,
-                                                        latency_improvement_ms.unwrap_or(0)
-                                                    );
-                                                    relay_for_lookup.switch_relay(new_addr);
-                                                    state_for_lookup.send_if_modified(|state| {
-                                                        if let ConnectionState::Connected {
-                                                            ref mut server_region,
-                                                            ref mut server_endpoint,
-                                                            ..
-                                                        } = *state
+                                                    let latency_improvement_ms =
+                                                        compute_latency_improvement(
+                                                            &ranked_candidates,
+                                                            &current_relay,
+                                                        );
+                                                    let relay_auth_needed =
+                                                        relay_auth_required_for_probe
+                                                            && relay_for_probe.relay_addr()
+                                                                != best_candidate.addr;
+                                                    if relay_auth_needed {
+                                                        let _auth_guard =
+                                                            relay_auth_lock_for_probe.lock().await;
+                                                        if !router_for_probe
+                                                            .is_current_lookup_session(
+                                                                session_epoch,
+                                                            )
+                                                            || !router_for_probe
+                                                                .is_current_lookup_generation(
+                                                                    generation,
+                                                                )
+                                                            || !router_for_probe
+                                                                .is_active_game_server(ip)
                                                         {
-                                                            *server_region = new_region.clone();
-                                                            *server_endpoint = new_addr.to_string();
-                                                            true
-                                                        } else {
-                                                            false
+                                                            return;
                                                         }
-                                                    });
-                                                    if let Err(e) = relay_for_lookup
-                                                        .send_keepalive_burst_async()
+
+                                                        match authenticate_auto_routing_relay_switch(
+                                                            &access_token_for_probe,
+                                                            &relay_for_probe,
+                                                            &best_candidate.region,
+                                                            best_candidate.addr,
+                                                        )
                                                         .await
+                                                        {
+                                                            RuntimeRelayAuthResult::Authenticated => {}
+                                                            RuntimeRelayAuthResult::RetryableFailure => return,
+                                                            RuntimeRelayAuthResult::Fatal(error_message) => {
+                                                                *runtime_auth_fatal_for_probe.lock() =
+                                                                    Some(error_message);
+                                                                relay_for_probe.stop();
+                                                                return;
+                                                            }
+                                                        }
+                                                    }
+
+                                                    if let Some((new_addr, new_region)) =
+                                                        router_for_probe.commit_switch_for_lookup(
+                                                            lookup,
+                                                            region_for_probe,
+                                                            best_candidate.region.clone(),
+                                                            best_candidate.addr,
+                                                            latency_improvement_ms,
+                                                        )
                                                     {
-                                                        log::warn!(
-                                                            "Auto-routing: Failed to send keepalive burst after probe refinement: {}",
-                                                            e
+                                                        log::info!(
+                                                            "Auto-routing: Probe refinement {} -> {} ({}ms improvement)",
+                                                            current_relay.0,
+                                                            new_region,
+                                                            latency_improvement_ms.unwrap_or(0)
+                                                        );
+                                                        if relay_for_probe.relay_addr() != new_addr
+                                                        {
+                                                            relay_for_probe.switch_relay(new_addr);
+                                                        }
+                                                        state_for_probe.send_if_modified(|state| {
+                                                            if let ConnectionState::Connected {
+                                                                ref mut server_region,
+                                                                ref mut server_endpoint,
+                                                                ..
+                                                            } = *state
+                                                            {
+                                                                *server_region = new_region.clone();
+                                                                *server_endpoint =
+                                                                    new_addr.to_string();
+                                                                true
+                                                            } else {
+                                                                false
+                                                            }
+                                                        });
+                                                        if let Err(e) = relay_for_probe
+                                                            .send_keepalive_burst_async()
+                                                            .await
+                                                        {
+                                                            log::warn!(
+                                                                "Auto-routing: Failed to send keepalive burst after probe refinement: {}",
+                                                                e
+                                                            );
+                                                        }
+                                                        crate::notification::show_relay_switch(
+                                                            &current_relay.0,
+                                                            &new_region,
+                                                            &location_for_probe,
                                                         );
                                                     }
-                                                    crate::notification::show_relay_switch(
-                                                        &current_relay.0,
-                                                        &new_region,
-                                                        &location,
-                                                    );
                                                 }
                                             }
                                         }
-                                    }
+                                    });
                                 }
                             }
                         }
@@ -1836,8 +2194,9 @@ impl VpnConnection {
                                 ip
                             );
                             // Release packets even on failure — better to route through
-                            // wrong relay than hold packets forever
-                            router_for_lookup.clear_pending_lookup(ip);
+                            // wrong relay than hold packets forever. Keep the IP retryable
+                            // because resolver/API failures are often transient.
+                            router_for_lookup.release_failed_lookup(ip);
                         }
                     }
                 }
@@ -1973,6 +2332,7 @@ impl VpnConnection {
         let process_performance_for_monitor = self.process_performance_manager.clone();
         let relay_health_monitor = relay_for_health;
         let workers_panic_cause_monitor = workers_panic_cause_for_monitor;
+        let runtime_auth_fatal_for_monitor = runtime_auth_fatal_error;
 
         tokio::spawn(async move {
             log::info!("V3: Process monitor started");
@@ -2153,6 +2513,42 @@ impl VpnConnection {
                         // packet through this NIC, which overrides any NLM
                         // false-positive (captive portals, virtual adapters,
                         // hidden-SSID corp networks). See `watchdog_tick`.
+                        let runtime_auth_error = runtime_auth_fatal_for_monitor.lock().take();
+                        if let Some(error_message) = runtime_auth_error {
+                            let transitioned = state_handle.send_if_modified(|state| {
+                                if matches!(*state, ConnectionState::Connected { .. }) {
+                                    log::error!(
+                                        "V3: runtime relay auth fatal error — transitioning Connected → Error"
+                                    );
+                                    *state = ConnectionState::Error(error_message.clone());
+                                    true
+                                } else {
+                                    false
+                                }
+                            });
+
+                            if transitioned {
+                                {
+                                    let mut driver_guard = driver.lock().await;
+                                    if let Err(e) = driver_guard.close() {
+                                        log::warn!(
+                                            "V3: runtime relay auth cleanup — driver.close() returned {}",
+                                            e
+                                        );
+                                    }
+                                }
+                                super::wfp_block::cleanup();
+                                if let Some(ref auto_router) = auto_router_for_monitor {
+                                    auto_router.reset();
+                                }
+                                if let Some(ref manager) = process_performance_for_monitor {
+                                    let mut guard = manager.lock().await;
+                                    guard.cleanup_all("runtime_relay_auth_failure");
+                                }
+                                break;
+                            }
+                        }
+
                         if watchdog_armed {
                             let probe = super::local_connectivity::probe();
                             let relay_health_now = relay_health_monitor.relay_health();
@@ -3984,7 +4380,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_candidate_after_preflight_all_unknown_policy_allows_marked_fallback() {
+    fn test_select_candidate_after_preflight_all_unknown_policy_rejects_fallback() {
         let attempts = vec![RelayCandidateAttempt {
             region: "germany-01".to_string(),
             addr: parse_addr("10.0.0.1:51821"),
@@ -3995,16 +4391,9 @@ mod tests {
             queue_full_mode: RelayQueueFullMode::Bypass,
         }];
 
-        let selected = select_candidate_after_preflight(&attempts)
-            .expect("unknown policy alone should not block legacy fallback");
-        assert_eq!(
-            selected,
-            (
-                "germany-01".to_string(),
-                parse_addr("10.0.0.1:51821"),
-                RelayQueueFullMode::Bypass
-            )
-        );
+        let error = select_candidate_after_preflight(&attempts)
+            .expect_err("unknown policy must fail closed instead of entering legacy fallback");
+        assert_eq!(error, CONNECT_FAIL_POLICY_UNAVAILABLE);
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -4752,6 +4752,10 @@ fn forward_tunneled_packet_from_reader(
         relay.relay_health(),
         super::udp_relay::RelayHealthState::Dead
     ) {
+        if auto_routing_must_not_bypass_physical(data, auto_router) {
+            return ReaderTunnelAction::Consumed;
+        }
+
         let event = READER_DIRECT_RELAY_BYPASS.fetch_add(1, Ordering::Relaxed) + 1;
         if event <= 5 || event.is_power_of_two() {
             log::warn!(
@@ -4798,6 +4802,9 @@ fn forward_tunneled_packet_from_reader(
                 );
             }
             if queue_overflow_action(queue_overflow_mode, data) == QueueFullAction::Bypass {
+                if auto_routing_must_not_bypass_physical(data, auto_router) {
+                    return ReaderTunnelAction::Consumed;
+                }
                 return ReaderTunnelAction::BypassPhysical;
             }
         }
@@ -5240,18 +5247,23 @@ fn run_packet_reader(
                         api_tunneling,
                     );
 
-                    // Auto-routing whitelist bypass: if bypass is active, tunnel-eligible packets
-                    // should be passed through to the physical adapter instead.
-                    let auto_routing_bypass =
-                        should_tunnel && auto_router.as_ref().map_or(false, |r| r.is_bypassed());
-
                     if auto_routing_packet_action(data, auto_router.as_ref(), should_tunnel)
                         == AutoRoutingPacketAction::Hold
                     {
                         continue;
                     }
 
+                    // Auto-routing whitelist bypass: compute this after candidate
+                    // evaluation because a fresh unclassified handoff can clear bypass
+                    // to fail closed through SwiftTunnel instead of leaking direct.
+                    let auto_routing_bypass = should_tunnel
+                        && auto_router.as_ref().map_or(false, |r| r.is_bypassed())
+                        && !auto_routing_must_not_bypass_physical(data, auto_router.as_ref());
+
                     if !should_tunnel || auto_routing_bypass {
+                        if auto_routing_must_not_bypass_physical(data, auto_router.as_ref()) {
+                            continue;
+                        }
                         // Batch passthrough (much cheaper than per-packet bypass reinjection).
                         let _ = passthrough_to_adapter.push(&packets[i]);
 
@@ -5312,8 +5324,9 @@ fn run_packet_reader(
                             QueueOverflowMode::from_u8(queue_overflow_mode.load(Ordering::Relaxed));
                         match queue_overflow_action(mode, data) {
                             QueueFullAction::Bypass => {
-                                if auto_routing_packet_action(data, auto_router.as_ref(), false)
-                                    == AutoRoutingPacketAction::Hold
+                                if auto_routing_must_not_bypass_physical(data, auto_router.as_ref())
+                                    || auto_routing_packet_action(data, auto_router.as_ref(), false)
+                                        == AutoRoutingPacketAction::Hold
                                 {
                                     let event =
                                         queue_full_events.fetch_add(1, Ordering::Relaxed) + 1;
@@ -5496,17 +5509,18 @@ fn run_packet_worker(
                 );
             }
 
-            // Auto-routing whitelist bypass: if the current game region is whitelisted,
-            // game packets that would normally be tunneled are passed through to the
-            // real adapter instead. Lock-free AtomicBool check (<1ns overhead).
-            let auto_routing_bypass =
-                should_tunnel && auto_router.as_ref().map_or(false, |r| r.is_bypassed());
-
             if auto_routing_packet_action(&work.data, auto_router.as_ref(), should_tunnel)
                 == AutoRoutingPacketAction::Hold
             {
                 continue;
             }
+
+            // Auto-routing whitelist bypass: compute this after candidate evaluation
+            // because a fresh unclassified handoff can clear bypass to fail closed
+            // through SwiftTunnel instead of leaking direct.
+            let auto_routing_bypass = should_tunnel
+                && auto_router.as_ref().map_or(false, |r| r.is_bypassed())
+                && !auto_routing_must_not_bypass_physical(&work.data, auto_router.as_ref());
 
             if should_tunnel && !auto_routing_bypass {
                 stats.packets_tunneled.fetch_add(1, Ordering::Relaxed);
@@ -5641,7 +5655,12 @@ fn run_packet_worker(
                             if queue_overflow_action(mode, work.data.as_slice())
                                 == QueueFullAction::Bypass
                             {
-                                send_bypass_packet(&driver, &adapters, &work);
+                                if !auto_routing_must_not_bypass_physical(
+                                    work.data.as_slice(),
+                                    auto_router.as_ref(),
+                                ) {
+                                    send_bypass_packet(&driver, &adapters, &work);
+                                }
                             } else if relay_fail <= 10 || relay_fail % 100 == 0 {
                                 log::warn!(
                                     "Worker {}: V3 relay sender backpressure, dropping tunnel packet ({} total)",
@@ -5688,14 +5707,26 @@ fn run_packet_worker(
                 } else {
                     // Either no relay context, or the relay is marked Dead —
                     // forward to the physical adapter (bypass) so the game
-                    // isn't silently drop-forwarded to nowhere.
-                    send_bypass_packet(&driver, &adapters, &work);
+                    // isn't silently drop-forwarded to nowhere. Auto-routing
+                    // fail-closed candidates are the exception: they must not
+                    // leak direct while their region/auth state is unresolved.
+                    if !auto_routing_must_not_bypass_physical(
+                        work.data.as_slice(),
+                        auto_router.as_ref(),
+                    ) {
+                        send_bypass_packet(&driver, &adapters, &work);
+                    }
                 }
             } else {
                 stats.packets_bypassed.fetch_add(1, Ordering::Relaxed);
                 stats
                     .bytes_bypassed
                     .fetch_add(packet_len, Ordering::Relaxed);
+
+                if auto_routing_must_not_bypass_physical(work.data.as_slice(), auto_router.as_ref())
+                {
+                    continue;
+                }
 
                 // CRITICAL FIX: Forward bypass packets to adapter
                 // Previously this was missing, causing all non-tunnel traffic to be dropped!
@@ -6619,6 +6650,19 @@ fn auto_routing_candidate_dst_ip(data: &[u8]) -> Option<Ipv4Addr> {
 /// packet to the destination, which catches fragments and queue-overflow races without
 /// starting lookups for unrelated traffic.
 #[inline(always)]
+fn auto_routing_must_not_bypass_physical(
+    data: &[u8],
+    auto_router: Option<&Arc<super::auto_routing::AutoRouter>>,
+) -> bool {
+    let Some(auto_router) = auto_router else {
+        return false;
+    };
+    let Some(dst_ip) = parse_ipv4_dst_ip(data) else {
+        return false;
+    };
+    is_roblox_game_server_ip(dst_ip) && auto_router.must_not_bypass_physical(dst_ip)
+}
+
 fn auto_routing_packet_action(
     data: &[u8],
     auto_router: Option<&Arc<super::auto_routing::AutoRouter>>,
@@ -9974,10 +10018,98 @@ mod tests {
             AutoRoutingPacketAction::Hold
         );
         assert!(router.is_lookup_pending(dst_ip));
-        let (queued_ip, generation, _session_epoch) =
-            rx.try_recv().expect("lookup should be queued");
-        assert_eq!(queued_ip, dst_ip);
-        assert_eq!(generation, 1);
+        let lookup = rx.try_recv().expect("lookup should be queued");
+        assert_eq!(lookup.ip, dst_ip);
+        assert_eq!(lookup.generation, 1);
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_suppresses_fresh_candidate_then_holds_stale_handoff() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+
+        let src_ip = Ipv4Addr::new(192, 168, 1, 210);
+        let active_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let next_ip = Ipv4Addr::new(128, 116, 55, 100);
+        let active_frame = build_ipv4_frame(17, src_ip, active_ip, 53020, 54020);
+        let next_frame = build_ipv4_frame(17, src_ip, next_ip, 53021, 54021);
+
+        assert_eq!(
+            auto_routing_packet_action(&active_frame, Some(&router), true),
+            AutoRoutingPacketAction::Hold
+        );
+        let _ = rx.try_recv().expect("active lookup should be queued");
+        assert!(router.pin_active_game_server(active_ip));
+        router.clear_pending_lookup(active_ip);
+
+        assert_eq!(
+            auto_routing_packet_action(&next_frame, Some(&router), true),
+            AutoRoutingPacketAction::Pass,
+            "fresh active server should suppress route churn without holding packets"
+        );
+        assert!(rx.try_recv().is_err());
+        assert!(!router.is_lookup_pending(next_ip));
+
+        std::thread::sleep(Duration::from_millis(20));
+
+        assert_eq!(
+            auto_routing_packet_action(&next_frame, Some(&router), true),
+            AutoRoutingPacketAction::Hold,
+            "stale active server should allow a real handoff and hold first packets"
+        );
+        let lookup = rx.try_recv().expect("handoff lookup should be queued");
+        assert_eq!(lookup.ip, next_ip);
+        assert!(router.is_lookup_pending(next_ip));
+    }
+
+    #[test]
+    fn test_auto_routing_packet_action_clears_bypass_for_fresh_unclassified_handoff() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let router = Arc::new(crate::vpn::auto_routing::AutoRouter::new(true, "singapore"));
+        router.set_lookup_channel(tx);
+        router.set_current_relay("54.255.205.216:51821".parse().unwrap(), "singapore");
+        router.set_available_servers(vec![
+            (
+                "singapore".to_string(),
+                "54.255.205.216:51821".parse().unwrap(),
+                Some(10),
+            ),
+            (
+                "us-east-nj".to_string(),
+                "198.51.100.10:51821".parse().unwrap(),
+                Some(200),
+            ),
+        ]);
+        router.set_whitelisted_regions(vec!["Singapore".to_string()]);
+        assert!(
+            router
+                .get_best_server_for_region(&crate::geolocation::RobloxRegion::Singapore)
+                .is_none()
+        );
+        assert!(router.is_bypassed());
+
+        let src_ip = Ipv4Addr::new(192, 168, 1, 210);
+        let active_ip = Ipv4Addr::new(128, 116, 50, 100);
+        let next_ip = Ipv4Addr::new(128, 116, 55, 100);
+        assert!(router.pin_active_game_server(active_ip));
+
+        let next_frame = build_ipv4_frame(17, src_ip, next_ip, 53021, 54021);
+        assert_eq!(
+            auto_routing_packet_action(&next_frame, Some(&router), true),
+            AutoRoutingPacketAction::Pass,
+            "fresh different game-server candidate should not hold packets"
+        );
+        assert!(rx.try_recv().is_err());
+        assert!(!router.is_lookup_pending(next_ip));
+        assert!(
+            !router.is_bypassed(),
+            "bypass must fail closed until the handoff candidate is classified"
+        );
+        assert!(
+            router.must_not_bypass_physical(next_ip),
+            "unclassified handoff candidates must not use physical bypass under relay backpressure"
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/udp_relay.rs
+++ b/swifttunnel-core/src/vpn/udp_relay.rs
@@ -36,6 +36,7 @@ const PONG_FRAME_LEN: usize = SESSION_ID_LEN + 1 + 4 + 8 + 8;
 const AUTH_HANDSHAKE_TOTAL_TIMEOUT: Duration = Duration::from_millis(1500);
 const AUTH_HANDSHAKE_RETRY_DELAY: Duration = Duration::from_millis(250);
 const AUTH_HANDSHAKE_ATTEMPTS: usize = 4;
+const AUTH_ACK_INBOX_CAPACITY: usize = 16;
 
 /// Outer path MTU for relay packets (client <-> relay).
 ///
@@ -316,6 +317,7 @@ pub enum RelayAuthAckStatus {
     SidMismatch = 4,
     ServerMismatch = 5,
     AuthDisabled = 6,
+    Replay = 7,
 }
 
 impl RelayAuthAckStatus {
@@ -328,6 +330,7 @@ impl RelayAuthAckStatus {
             4 => Some(Self::SidMismatch),
             5 => Some(Self::ServerMismatch),
             6 => Some(Self::AuthDisabled),
+            7 => Some(Self::Replay),
             _ => None,
         }
     }
@@ -341,6 +344,7 @@ impl RelayAuthAckStatus {
             Self::SidMismatch => "sid_mismatch",
             Self::ServerMismatch => "server_mismatch",
             Self::AuthDisabled => "auth_disabled",
+            Self::Replay => "replay",
         }
     }
 }
@@ -551,6 +555,17 @@ pub struct UdpRelay {
     outbound_pool: Arc<OutboundPool>,
     outbound_tx: channel::Sender<OutboundJob>,
     ping: Arc<PingMetrics>,
+    /// Auth ACKs observed by the inbound receiver thread.
+    ///
+    /// Initial connect authenticates before the inbound receiver starts and can read
+    /// the socket directly. Runtime auto-route switches authenticate while that
+    /// receiver owns the socket, so control ACKs are captured here instead of
+    /// being swallowed as non-packet frames.
+    auth_ack_inbox: parking_lot::Mutex<VecDeque<(SocketAddr, RelayAuthAckStatus)>>,
+    /// Candidate relay currently allowed to send auth ACKs before becoming the
+    /// data-path relay. Runtime auto-route auth uses this so data packets are
+    /// not sent to an unauthenticated relay while the handshake is still pending.
+    pending_auth_relay_addr: parking_lot::Mutex<Option<SocketAddr>>,
     /// Relay health state — shared with connection manager for silent disconnect detection.
     relay_health: Arc<AtomicU8>,
     /// Consecutive keepalives sent without receiving any inbound traffic.
@@ -882,6 +897,10 @@ impl UdpRelay {
             outbound_pool,
             outbound_tx,
             ping,
+            auth_ack_inbox: parking_lot::Mutex::new(VecDeque::with_capacity(
+                AUTH_ACK_INBOX_CAPACITY,
+            )),
+            pending_auth_relay_addr: parking_lot::Mutex::new(None),
             relay_health,
             unanswered_keepalives: AtomicU32::new(0),
             inject_error_streak: AtomicU32::new(0),
@@ -1139,9 +1158,7 @@ impl UdpRelay {
         false
     }
 
-    /// Send relay auth hello frame:
-    /// [session_id:8][0xA1][token_len:2][token_utf8].
-    pub fn send_auth_hello(&self, token: &str) -> Result<()> {
+    fn send_auth_hello_to(&self, relay_addr: SocketAddr, token: &str) -> Result<()> {
         let token_bytes = token.as_bytes();
         if token_bytes.is_empty() || token_bytes.len() > u16::MAX as usize {
             anyhow::bail!(
@@ -1156,17 +1173,92 @@ impl UdpRelay {
         frame.extend_from_slice(&(token_bytes.len() as u16).to_be_bytes());
         frame.extend_from_slice(token_bytes);
 
-        let current_addr = **self.relay_addr.load();
         self.socket
-            .send_to(&frame, current_addr)
+            .send_to(&frame, relay_addr)
             .context("Failed to send relay auth hello")?;
         log::debug!(
             "UDP Relay: Sent auth hello to {} (session {:016x}, token {} bytes)",
-            current_addr,
+            relay_addr,
             self.session_id_u64(),
             token_bytes.len()
         );
         Ok(())
+    }
+
+    /// Send relay auth hello frame:
+    /// [session_id:8][0xA1][token_len:2][token_utf8].
+    pub fn send_auth_hello(&self, token: &str) -> Result<()> {
+        let current_addr = **self.relay_addr.load();
+        self.send_auth_hello_to(current_addr, token)
+    }
+
+    fn parse_auth_ack_frame(&self, frame: &[u8], len: usize) -> Option<RelayAuthAckStatus> {
+        if len < SESSION_ID_LEN + 2 {
+            return None;
+        }
+        if frame[..SESSION_ID_LEN] != self.session_id {
+            return None;
+        }
+        if frame[SESSION_ID_LEN] != AUTH_ACK_FRAME_TYPE {
+            return None;
+        }
+
+        Some(
+            RelayAuthAckStatus::from_u8(frame[SESSION_ID_LEN + 1])
+                .unwrap_or(RelayAuthAckStatus::BadFormat),
+        )
+    }
+
+    fn queue_observed_auth_ack(&self, from: SocketAddr, status: RelayAuthAckStatus) {
+        let mut inbox = self.auth_ack_inbox.lock();
+        if inbox.len() >= AUTH_ACK_INBOX_CAPACITY {
+            inbox.pop_front();
+        }
+        inbox.push_back((from, status));
+    }
+
+    fn clear_queued_auth_acks_for(&self, relay_addr: SocketAddr) {
+        self.auth_ack_inbox
+            .lock()
+            .retain(|(from, _)| *from != relay_addr);
+    }
+
+    fn set_pending_auth_relay(&self, relay_addr: SocketAddr) {
+        *self.pending_auth_relay_addr.lock() = Some(relay_addr);
+    }
+
+    fn clear_pending_auth_relay(&self, relay_addr: SocketAddr) {
+        let mut pending = self.pending_auth_relay_addr.lock();
+        if pending.is_some_and(|addr| addr == relay_addr) {
+            *pending = None;
+        }
+    }
+
+    fn is_pending_auth_relay_source(&self, relay_addr: SocketAddr) -> bool {
+        self.pending_auth_relay_addr
+            .lock()
+            .is_some_and(|pending| pending == relay_addr)
+    }
+
+    fn take_queued_auth_ack_for(&self, relay_addr: SocketAddr) -> Option<RelayAuthAckStatus> {
+        let mut inbox = self.auth_ack_inbox.lock();
+        let pos = inbox.iter().position(|(from, _)| *from == relay_addr)?;
+        inbox.remove(pos).map(|(_, status)| status)
+    }
+
+    fn wait_for_observed_auth_ack(
+        &self,
+        relay_addr: SocketAddr,
+        timeout: Duration,
+    ) -> Option<RelayAuthAckStatus> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if let Some(status) = self.take_queued_auth_ack_for(relay_addr) {
+                return Some(status);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        None
     }
 
     fn wait_for_auth_ack_with_timeout(
@@ -1183,19 +1275,9 @@ impl UdpRelay {
                         continue;
                     }
 
-                    if len < SESSION_ID_LEN + 2 {
+                    let Some(status) = self.parse_auth_ack_frame(&recv_buf, len) else {
                         continue;
-                    }
-                    if recv_buf[..SESSION_ID_LEN] != self.session_id {
-                        continue;
-                    }
-                    if recv_buf[SESSION_ID_LEN] != AUTH_ACK_FRAME_TYPE {
-                        continue;
-                    }
-
-                    let status_byte = recv_buf[SESSION_ID_LEN + 1];
-                    let status = RelayAuthAckStatus::from_u8(status_byte)
-                        .unwrap_or(RelayAuthAckStatus::BadFormat);
+                    };
                     return Ok(Some(status));
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
@@ -1236,6 +1318,44 @@ impl UdpRelay {
         }
 
         Ok(None)
+    }
+
+    /// Authenticate a candidate relay while the inbound receiver owns socket reads.
+    ///
+    /// Runtime auto-route switches cannot call `recv_from` directly because the
+    /// inbound injector thread is already reading the UDP socket. Instead, the
+    /// receiver records auth ACK control frames in `auth_ack_inbox`, and this
+    /// method waits for one from the candidate relay without making it the live
+    /// data-path relay first.
+    pub fn authenticate_relay_addr_with_observed_ack(
+        &self,
+        relay_addr: SocketAddr,
+        token: &str,
+    ) -> Result<Option<RelayAuthAckStatus>> {
+        self.clear_queued_auth_acks_for(relay_addr);
+        self.set_pending_auth_relay(relay_addr);
+        let deadline = Instant::now() + AUTH_HANDSHAKE_TOTAL_TIMEOUT;
+        let mut result = Ok(None);
+
+        if let Err(e) = self.send_auth_hello_to(relay_addr, token) {
+            result = Err(e);
+        } else {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if !remaining.is_zero() {
+                if let Some(status) = self.wait_for_observed_auth_ack(relay_addr, remaining) {
+                    log::info!(
+                        "UDP Relay: Observed auth ack {} from {} for session {:016x}",
+                        status.as_str(),
+                        relay_addr,
+                        self.session_id_u64()
+                    );
+                    result = Ok(Some(status));
+                }
+            }
+        }
+
+        self.clear_pending_auth_relay(relay_addr);
+        result
     }
 
     /// Get the stop flag for external control
@@ -1357,8 +1477,17 @@ impl UdpRelay {
     ) -> Result<Option<&'a [u8]>> {
         match self.socket.recv_from(frame_buffer) {
             Ok((len, from)) => {
-                // Verify it's from our relay server (current or previous during grace period)
+                // Verify it's from our relay server (current or previous during grace period).
+                // A pending runtime auth candidate may send an AUTH_ACK before it becomes
+                // the data-path relay; queue that control frame without accepting data
+                // packets from the candidate yet.
                 if !self.is_expected_relay_source(from) {
+                    if self.is_pending_auth_relay_source(from) {
+                        if let Some(status) = self.parse_auth_ack_frame(frame_buffer, len) {
+                            self.queue_observed_auth_ack(from, status);
+                            return Ok(None);
+                        }
+                    }
                     log::warn!("UDP Relay: Received packet from unexpected source {}", from);
                     return Ok(None);
                 }
@@ -1381,7 +1510,13 @@ impl UdpRelay {
                 // Control frames (auth + ping telemetry) should never reach packet injection.
                 if payload_len >= 1 {
                     match frame_buffer[SESSION_ID_LEN] {
-                        AUTH_HELLO_FRAME_TYPE | AUTH_ACK_FRAME_TYPE | PING_FRAME_TYPE => {
+                        AUTH_ACK_FRAME_TYPE => {
+                            if let Some(status) = self.parse_auth_ack_frame(frame_buffer, len) {
+                                self.queue_observed_auth_ack(from, status);
+                            }
+                            return Ok(None);
+                        }
+                        AUTH_HELLO_FRAME_TYPE | PING_FRAME_TYPE => {
                             return Ok(None);
                         }
                         PONG_FRAME_TYPE => {
@@ -2021,6 +2156,15 @@ mod tests {
     }
 
     #[test]
+    fn test_replay_auth_ack_status_is_recognized() {
+        assert_eq!(
+            RelayAuthAckStatus::from_u8(7),
+            Some(RelayAuthAckStatus::Replay)
+        );
+        assert_eq!(RelayAuthAckStatus::Replay.as_str(), "replay");
+    }
+
+    #[test]
     fn test_session_id_generation() {
         let mut id1 = [0u8; 8];
         let mut id2 = [0u8; 8];
@@ -2395,6 +2539,31 @@ mod tests {
 
         let snap = relay.ping_snapshot();
         assert!(snap.received >= 1);
+    }
+
+    #[test]
+    fn test_pending_auth_ack_is_queued_without_switching_data_path() {
+        let relay = UdpRelay::new("127.0.0.1:51821".parse().unwrap()).unwrap();
+        let candidate_relay = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let local_addr = relay_loopback_addr(&relay);
+        let candidate_addr = candidate_relay.local_addr().unwrap();
+        relay.set_pending_auth_relay(candidate_addr);
+
+        let mut frame = [0u8; SESSION_ID_LEN + 2];
+        frame[..SESSION_ID_LEN].copy_from_slice(relay.session_id_bytes());
+        frame[SESSION_ID_LEN] = AUTH_ACK_FRAME_TYPE;
+        frame[SESSION_ID_LEN + 1] = RelayAuthAckStatus::Ok as u8;
+
+        candidate_relay.send_to(&frame, local_addr).unwrap();
+
+        let mut buffer = [0u8; 1600];
+        let result = relay.receive_inbound_payload(&mut buffer).unwrap();
+        assert!(result.is_none());
+        assert_ne!(relay.relay_addr(), candidate_addr);
+        assert_eq!(
+            relay.take_queued_auth_ack_for(candidate_addr),
+            Some(RelayAuthAckStatus::Ok)
+        );
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -6,7 +6,7 @@ use tauri::{AppHandle, Emitter, State};
 
 use crate::events::{SERVER_LIST_UPDATED, VPN_STATE_CHANGED, VpnStateEvent};
 use crate::state::AppState;
-use swifttunnel_core::auth::types::AuthError;
+use swifttunnel_core::auth::types::{AuthError, AuthState};
 use swifttunnel_core::settings::AdapterBindingMode;
 use swifttunnel_core::vpn::{
     AdapterBindingPreference, BindingPreferenceSource, BindingPreflightInfo, VpnError,
@@ -409,6 +409,15 @@ pub async fn vpn_connect(
         settings_snapshot.game_process_performance,
         settings_snapshot.enable_api_tunneling,
     );
+    if custom_relay.is_some() {
+        let is_tester = {
+            let auth = state.auth_manager.lock().await;
+            matches!(auth.get_state(), AuthState::LoggedIn(session) if session.user.is_tester)
+        };
+        if !is_tester {
+            return Err("Custom relay servers are only available to tester accounts".to_string());
+        }
+    }
     if custom_relay.is_some() && auto_routing {
         log::info!("Auto-routing disabled for this session because custom_relay_server is set");
         auto_routing = false;


### PR DESCRIPTION
## Summary

Fixes Auto Route for same-session Roblox refreshes/teleports/ranked queue handoffs without letting unrelated mid-game Roblox traffic churn the relay route.

## What changed

- Replaced the single-session game-server pin with an active-server handoff state machine:
  - fresh active server traffic refreshes the pin
  - different Roblox IPs are suppressed while the active server is fresh
  - idle handoff candidates carry `observed_at`, generation, and session epoch before they can affect routing
- Keeps candidates retry-safe:
  - resolver/auth/commit failures release packet holds and enter cooldown
  - stale queued lookups are drained without starving the newest candidate
  - failed/unclassified candidates are marked fail-closed so they cannot physical-bypass under whitelist, queue-full, relay-dead, or backpressure paths
- Authenticates runtime relay switches before committing the new route:
  - inbound auth ACKs are captured by source while the receiver owns the socket
  - replay and ban responses become fatal runtime auth failures with cleanup
  - custom relay remains tester-only and now performs relay-ticket policy checks instead of relying on the UI gate
- Updated Auto Route docs in `README.md` and `V3-ROUTING.md`.

## Verification

- `cargo fmt --check` ✅
- `git diff --check` ✅
- `cargo check -p swifttunnel-core --lib --locked` blocked locally by existing dependency mismatch in `windows-future` / `windows-core` before project code compiles.
- Windows VM/testbench verification not run in this session; required before merge because this touches NDIS packet interception and desktop VPN behavior.
