### PR TITLE
fix(vpn): restore relay DSCP marking

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 
 SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic and the temporary CDN IPs resolved for those bootstrap hostnames, through the selected relay. Route Assist TCP routing is handshake-gated so SwiftTunnel can clamp relay-owned flows before large HTTPS packets are exchanged; non-Roblox browser traffic and already-established TCP connections still bypass SwiftTunnel.
 
+On Windows, the V3 relay client marks SwiftTunnel relay UDP traffic with DSCP EF (46) best-effort for lower jitter on networks that honor DSCP. When latency network throttling boost is enabled, SwiftTunnel also installs the Windows QoS policy needed for deterministic DSCP handling, scoped to SwiftTunnel's relay socket/process; the old broad Gaming QoS policies for Roblox executables and the generic Microsoft Store `Windows10Universal.exe` host stay removed.
+
 Roblox detection covers the standard Win32 player/studio executables by exact process stem or known Roblox alias only. Microsoft Store/UWP Roblox is intentionally not tunnel-eligible because it runs under the generic `Windows10Universal.exe` host used by unrelated Store apps.
 
 

--- a/V3-ROUTING.md
+++ b/V3-ROUTING.md
@@ -70,6 +70,7 @@ Inbound (Relay → Client):
    - When Auto Route is enabled, the initial region is chosen from the in-app ping-test latency cache when available.
 2. Configure split tunnel (ndisapi)
 3. Create UDP relay connection
+   - On Windows, SwiftTunnel marks the relay UDP socket with DSCP EF (46) best-effort so latency-sensitive game packets can stay in low-latency queues on networks that honor DSCP.
 4. Connected
 
 **V3 skips:**
@@ -105,6 +106,11 @@ pub struct UdpRelay {
 - `forward_outbound(payload)` - Add session ID and send to relay
 - `receive_inbound(buffer)` - Receive from relay and strip session ID
 - `send_keepalive()` - Maintain NAT binding
+
+### Relay Traffic QoS
+- The removed Gaming QoS boost must stay removed: do not restore broad Windows QoS policies for Roblox executables or `Windows10Universal.exe`.
+- The client may mark only SwiftTunnel relay UDP traffic with DSCP EF (46). It does this socket-scoped in `udp_relay.rs`; when latency network throttling boost is enabled, `network_booster.rs` also installs a process+UDP-scoped SwiftTunnel QoS policy and restores the global QoS registry values from snapshots on cleanup.
+- Relay ports are still taken from the server-list API. QoS policy matching intentionally avoids hardcoding a relay port; the actual relay socket is marked directly.
 
 ### Auto Route Selection
 - Initial Auto Route connects to the region with the best measured in-app ping-test latency when latency data exists; otherwise it falls back to the requested/last selected region.

--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -18,6 +18,17 @@ const REMOVED_QOS_POLICY_NAMES: &[&str] = &[
     "SwiftTunnel_QoS_Relay_swifttunnel-desktop",
     "SwiftTunnel_QoS_Windows10Universal",
 ];
+// Replacement for the removed Gaming QoS boost: scope DSCP marking to
+// SwiftTunnel's relay UDP traffic only. Do not reintroduce Roblox executable or
+// Windows10Universal policies; intercepted game packets leave Windows through
+// SwiftTunnel's relay UDP socket.
+const RELAY_QOS_EXECUTABLES: &[&str] = &["SwiftTunnel.exe", "swifttunnel-desktop.exe"];
+const RELAY_QOS_POLICY_PREFIX: &str = "SwiftTunnel_RelaySocketQoS_";
+// Relay ports come from the server-list API; keep the policy process+UDP scoped
+// instead of hardcoding a port here. The socket-level IP_TOS mark still applies
+// to the exact relay socket used for the session.
+const RELAY_QOS_REMOTE_PORT: &str = "*";
+const RELAY_QOS_DSCP_VALUE: &str = "46";
 const NETWORK_SYSTEM_PROFILE_KEY: &str =
     r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile";
 const REG_VALUE_TCP_ACK_FREQUENCY: &str = "TcpAckFrequency";
@@ -125,6 +136,21 @@ impl NetworkBooster {
         let mut warnings = Vec::new();
 
         Self::cleanup_removed_qos_policies();
+
+        let relay_qos_requested = Self::relay_qos_requested(&requested_config);
+        if relay_qos_requested {
+            if let Err(e) = self.enable_relay_socket_qos_policy() {
+                if let Err(cleanup_error) = self.remove_relay_socket_qos_policy() {
+                    warnings.push(format!(
+                        "Enable relay DSCP policy cleanup after failure: {}",
+                        cleanup_error
+                    ));
+                }
+                warnings.push(format!("Enable relay DSCP policy: {}", e));
+            }
+        } else if let Err(e) = self.remove_relay_socket_qos_policy() {
+            warnings.push(format!("Remove relay DSCP policy: {}", e));
+        }
 
         // Tier 1 (Safe) Network Boosts
         if requested_config.disable_nagle {
@@ -396,10 +422,7 @@ impl NetworkBooster {
 
     fn cleanup_removed_qos_policies() {
         for policy_name in REMOVED_QOS_POLICY_NAMES {
-            let policy_path = format!(
-                r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
-                policy_name
-            );
+            let policy_path = Self::qos_policy_path(policy_name);
             let _ = hidden_command("reg")
                 .args(["delete", &policy_path, "/f"])
                 .output();
@@ -408,6 +431,111 @@ impl NetworkBooster {
         if let Err(e) = Self::remove_legacy_roblox_priority_policy() {
             warn!("Removed QoS policy cleanup failed: {}", e);
         }
+    }
+
+    fn qos_policy_path(policy_name: &str) -> String {
+        format!(
+            r"HKLM\SOFTWARE\Policies\Microsoft\Windows\QoS\{}",
+            policy_name
+        )
+    }
+
+    fn relay_qos_policy_name(exe: &str) -> String {
+        format!(
+            "{}{}",
+            RELAY_QOS_POLICY_PREFIX,
+            exe.trim_end_matches(".exe")
+        )
+    }
+
+    fn cleanup_relay_socket_qos_policies() {
+        for exe in RELAY_QOS_EXECUTABLES {
+            let policy_name = Self::relay_qos_policy_name(exe);
+            let policy_path = Self::qos_policy_path(&policy_name);
+            let _ = hidden_command("reg")
+                .args(["delete", &policy_path, "/f"])
+                .output();
+        }
+    }
+
+    fn set_registry_string(key_path: &str, value_name: &str, value: &str) -> Result<()> {
+        let output = hidden_command("reg")
+            .args([
+                "add", key_path, "/v", value_name, "/t", "REG_SZ", "/d", value, "/f",
+            ])
+            .output();
+
+        match output {
+            Ok(result) if result.status.success() => Ok(()),
+            Ok(_) => Err(anyhow::anyhow!(
+                "failed to set {}\\{} to {}",
+                key_path,
+                value_name,
+                value
+            )),
+            Err(e) => Err(anyhow::anyhow!(
+                "failed to set {}\\{} to {}: {}",
+                key_path,
+                value_name,
+                value,
+                e
+            )),
+        }
+    }
+
+    fn write_relay_qos_policy(policy_name: &str, exe: &str) -> Result<()> {
+        let policy_path = Self::qos_policy_path(policy_name);
+        for (value_name, value) in [
+            ("Version", "1.0"),
+            ("Application Name", exe),
+            ("Protocol", "UDP"),
+            ("DSCP Value", RELAY_QOS_DSCP_VALUE),
+            ("Throttle Rate", "-1"),
+            ("Local Port", "*"),
+            ("Local IP", "*"),
+            ("Local IP Prefix Length", "*"),
+            ("Remote Port", RELAY_QOS_REMOTE_PORT),
+            ("Remote IP", "*"),
+            ("Remote IP Prefix Length", "*"),
+        ] {
+            Self::set_registry_string(&policy_path, value_name, value)?;
+        }
+        Ok(())
+    }
+
+    fn relay_qos_requested(config: &NetworkConfig) -> bool {
+        config.disable_network_throttling
+    }
+
+    fn enable_relay_socket_qos_policy(&mut self) -> Result<()> {
+        info!("Enabling relay-scoped DSCP EF policy for SwiftTunnel UDP traffic");
+
+        if self.qos_registry_snapshot.is_none() {
+            self.qos_registry_snapshot = Some(QosRegistrySnapshot {
+                do_not_use_nla: Self::query_registry_dword(TCPIP_QOS_KEY, REG_VALUE_DO_NOT_USE_NLA),
+                disable_user_tos_setting: Self::query_registry_dword(
+                    TCPIP_PARAMETERS_KEY,
+                    REG_VALUE_DISABLE_USER_TOS_SETTING,
+                ),
+            });
+        }
+
+        // Make Windows policy/user TOS marking deterministic on all network profiles,
+        // then scope the DSCP policy to only SwiftTunnel's relay UDP endpoint.
+        Self::set_registry_dword(TCPIP_QOS_KEY, REG_VALUE_DO_NOT_USE_NLA, 1)?;
+        Self::set_registry_dword(TCPIP_PARAMETERS_KEY, REG_VALUE_DISABLE_USER_TOS_SETTING, 0)?;
+
+        for exe in RELAY_QOS_EXECUTABLES {
+            let policy_name = Self::relay_qos_policy_name(exe);
+            Self::write_relay_qos_policy(&policy_name, exe)?;
+        }
+
+        Ok(())
+    }
+
+    fn remove_relay_socket_qos_policy(&mut self) -> Result<()> {
+        Self::cleanup_relay_socket_qos_policies();
+        self.restore_qos_registry_snapshot()
     }
 
     fn powershell_single_quote(value: &str) -> String {
@@ -578,7 +706,7 @@ impl NetworkBooster {
         Ok(())
     }
 
-    fn restore_removed_qos_registry_snapshot(&mut self) -> Result<()> {
+    fn restore_qos_registry_snapshot(&mut self) -> Result<()> {
         let Some(snapshot) = self.qos_registry_snapshot.clone() else {
             return Ok(());
         };
@@ -612,8 +740,8 @@ impl NetworkBooster {
         }
 
         Self::cleanup_removed_qos_policies();
-        if let Err(e) = self.restore_removed_qos_registry_snapshot() {
-            errors.push(format!("removed QoS registry snapshot restore: {}", e));
+        if let Err(e) = self.remove_relay_socket_qos_policy() {
+            errors.push(format!("relay DSCP policy restore: {}", e));
         }
 
         // Remove firewall rules
@@ -716,11 +844,13 @@ pub fn cleanup_all_system_state() -> Result<()> {
         warn!("Cleanup: failed to remove hosts overrides: {e}");
     }
 
-    // 2. Delete removed SwiftTunnel QoS policies from older releases.
+    // 2. Delete SwiftTunnel QoS policies from older releases and the current
+    // relay-scoped DSCP policy.
     NetworkBooster::cleanup_removed_qos_policies();
+    NetworkBooster::cleanup_relay_socket_qos_policies();
 
     info!(
-        "Cleanup: leaving global TCP registry values untouched unless a persisted SwiftTunnel snapshot restored them"
+        "Cleanup: leaving global TCP/QoS registry values untouched unless a persisted SwiftTunnel snapshot restored them"
     );
 
     // 3. Remove firewall rules.
@@ -933,5 +1063,29 @@ mod tests {
             REMOVED_QOS_POLICY_NAMES.contains(&"SwiftTunnel_QoS_Relay_swifttunnel-desktop"),
             "removed QoS cleanup list must strip the former relay policy"
         );
+    }
+
+    #[test]
+    fn relay_qos_policy_is_relay_scoped_and_not_legacy_cleanup() {
+        for exe in RELAY_QOS_EXECUTABLES {
+            let policy_name = NetworkBooster::relay_qos_policy_name(exe);
+            assert!(policy_name.starts_with(RELAY_QOS_POLICY_PREFIX));
+            assert!(
+                !REMOVED_QOS_POLICY_NAMES.contains(&policy_name.as_str()),
+                "current relay DSCP policy must not be deleted by removed-policy cleanup"
+            );
+        }
+        assert_eq!(RELAY_QOS_REMOTE_PORT, "*");
+        assert_eq!(RELAY_QOS_DSCP_VALUE, "46");
+        assert!(NetworkBooster::relay_qos_requested(&NetworkConfig {
+            disable_network_throttling: true,
+            ..Default::default()
+        }));
+        assert!(!NetworkBooster::relay_qos_requested(&NetworkConfig {
+            disable_nagle: true,
+            ..Default::default()
+        }));
+        assert!(!RELAY_QOS_EXECUTABLES.contains(&"Windows10Universal.exe"));
+        assert!(!RELAY_QOS_EXECUTABLES.contains(&"RobloxPlayerBeta.exe"));
     }
 }

--- a/swifttunnel-core/src/vpn/udp_relay.rs
+++ b/swifttunnel-core/src/vpn/udp_relay.rs
@@ -100,6 +100,15 @@ const OUTBOUND_DATA_MAX_QUEUE_AGE_MS: u64 = 250;
 /// long enough to build a multi-second data backlog.
 const SEND_TIMEOUT: Duration = Duration::from_millis(5);
 
+/// DSCP Expedited Forwarding for relay UDP packets.
+///
+/// Keep this socket-scoped: the old Gaming QoS boost created broad Windows QoS
+/// policies for Roblox executables. Intercepted game packets leave the client as
+/// SwiftTunnel relay UDP traffic, so marking this socket preserves low-latency
+/// queueing without tagging unrelated app traffic.
+const RELAY_DSCP_EF: i32 = 46;
+const RELAY_DSCP_EF_TOS_BYTE: i32 = RELAY_DSCP_EF << 2;
+
 /// Control-plane ping for RTT/jitter telemetry (optional).
 const PING_INTERVAL: Duration = Duration::from_millis(50); // 20Hz
 const PING_IDLE_THRESHOLD: Duration = Duration::from_secs(2);
@@ -623,6 +632,22 @@ impl UdpRelay {
                 );
                 if result != 0 {
                     log::warn!("UDP Relay: Failed to set SO_SNDBUF to 256KB, using default");
+                }
+
+                // Windows only honors user-set IP_TOS when DisableUserTOSSetting=0.
+                // The latency network boost sets that registry value and also installs
+                // a SwiftTunnel-only QoS policy; without it, this socket mark may be
+                // accepted by Winsock but stripped before packets leave the host.
+                let tos = RELAY_DSCP_EF_TOS_BYTE;
+                let tos_bytes = std::slice::from_raw_parts(&tos as *const i32 as *const u8, 4);
+                let result = windows::Win32::Networking::WinSock::setsockopt(
+                    sock,
+                    windows::Win32::Networking::WinSock::IPPROTO_IP.0,
+                    windows::Win32::Networking::WinSock::IP_TOS,
+                    Some(tos_bytes),
+                );
+                if result != 0 {
+                    log::warn!("UDP Relay: Failed to set IP_TOS DSCP EF; continuing");
                 }
             }
         }
@@ -2261,6 +2286,13 @@ mod tests {
         );
         // Unreachable streak must never have been touched by non-repairable errors.
         assert_eq!(unreachable.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn relay_dscp_ef_tos_byte_keeps_ecn_bits_clear() {
+        assert_eq!(RELAY_DSCP_EF, 46);
+        assert_eq!(RELAY_DSCP_EF_TOS_BYTE, 184);
+        assert_eq!(RELAY_DSCP_EF_TOS_BYTE & 0b11, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Restores the low-jitter relay QoS behavior users lost after the 2.1.5 → 2.1.7 update without bringing back the broad Gaming QoS policies that tagged Roblox executables and the generic Microsoft Store host.

V3 relay sockets now mark SwiftTunnel UDP relay traffic as DSCP EF (46), and saved latency network boosts install a SwiftTunnel-only UDP QoS policy for Windows paths that require policy-based marking. Cleanup still removes the old Roblox/UWP QoS policies and restores QoS registry snapshots.

## Details

- Marks the `UdpRelay` socket with `IP_TOS` DSCP EF so the active relay socket carries the low-latency traffic class directly.
- Adds a replacement QoS policy scoped to SwiftTunnel UDP traffic only (`SwiftTunnel.exe` / `swifttunnel-desktop.exe`), avoiding the removed Roblox executable and `Windows10Universal.exe` policies.
- Keeps relay-port selection dynamic: the policy does not hardcode `51821`, and the actual socket is marked for whichever relay endpoint the server list selects.
- Documents the safe DSCP behavior in `README.md` and `V3-ROUTING.md`.

## Testing

- `cargo fmt --all -- --check`
- Pull request CI: frontend build and GitHub Windows Rust check passed.
- Manual CI dispatch with `force_testbench=true`: Rust Check, Frontend Build, Split Tunnel Testbench Availability, and Split Tunnel Testbench (Windows) all passed: https://github.com/Swift-tunnel/swifttunnel-app/actions/runs/26360981023
