### PR TITLE
[codex] Separate country ban bypass from route assist

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@
 Only game traffic is optimized through SwiftTunnel. Discord, Spotify, Chrome — everything else uses your normal internet. No bandwidth wasted.
 
 ### 🧭 Roblox Route Assist
-Optional Roblox login/API HTTP(S) routing helps users bypass network bans and gives Roblox a better chance of placing sessions near the SwiftTunnel region they picked. Browser traffic is still scoped to Roblox destinations only; unrelated websites keep using the normal connection. TCP flows are routed only when SwiftTunnel captures the Roblox/bootstrap HTTPS handshake, so existing browser or Roblox connections are not moved into the relay halfway through.
+Optional Roblox-owned login/API HTTP(S) routing helps users bypass network issues and gives Roblox a better chance of placing sessions near the SwiftTunnel region they picked. TCP relay flows are routed only when SwiftTunnel captures a configured tunnel process's HTTPS handshake, so existing Roblox connections are not moved into the relay halfway through.
+
+### 🌐 Bypass country bans
+When Roblox is blocked by country-level DPI, SwiftTunnel can start a scoped GoodbyeDPI helper with a narrow Roblox hostlist. This applies to both browser launch/login traffic and the Roblox app.
 
 ### ⚡ Low Latency Gaming Servers
 27 gaming-optimized relays across 12 gaming regions. Each relay runs:
@@ -106,7 +109,9 @@ Starts on the lowest-latency region from the in-app ping test, then resolves det
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic and the temporary CDN IPs resolved for those bootstrap hostnames, through the selected relay. Route Assist TCP routing is handshake-gated so SwiftTunnel can clamp relay-owned flows before large HTTPS packets are exchanged; non-Roblox browser traffic and already-established TCP connections still bypass SwiftTunnel.
+SwiftTunnel intercepts game traffic at the network layer. Only packets from your game are optimized and routed through our servers. DNS normally stays on the local connection; when Roblox Route Assist is enabled, SwiftTunnel also repairs exact Roblox launch/API hostnames with temporary hosts-file entries resolved over HTTPS DNS and routes Roblox-owned login/API HTTP(S) through the selected relay. Already-established TCP connections still bypass SwiftTunnel.
+
+When Bypass country bans is enabled, the scoped GoodbyeDPI helper applies to Roblox hostnames for both browser and app traffic without changing relay ownership.
 
 On Windows, the V3 relay client marks SwiftTunnel relay UDP traffic with DSCP EF (46) best-effort for lower jitter on networks that honor DSCP. When latency network throttling boost is enabled, SwiftTunnel also installs the Windows QoS policy needed for deterministic DSCP handling, scoped to SwiftTunnel's relay socket/process; the old broad Gaming QoS policies for Roblox executables and the generic Microsoft Store `Windows10Universal.exe` host stay removed.
 

--- a/swifttunnel-core/src/bin/testbench_shared/mod.rs
+++ b/swifttunnel-core/src/bin/testbench_shared/mod.rs
@@ -37,6 +37,7 @@ pub struct CommonCliOptions {
     pub https_get_url: Option<String>,
     pub custom_relay_server: Option<String>,
     pub enable_api_tunneling: bool,
+    pub enable_country_ban: bool,
     pub skip_manual_process_register: bool,
 }
 
@@ -96,6 +97,7 @@ pub fn parse_common_cli_options(args: &[String]) -> Result<CommonCliOptions, Str
             "--https-get-url" => opts.https_get_url = Some(next(flag, &mut idx)?),
             "--custom-relay" => opts.custom_relay_server = Some(next(flag, &mut idx)?),
             "--enable-api-tunneling" => opts.enable_api_tunneling = true,
+            "--enable-country-ban" => opts.enable_country_ban = true,
             "--skip-manual-process-register" => opts.skip_manual_process_register = true,
             "--help" | "-h" => return Err("help".to_string()),
             other => return Err(format!("Unknown argument: {}", other)),
@@ -145,6 +147,12 @@ pub fn resolve_enable_api_tunneling(opts: &CommonCliOptions, settings: &AppSetti
     opts.enable_api_tunneling
         || parse_env_flag("SWIFTTUNNEL_TEST_ENABLE_API_TUNNELING")
         || settings.enable_api_tunneling
+}
+
+pub fn resolve_enable_country_ban(opts: &CommonCliOptions, settings: &AppSettings) -> bool {
+    opts.enable_country_ban
+        || parse_env_flag("SWIFTTUNNEL_TEST_ENABLE_COUNTRY_BAN")
+        || settings.enable_country_ban
 }
 
 pub fn resolve_binding_preference(
@@ -641,6 +649,7 @@ pub async fn connect_vpn(
         binding_preference,
         settings.game_process_performance,
         resolve_enable_api_tunneling(opts, settings),
+        resolve_enable_country_ban(opts, settings),
     )
     .await
     .map_err(|e| swifttunnel_core::vpn::user_friendly_error(&e))

--- a/swifttunnel-core/src/network_booster.rs
+++ b/swifttunnel-core/src/network_booster.rs
@@ -844,6 +844,11 @@ pub fn cleanup_all_system_state() -> Result<()> {
         warn!("Cleanup: failed to remove hosts overrides: {e}");
     }
 
+    // 1b. Stop SwiftTunnel's scoped GoodbyeDPI helper and remove its runtime hostlist.
+    if let Err(e) = crate::roblox_proxy::goodbyedpi::cleanup_for_uninstall() {
+        warn!("Cleanup: GoodbyeDPI cleanup failed (non-fatal): {e}");
+    }
+
     // 2. Delete SwiftTunnel QoS policies from older releases and the current
     // relay-scoped DSCP policy.
     NetworkBooster::cleanup_removed_qos_policies();

--- a/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
+++ b/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
@@ -164,6 +164,26 @@ pub fn start_for_roblox() -> Result<Option<GoodbyeDpiGuard>, String> {
     }))
 }
 
+pub fn cleanup_for_uninstall() -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    if cfg!(windows) {
+        if let Err(e) = stop_managed_goodbyedpi_processes() {
+            errors.push(e);
+        }
+    }
+
+    if let Err(e) = remove_goodbyedpi_data_dir() {
+        errors.push(e);
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
 fn locate_goodbyedpi_executable() -> Option<PathBuf> {
     let current_exe = std::env::current_exe().ok();
     let env_path = std::env::var_os(GOODBYEDPI_ENV_PATH)
@@ -202,6 +222,24 @@ fn goodbyedpi_data_dir() -> PathBuf {
         .join("goodbyedpi")
 }
 
+fn remove_goodbyedpi_data_dir() -> Result<(), String> {
+    remove_goodbyedpi_data_dir_at(&goodbyedpi_data_dir())
+}
+
+fn remove_goodbyedpi_data_dir_at(path: &Path) -> Result<(), String> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {
+            info!("Removed GoodbyeDPI runtime directory {}", path.display());
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!(
+            "Failed to remove GoodbyeDPI runtime directory {}: {e}",
+            path.display()
+        )),
+    }
+}
+
 fn remove_hostlist_file(path: &Path) -> Result<(), std::io::Error> {
     match fs::remove_file(path) {
         Ok(()) => Ok(()),
@@ -225,6 +263,96 @@ pub(crate) fn roblox_hostlist_contents() -> String {
         out.push('\n');
     }
     out
+}
+
+fn stop_managed_goodbyedpi_processes() -> Result<(), String> {
+    let current_exe = std::env::current_exe().ok();
+    let program_files = std::env::var_os("ProgramFiles").map(PathBuf::from);
+    let roots = managed_goodbyedpi_roots(current_exe.as_deref(), program_files.as_deref());
+    if roots.is_empty() {
+        return Ok(());
+    }
+
+    let script = build_stop_managed_processes_script(&roots);
+    let status = crate::hidden_command("powershell")
+        .args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &script,
+        ])
+        .status()
+        .map_err(|e| format!("Failed to run GoodbyeDPI process cleanup: {e}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "GoodbyeDPI process cleanup exited with {}",
+            status
+                .code()
+                .map_or_else(|| "unknown status".to_string(), |code| code.to_string())
+        ))
+    }
+}
+
+fn managed_goodbyedpi_roots(
+    current_exe: Option<&Path>,
+    program_files: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    if let Some(base) = current_exe.and_then(Path::parent) {
+        roots.push(base.join("tools").join("goodbyedpi"));
+        roots.push(base.join("resources").join("tools").join("goodbyedpi"));
+        roots.push(base.join("goodbyedpi"));
+    }
+
+    if let Some(program_files) = program_files {
+        let install_root = program_files.join("SwiftTunnel");
+        roots.push(install_root.join("tools").join("goodbyedpi"));
+        roots.push(
+            install_root
+                .join("resources")
+                .join("tools")
+                .join("goodbyedpi"),
+        );
+        roots.push(install_root.join("goodbyedpi"));
+    }
+
+    dedupe_paths(roots)
+}
+
+fn build_stop_managed_processes_script(roots: &[PathBuf]) -> String {
+    let roots = roots
+        .iter()
+        .map(|path| format!("'{}'", powershell_single_quote(&path.to_string_lossy())))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        r#"$ErrorActionPreference = 'Stop'
+$roots = @({roots}) | ForEach-Object {{
+  [System.IO.Path]::GetFullPath($_).TrimEnd('\') + '\'
+}}
+Get-CimInstance Win32_Process -Filter "Name = 'goodbyedpi.exe'" | ForEach-Object {{
+  $path = $_.ExecutablePath
+  if (-not [string]::IsNullOrWhiteSpace($path)) {{
+    $fullPath = [System.IO.Path]::GetFullPath($path)
+    foreach ($root in $roots) {{
+      if ($fullPath.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {{
+        Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop
+        break
+      }}
+    }}
+  }}
+}}"#
+    )
+}
+
+fn powershell_single_quote(value: &str) -> String {
+    value.replace('\'', "''")
 }
 
 pub(crate) fn candidate_executable_paths(
@@ -335,5 +463,44 @@ mod tests {
         let _ = fs::remove_file(&path);
 
         assert!(remove_hostlist_file(&path).is_ok());
+    }
+
+    #[test]
+    fn managed_goodbyedpi_roots_scope_to_install_dirs() {
+        let roots = managed_goodbyedpi_roots(
+            Some(Path::new(r"C:\Program Files\SwiftTunnel\SwiftTunnel.exe")),
+            Some(Path::new(r"C:\Program Files")),
+        );
+
+        assert!(roots.contains(&PathBuf::from(
+            r"C:\Program Files\SwiftTunnel\tools\goodbyedpi"
+        )));
+        assert!(roots.contains(&PathBuf::from(
+            r"C:\Program Files\SwiftTunnel\resources\tools\goodbyedpi"
+        )));
+        assert!(!roots.contains(&PathBuf::from(r"D:\tools\goodbyedpi")));
+    }
+
+    #[test]
+    fn stop_script_uses_path_scoped_process_cleanup() {
+        let script = build_stop_managed_processes_script(&[PathBuf::from(
+            r"C:\Program Files\Swift'Tunnel\tools\goodbyedpi",
+        )]);
+
+        assert!(script.contains("Get-CimInstance Win32_Process"));
+        assert!(script.contains("Name = 'goodbyedpi.exe'"));
+        assert!(script.contains("ExecutablePath"));
+        assert!(script.contains("StartsWith"));
+        assert!(script.contains("Stop-Process"));
+        assert!(script.contains("Swift''Tunnel"));
+        assert!(!script.contains("taskkill"));
+    }
+
+    #[test]
+    fn remove_goodbyedpi_data_dir_ignores_missing_dir() {
+        let path = std::env::temp_dir().join("swifttunnel-missing-goodbyedpi-dir");
+        let _ = fs::remove_dir_all(&path);
+
+        assert!(remove_goodbyedpi_data_dir_at(&path).is_ok());
     }
 }

--- a/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
+++ b/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
@@ -38,25 +38,49 @@ impl GoodbyeDpiGuard {
                     self.exe_path.display()
                 );
             }
-            Ok(None) => {
-                if let Err(e) = self.child.kill() {
+            Ok(None) => match self.child.kill() {
+                Ok(()) => {
+                    if let Err(e) = self.child.wait() {
+                        warn!(
+                            "Failed to wait for GoodbyeDPI process {} cleanup: {}",
+                            self.child.id(),
+                            e
+                        );
+                    } else {
+                        info!("Stopped GoodbyeDPI helper ({})", self.exe_path.display());
+                    }
+                }
+                Err(e) => {
                     warn!(
                         "Failed to stop GoodbyeDPI process {} ({}): {}",
                         self.child.id(),
                         self.exe_path.display(),
                         e
                     );
+                    match self.child.try_wait() {
+                        Ok(Some(status)) => {
+                            info!(
+                                "GoodbyeDPI exited during cleanup race (status: {}, exe: {})",
+                                status,
+                                self.exe_path.display()
+                            );
+                        }
+                        Ok(None) => {
+                            warn!(
+                                "Skipping blocking wait for GoodbyeDPI process {} after kill failure",
+                                self.child.id()
+                            );
+                        }
+                        Err(wait_err) => {
+                            warn!(
+                                "Failed to re-check GoodbyeDPI process {} after kill failure: {}",
+                                self.child.id(),
+                                wait_err
+                            );
+                        }
+                    }
                 }
-                if let Err(e) = self.child.wait() {
-                    warn!(
-                        "Failed to wait for GoodbyeDPI process {} cleanup: {}",
-                        self.child.id(),
-                        e
-                    );
-                } else {
-                    info!("Stopped GoodbyeDPI helper ({})", self.exe_path.display());
-                }
-            }
+            },
             Err(e) => {
                 warn!(
                     "Failed to inspect GoodbyeDPI process {} during cleanup: {}",
@@ -66,16 +90,12 @@ impl GoodbyeDpiGuard {
             }
         }
 
-        match fs::remove_file(&self.hostlist_path) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => {
-                warn!(
-                    "Failed to remove GoodbyeDPI Roblox hostlist {}: {}",
-                    self.hostlist_path.display(),
-                    e
-                );
-            }
+        if let Err(e) = remove_hostlist_file(&self.hostlist_path) {
+            warn!(
+                "Failed to remove GoodbyeDPI Roblox hostlist {}: {}",
+                self.hostlist_path.display(),
+                e
+            );
         }
     }
 }
@@ -110,13 +130,23 @@ pub fn start_for_roblox() -> Result<Option<GoodbyeDpiGuard>, String> {
         command.current_dir(dir);
     }
 
-    let child = command.spawn().map_err(|e| {
-        format!(
-            "Failed to start GoodbyeDPI helper {} with hostlist {}: {e}",
-            exe_path.display(),
-            hostlist_path.display()
-        )
-    })?;
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            if let Err(cleanup_err) = remove_hostlist_file(&hostlist_path) {
+                warn!(
+                    "Failed to remove GoodbyeDPI hostlist after spawn failure {}: {}",
+                    hostlist_path.display(),
+                    cleanup_err
+                );
+            }
+            return Err(format!(
+                "Failed to start GoodbyeDPI helper {} with hostlist {}: {e}",
+                exe_path.display(),
+                hostlist_path.display()
+            ));
+        }
+    };
 
     info!(
         "Started GoodbyeDPI helper pid={} exe={} hostlist={}",
@@ -169,6 +199,14 @@ fn goodbyedpi_data_dir() -> PathBuf {
         .unwrap_or_else(std::env::temp_dir)
         .join("SwiftTunnel")
         .join("goodbyedpi")
+}
+
+fn remove_hostlist_file(path: &Path) -> Result<(), std::io::Error> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 pub(crate) fn build_goodbyedpi_args(hostlist_path: &Path) -> Vec<String> {
@@ -288,5 +326,13 @@ mod tests {
         assert!(paths.contains(&PathBuf::from(
             "C:/Program Files/SwiftTunnel/tools/goodbyedpi/x86_64/goodbyedpi.exe"
         )));
+    }
+
+    #[test]
+    fn remove_hostlist_file_ignores_missing_file() {
+        let path = std::env::temp_dir().join("swifttunnel-missing-goodbyedpi-hostlist.txt");
+        let _ = fs::remove_file(&path);
+
+        assert!(remove_hostlist_file(&path).is_ok());
     }
 }

--- a/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
+++ b/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
@@ -16,6 +16,7 @@ const GOODBYEDPI_EXE_NAME: &str = "goodbyedpi.exe";
 const HOSTLIST_NAME: &str = "roblox-hostlist.txt";
 
 #[derive(Debug)]
+#[must_use = "dropping GoodbyeDpiGuard stops the GoodbyeDPI subprocess immediately"]
 pub struct GoodbyeDpiGuard {
     child: Child,
     exe_path: PathBuf,

--- a/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
+++ b/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
@@ -1,0 +1,292 @@
+//! Scoped GoodbyeDPI launcher for Roblox country-ban traffic.
+//!
+//! SwiftTunnel no longer routes browser-owned Roblox HTTP(S) through the relay.
+//! When Bypass country bans is enabled, this helper starts a bundled GoodbyeDPI
+//! process with a narrow hostlist so both browser and Roblox app traffic get DPI
+//! circumvention without becoming relay-owned traffic.
+
+use log::{debug, info, warn};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Stdio};
+
+const GOODBYEDPI_ENV_PATH: &str = "SWIFTTUNNEL_GOODBYEDPI_PATH";
+const GOODBYEDPI_EXE_NAME: &str = "goodbyedpi.exe";
+const HOSTLIST_NAME: &str = "roblox-hostlist.txt";
+
+#[derive(Debug)]
+pub struct GoodbyeDpiGuard {
+    child: Child,
+    exe_path: PathBuf,
+    hostlist_path: PathBuf,
+    stopped: bool,
+}
+
+impl GoodbyeDpiGuard {
+    pub fn stop(&mut self) {
+        if self.stopped {
+            return;
+        }
+        self.stopped = true;
+
+        match self.child.try_wait() {
+            Ok(Some(status)) => {
+                info!(
+                    "GoodbyeDPI already exited before cleanup (status: {}, exe: {})",
+                    status,
+                    self.exe_path.display()
+                );
+            }
+            Ok(None) => {
+                if let Err(e) = self.child.kill() {
+                    warn!(
+                        "Failed to stop GoodbyeDPI process {} ({}): {}",
+                        self.child.id(),
+                        self.exe_path.display(),
+                        e
+                    );
+                }
+                if let Err(e) = self.child.wait() {
+                    warn!(
+                        "Failed to wait for GoodbyeDPI process {} cleanup: {}",
+                        self.child.id(),
+                        e
+                    );
+                } else {
+                    info!("Stopped GoodbyeDPI helper ({})", self.exe_path.display());
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to inspect GoodbyeDPI process {} during cleanup: {}",
+                    self.child.id(),
+                    e
+                );
+            }
+        }
+
+        match fs::remove_file(&self.hostlist_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                warn!(
+                    "Failed to remove GoodbyeDPI Roblox hostlist {}: {}",
+                    self.hostlist_path.display(),
+                    e
+                );
+            }
+        }
+    }
+}
+
+impl Drop for GoodbyeDpiGuard {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+pub fn start_for_roblox() -> Result<Option<GoodbyeDpiGuard>, String> {
+    if !cfg!(windows) {
+        debug!("GoodbyeDPI helper skipped: supported only on Windows");
+        return Ok(None);
+    }
+
+    let Some(exe_path) = locate_goodbyedpi_executable() else {
+        warn!("GoodbyeDPI helper not found; Bypass country bans will not apply to Roblox traffic");
+        return Ok(None);
+    };
+
+    let hostlist_path = write_roblox_hostlist()?;
+    let args = build_goodbyedpi_args(&hostlist_path);
+    let program = exe_path.to_string_lossy();
+    let mut command = crate::hidden_command(&program);
+    command
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(dir) = exe_path.parent() {
+        command.current_dir(dir);
+    }
+
+    let child = command.spawn().map_err(|e| {
+        format!(
+            "Failed to start GoodbyeDPI helper {} with hostlist {}: {e}",
+            exe_path.display(),
+            hostlist_path.display()
+        )
+    })?;
+
+    info!(
+        "Started GoodbyeDPI helper pid={} exe={} hostlist={}",
+        child.id(),
+        exe_path.display(),
+        hostlist_path.display()
+    );
+
+    Ok(Some(GoodbyeDpiGuard {
+        child,
+        exe_path,
+        hostlist_path,
+        stopped: false,
+    }))
+}
+
+fn locate_goodbyedpi_executable() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok();
+    let env_path = std::env::var_os(GOODBYEDPI_ENV_PATH)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty());
+
+    candidate_executable_paths(current_exe.as_deref(), env_path)
+        .into_iter()
+        .find(|path| path.is_file())
+}
+
+fn write_roblox_hostlist() -> Result<PathBuf, String> {
+    let dir = goodbyedpi_data_dir();
+    fs::create_dir_all(&dir).map_err(|e| {
+        format!(
+            "Failed to create GoodbyeDPI data directory {}: {e}",
+            dir.display()
+        )
+    })?;
+
+    let path = dir.join(HOSTLIST_NAME);
+    fs::write(&path, roblox_hostlist_contents()).map_err(|e| {
+        format!(
+            "Failed to write GoodbyeDPI Roblox hostlist {}: {e}",
+            path.display()
+        )
+    })?;
+    Ok(path)
+}
+
+fn goodbyedpi_data_dir() -> PathBuf {
+    std::env::var_os("ProgramData")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("SwiftTunnel")
+        .join("goodbyedpi")
+}
+
+pub(crate) fn build_goodbyedpi_args(hostlist_path: &Path) -> Vec<String> {
+    vec![
+        "-9".to_string(),
+        "--blacklist".to_string(),
+        hostlist_path.to_string_lossy().to_string(),
+    ]
+}
+
+pub(crate) fn roblox_hostlist_contents() -> String {
+    let mut out = String::new();
+    for domain in super::hosts::ROBLOX_BOOTSTRAP_DOMAINS {
+        out.push_str(domain);
+        out.push('\n');
+    }
+    out
+}
+
+pub(crate) fn candidate_executable_paths(
+    current_exe: Option<&Path>,
+    env_path: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(path) = env_path {
+        paths.push(path);
+    }
+
+    if let Some(base) = current_exe.and_then(Path::parent) {
+        add_goodbyedpi_candidates(&mut paths, &base.join("tools").join("goodbyedpi"));
+        add_goodbyedpi_candidates(
+            &mut paths,
+            &base.join("resources").join("tools").join("goodbyedpi"),
+        );
+        add_goodbyedpi_candidates(&mut paths, &base.join("goodbyedpi"));
+    }
+
+    if let Some(program_files) = std::env::var_os("ProgramFiles").map(PathBuf::from) {
+        add_goodbyedpi_candidates(
+            &mut paths,
+            &program_files
+                .join("SwiftTunnel")
+                .join("tools")
+                .join("goodbyedpi"),
+        );
+        add_goodbyedpi_candidates(
+            &mut paths,
+            &program_files
+                .join("SwiftTunnel")
+                .join("resources")
+                .join("tools")
+                .join("goodbyedpi"),
+        );
+    }
+
+    dedupe_paths(paths)
+}
+
+fn add_goodbyedpi_candidates(paths: &mut Vec<PathBuf>, root: &Path) {
+    paths.push(root.join(GOODBYEDPI_EXE_NAME));
+    paths.push(root.join("x86_64").join(GOODBYEDPI_EXE_NAME));
+    paths.push(root.join("x86").join(GOODBYEDPI_EXE_NAME));
+}
+
+fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for path in paths {
+        if seen.insert(path.clone()) {
+            out.push(path);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn goodbyedpi_args_use_modern_mode_and_blacklist() {
+        let path = PathBuf::from(r"C:\ProgramData\SwiftTunnel\goodbyedpi\roblox-hostlist.txt");
+
+        let args = build_goodbyedpi_args(&path);
+
+        assert_eq!(args[0], "-9");
+        assert_eq!(args[1], "--blacklist");
+        assert_eq!(args[2], path.to_string_lossy());
+    }
+
+    #[test]
+    fn roblox_hostlist_is_exact_bootstrap_allowlist() {
+        let contents = roblox_hostlist_contents();
+        let domains: Vec<&str> = contents.lines().collect();
+
+        assert_eq!(
+            domains.as_slice(),
+            super::super::hosts::ROBLOX_BOOTSTRAP_DOMAINS
+        );
+        assert!(domains.contains(&"www.roblox.com"));
+        assert!(domains.contains(&"auth.roblox.com"));
+        assert!(!domains.contains(&"roblox.com"));
+        assert!(contents.ends_with('\n'));
+    }
+
+    #[test]
+    fn candidate_paths_prioritize_env_then_staged_tools() {
+        let exe = PathBuf::from("C:/Program Files/SwiftTunnel/SwiftTunnel.exe");
+        let env = PathBuf::from("D:/tools/goodbyedpi.exe");
+
+        let paths = candidate_executable_paths(Some(&exe), Some(env.clone()));
+
+        assert_eq!(paths.first(), Some(&env));
+        assert!(paths.contains(&PathBuf::from(
+            "C:/Program Files/SwiftTunnel/tools/goodbyedpi/goodbyedpi.exe"
+        )));
+        assert!(paths.contains(&PathBuf::from(
+            "C:/Program Files/SwiftTunnel/tools/goodbyedpi/x86_64/goodbyedpi.exe"
+        )));
+    }
+}

--- a/swifttunnel-core/src/roblox_proxy/mod.rs
+++ b/swifttunnel-core/src/roblox_proxy/mod.rs
@@ -1,9 +1,12 @@
-//! Roblox bootstrap DNS repair.
+//! Roblox bootstrap DNS repair and browser-side DPI helper.
 //!
-//! API tunneling can carry Roblox HTTPS traffic through a SwiftTunnel
-//! relay, but Roblox still needs a working local hostname lookup before
-//! it opens that TCP connection. This module keeps a narrow hosts-file
-//! repair for launch/API endpoints and also removes stale
-//! entries from older local-proxy builds.
+//! API tunneling can carry Roblox-owned HTTPS traffic through a SwiftTunnel
+//! relay, but Roblox still needs a working local hostname lookup before it opens
+//! that TCP connection. Browser-owned Roblox HTTP(S) is intentionally left out
+//! of the relay path. Bypass country bans can start a scoped GoodbyeDPI helper
+//! for both browser and Roblox app traffic when available.
+//! This module keeps a narrow hosts-file repair for launch/API endpoints and
+//! also removes stale entries from older local-proxy builds.
 
+pub mod goodbyedpi;
 pub mod hosts;

--- a/swifttunnel-core/src/settings.rs
+++ b/swifttunnel-core/src/settings.rs
@@ -173,13 +173,19 @@ pub struct AppSettings {
     #[serde(default)]
     pub game_process_performance: GameProcessPerformanceSettings,
 
-    /// Route Roblox TCP/HTTPS traffic through the relay to bypass ISP blocking.
+    /// Route Roblox-owned TCP/HTTPS traffic through the relay.
     ///
-    /// When enabled, TCP packets from tunnel apps and browser-owned Roblox
-    /// login/API HTTP(S) flows are forwarded through the V3 relay alongside
-    /// UDP game traffic. Off by default.
+    /// When enabled, TCP packets from tunnel apps are forwarded through the V3
+    /// relay alongside UDP game traffic. Browser-owned Roblox traffic is never
+    /// routed by Route Assist. Off by default.
     #[serde(default)]
     pub enable_api_tunneling: bool,
+    /// Run the scoped GoodbyeDPI helper for Roblox country-level DPI blocks.
+    ///
+    /// When enabled, GoodbyeDPI applies to Roblox hostnames for both browser and
+    /// Roblox app traffic. This does not route browser traffic through the relay.
+    #[serde(default)]
+    pub enable_country_ban: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -271,6 +277,7 @@ impl Default for AppSettings {
             adapter_binding_mode: AdapterBindingMode::SmartAuto,
             game_process_performance: GameProcessPerformanceSettings::default(),
             enable_api_tunneling: false,
+            enable_country_ban: false,
         }
     }
 }
@@ -604,15 +611,18 @@ mod tests {
         let json = r#"{"theme": "dark", "config": {}, "optimizations_active": false}"#;
         let loaded: AppSettings = serde_json::from_str(json).unwrap();
         assert!(!loaded.enable_api_tunneling);
+        assert!(!loaded.enable_country_ban);
     }
 
     #[test]
-    fn test_settings_api_tunneling_roundtrip() {
+    fn test_settings_route_assist_and_country_ban_roundtrip() {
         let mut settings = AppSettings::default();
         settings.enable_api_tunneling = true;
+        settings.enable_country_ban = true;
         let json = serde_json::to_string(&settings).unwrap();
         let loaded: AppSettings = serde_json::from_str(&json).unwrap();
         assert!(loaded.enable_api_tunneling);
+        assert!(loaded.enable_country_ban);
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/connection.rs
+++ b/swifttunnel-core/src/vpn/connection.rs
@@ -847,6 +847,8 @@ pub struct VpnConnection {
     process_performance_manager: Option<Arc<Mutex<GameProcessPerformanceManager>>>,
     /// Tracks whether this connection wrote the temporary Roblox bootstrap hosts repair.
     bootstrap_dns_repair_applied: bool,
+    /// Scoped GoodbyeDPI helper for Bypass country bans Roblox traffic.
+    goodbye_dpi_guard: Option<crate::roblox_proxy::goodbyedpi::GoodbyeDpiGuard>,
 }
 
 impl VpnConnection {
@@ -862,6 +864,7 @@ impl VpnConnection {
             auto_lookup_handle: None,
             process_performance_manager: None,
             bootstrap_dns_repair_applied: false,
+            goodbye_dpi_guard: None,
         }
     }
 
@@ -983,6 +986,7 @@ impl VpnConnection {
         binding_preference: Option<AdapterBindingPreference>,
         process_performance_settings: GameProcessPerformanceSettings,
         enable_api_tunneling: bool,
+        enable_country_ban: bool,
     ) -> VpnResult<()> {
         let prior_was_error = {
             let state = self.state.borrow();
@@ -1086,6 +1090,28 @@ impl VpnConnection {
         // V3 doesn't need a virtual adapter
         self.set_state(ConnectionState::ConfiguringSplitTunnel)
             .await;
+
+        if enable_country_ban {
+            match crate::roblox_proxy::goodbyedpi::start_for_roblox() {
+                Ok(Some(guard)) => {
+                    self.goodbye_dpi_guard = Some(guard);
+                    log::info!(
+                        "V3: Started Bypass country bans GoodbyeDPI helper for Roblox traffic"
+                    );
+                }
+                Ok(None) => {
+                    log::warn!(
+                        "V3: Bypass country bans helper unavailable; Roblox traffic will continue without GoodbyeDPI"
+                    );
+                }
+                Err(e) => {
+                    log::warn!(
+                        "V3: Bypass country bans helper startup failed; continuing without GoodbyeDPI: {}",
+                        e
+                    );
+                }
+            }
+        }
 
         if enable_api_tunneling && !tunnel_apps.is_empty() {
             match crate::roblox_proxy::hosts::apply_bootstrap_overrides().await {
@@ -2448,6 +2474,10 @@ impl VpnConnection {
         // Cleanup WFP block filters
         super::wfp_block::cleanup();
 
+        if let Some(mut guard) = self.goodbye_dpi_guard.take() {
+            guard.stop();
+        }
+
         if self.bootstrap_dns_repair_applied {
             match crate::roblox_proxy::hosts::remove_overrides_async().await {
                 Ok(()) => {
@@ -2651,6 +2681,10 @@ impl Drop for VpnConnection {
         // Stop ETW watcher
         if let Some(mut watcher) = self.etw_watcher.take() {
             watcher.stop();
+        }
+
+        if let Some(mut guard) = self.goodbye_dpi_guard.take() {
+            guard.stop();
         }
 
         if let Some(manager) = self.process_performance_manager.take() {

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6678,62 +6678,24 @@ fn process_name_in_tunnel_scope(name: &str, snapshot: &ProcessSnapshot) -> bool 
     process_name_matches_any_tunnel_app(&name_lower, &snapshot.tunnel_apps)
 }
 
-fn process_name_stem_lower(name: &str) -> String {
-    let file_name = name.rsplit(['\\', '/']).next().unwrap_or(name).trim();
-    let lower = file_name.to_ascii_lowercase();
-    lower
-        .strip_suffix(".exe")
-        .unwrap_or(lower.as_str())
-        .to_string()
-}
-
-fn process_name_in_browser_http_scope(name: &str) -> bool {
-    matches!(
-        process_name_stem_lower(name).as_str(),
-        "arc"
-            | "brave"
-            | "brave-browser"
-            | "chrome"
-            | "chromium"
-            | "chromium-browser"
-            | "firefox"
-            | "msedge"
-            | "opera"
-            | "opera-browser"
-            | "opera_gx"
-            | "operagx"
-            | "vivaldi"
-    )
-}
-
-fn tcp_owner_scope_match<P>(
-    pid: u32,
-    snapshot: &ProcessSnapshot,
-    process_name_lookup: &P,
-) -> (bool, bool)
+fn tcp_owner_scope_match<P>(pid: u32, snapshot: &ProcessSnapshot, process_name_lookup: &P) -> bool
 where
     P: Fn(u32) -> Option<String>,
 {
     if snapshot.is_tunnel_pid_public(pid) {
-        return (true, false);
+        return true;
     }
 
     if let Some(name) = snapshot.pid_names.get(&pid) {
-        return (
-            process_name_in_tunnel_scope(name, snapshot),
-            process_name_in_browser_http_scope(name),
-        );
+        return process_name_in_tunnel_scope(name, snapshot);
     }
 
     let name = process_name_lookup(pid);
     let Some(name) = name.as_deref() else {
-        return (false, false);
+        return false;
     };
 
-    (
-        process_name_in_tunnel_scope(name, snapshot),
-        process_name_in_browser_http_scope(name),
-    )
+    process_name_in_tunnel_scope(name, snapshot)
 }
 
 /// Debug counters for inline cache diagnostics
@@ -7012,12 +6974,8 @@ where
         // couldn't identify the source process. This catches first packets sent
         // before the UDP table is populated (0.5-2ms race window).
         //
-        // TCP speculation is allowed only when API tunneling is enabled and a
-        // tunnel process is already known. This catches first SYNs for Roblox
-        // API/teleport flows before the owner table publishes the source port.
-        // Browser-owned HTTP(S) is allowed only for Roblox destinations so
-        // login/account flows can share the selected relay without tunneling
-        // unrelated browser traffic.
+        // TCP relay seeding is strictly process-owned. Only captured SYNs from
+        // configured tunnel processes may become relay-owned flows.
         let has_tunnel_scope = !snapshot.tunnel_pids.is_empty() || !snapshot.tunnel_apps.is_empty();
         let can_speculate_tcp_api = protocol == Protocol::Tcp && api_tunneling && has_tunnel_scope;
         let is_tcp_api_bootstrap_syn =
@@ -7032,28 +6990,19 @@ where
         } else {
             None
         };
-        let (tcp_api_bootstrap_owned_by_tunnel, tcp_api_bootstrap_owned_by_browser) =
-            if is_tcp_api_bootstrap_syn && snapshot_tunnel_hit {
-                (true, false)
-            } else {
-                tcp_api_bootstrap_owner
-                    .map(|pid| tcp_owner_scope_match(pid, snapshot, &process_name_lookup))
-                    .unwrap_or((false, false))
-            };
-        let tcp_api_bootstrap_owned_by_browser_route_assist =
-            tcp_api_bootstrap_owned_by_browser && is_route_assist_http_dst;
-        let tcp_api_bootstrap_known_unrelated = tcp_api_bootstrap_owner
-            .map(|_| {
-                !tcp_api_bootstrap_owned_by_tunnel
-                    && !tcp_api_bootstrap_owned_by_browser_route_assist
-            })
-            .unwrap_or(false);
+        let tcp_api_bootstrap_owned_by_tunnel = if is_tcp_api_bootstrap_syn && snapshot_tunnel_hit {
+            true
+        } else {
+            tcp_api_bootstrap_owner
+                .map(|pid| tcp_owner_scope_match(pid, snapshot, &process_name_lookup))
+                .unwrap_or(false)
+        };
         let tcp_api_bootstrap_allowed =
-            is_tcp_api_bootstrap_syn && !tcp_api_bootstrap_known_unrelated;
+            is_tcp_api_bootstrap_syn && tcp_api_bootstrap_owned_by_tunnel;
         let is_game_dst = if protocol == Protocol::Udp {
             super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
         } else {
-            is_route_assist_http_dst && is_tcp_initial_syn && !tcp_api_bootstrap_known_unrelated
+            tcp_api_bootstrap_allowed
         };
         if is_game_dst || tcp_api_bootstrap_allowed {
             // Log speculative tunneling for debugging (first 20 times only)
@@ -7070,7 +7019,7 @@ where
                 });
                 if spec_count < 20 {
                     log::info!(
-                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (Roblox destination or active bootstrap repair IP, initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={}, owner_is_browser_route_assist={})",
+                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={}, route_assist_http_dst={})",
                         src_ip,
                         src_port,
                         dst_ip,
@@ -7078,7 +7027,7 @@ where
                         is_tcp_initial_syn,
                         tcp_api_bootstrap_owner,
                         tcp_api_bootstrap_owned_by_tunnel,
-                        tcp_api_bootstrap_owned_by_browser_route_assist
+                        is_route_assist_http_dst
                     );
                 }
             } else {
@@ -11008,9 +10957,8 @@ mod tests {
 
     #[test]
     fn test_tcp_api_tunneling_speculates_when_tunnel_process_is_active() {
-        // First SYNs for Roblox API/teleport TCP flows can arrive before the
-        // Windows owner table publishes their source port. If a tunnel process
-        // is already active, allow destination-guarded TCP speculation.
+        // Route Assist seeds TCP only after the structured owner lookup ties
+        // the SYN back to a configured tunnel process.
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let dst_ip = Ipv4Addr::new(128, 116, 50, 100);
         let src_port = 40001;
@@ -11170,7 +11118,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tcp_api_tunneling_bootstraps_asset_syn_when_owner_not_published_yet() {
+    fn test_tcp_api_tunneling_does_not_bootstrap_asset_syn_when_owner_not_published_yet() {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let cdn_ip = Ipv4Addr::new(23, 61, 202, 142);
         let src_port = 40006;
@@ -11193,18 +11141,18 @@ mod tests {
         let frame = build_ipv4_tcp_frame_with_flags(src_ip, cdn_ip, src_port, dst_port, 0x02);
         let mut inline_cache: InlineCache = HashMap::new();
 
-        assert!(should_route_to_vpn_with_inline_cache_and_tcp_owner_lookup(
+        assert!(!should_route_to_vpn_with_inline_cache_and_tcp_owner_lookup(
             &frame,
             &snapshot,
             &mut inline_cache,
             true,
             |_ip, _port| None,
         ));
-        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+        assert!(inline_cache.is_empty());
     }
 
     #[test]
-    fn test_tcp_api_tunneling_bootstraps_asset_syn_when_app_scope_exists_without_pid() {
+    fn test_tcp_api_tunneling_does_not_bootstrap_asset_syn_when_app_scope_exists_without_pid() {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let cdn_ip = Ipv4Addr::new(23, 61, 202, 142);
         let src_port = 40007;
@@ -11226,14 +11174,14 @@ mod tests {
         let frame = build_ipv4_tcp_frame_with_flags(src_ip, cdn_ip, src_port, dst_port, 0x02);
         let mut inline_cache: InlineCache = HashMap::new();
 
-        assert!(should_route_to_vpn_with_inline_cache_and_tcp_owner_lookup(
+        assert!(!should_route_to_vpn_with_inline_cache_and_tcp_owner_lookup(
             &frame,
             &snapshot,
             &mut inline_cache,
             true,
             |_ip, _port| None,
         ));
-        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+        assert!(inline_cache.is_empty());
     }
 
     #[test]
@@ -11335,20 +11283,7 @@ mod tests {
     }
 
     #[test]
-    fn test_browser_http_scope_matches_exact_browser_stems() {
-        assert!(process_name_in_browser_http_scope(
-            "C:\\Program Files\\Google\\Chrome\\Application\\Chrome.exe"
-        ));
-        assert!(process_name_in_browser_http_scope(
-            "C:\\Browsers\\chromium-browser.exe"
-        ));
-        assert!(process_name_in_browser_http_scope("opera-browser.exe"));
-        assert!(!process_name_in_browser_http_scope("chrome_helper.exe"));
-        assert!(!process_name_in_browser_http_scope("Discord.exe"));
-    }
-
-    #[test]
-    fn test_tcp_api_tunneling_allows_browser_owned_roblox_http_syn() {
+    fn test_tcp_api_tunneling_does_not_allow_browser_owned_roblox_http_syn() {
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let roblox_api_ip = Ipv4Addr::new(128, 116, 50, 3);
         let src_port = 40010;
@@ -11374,7 +11309,7 @@ mod tests {
         let mut inline_cache: InlineCache = HashMap::new();
 
         assert!(
-            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
                 &frame,
                 &snapshot,
                 &mut inline_cache,
@@ -11398,7 +11333,7 @@ mod tests {
                 },
             )
         );
-        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+        assert!(inline_cache.is_empty());
     }
 
     #[test]
@@ -11563,7 +11498,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tcp_api_tunneling_allows_browser_owned_active_bootstrap_http_syn() {
+    fn test_tcp_api_tunneling_does_not_allow_browser_owned_active_bootstrap_http_syn() {
         let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
         crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
 
@@ -11594,7 +11529,7 @@ mod tests {
         let mut inline_cache: InlineCache = HashMap::new();
 
         assert!(
-            should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
                 &frame,
                 &snapshot,
                 &mut inline_cache,
@@ -11615,7 +11550,7 @@ mod tests {
                 },
             )
         );
-        assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+        assert!(inline_cache.is_empty());
 
         crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
     }

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6998,7 +6998,7 @@ where
                 .unwrap_or(false)
         };
         let tcp_api_bootstrap_allowed =
-            is_tcp_api_bootstrap_syn && tcp_api_bootstrap_owned_by_tunnel;
+            is_route_assist_http_dst && tcp_api_bootstrap_owned_by_tunnel;
         let is_game_dst = if protocol == Protocol::Udp {
             super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
         } else {
@@ -11079,11 +11079,16 @@ mod tests {
 
     #[test]
     fn test_tcp_api_tunneling_bootstraps_asset_syn_when_tunnel_process_is_active() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let cdn_ip = Ipv4Addr::new(184, 87, 193, 160);
         let src_port = 40002;
         let dst_port = 80;
         let tunnel_pid = 1234;
+
+        crate::roblox_proxy::hosts::set_active_bootstrap_ips_for_test([cdn_ip]);
 
         let snapshot = ProcessSnapshot {
             connections: HashMap::new(),
@@ -11115,6 +11120,8 @@ mod tests {
             },
         ));
         assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
     }
 
     #[test]
@@ -11186,11 +11193,16 @@ mod tests {
 
     #[test]
     fn test_tcp_api_tunneling_bootstraps_asset_syn_when_owner_pid_name_matches_app_scope() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let cdn_ip = Ipv4Addr::new(23, 61, 202, 142);
         let src_port = 40008;
         let dst_port = 80;
         let tunnel_pid = 8580;
+
+        crate::roblox_proxy::hosts::set_active_bootstrap_ips_for_test([cdn_ip]);
 
         let snapshot = ProcessSnapshot {
             connections: HashMap::new(),
@@ -11231,6 +11243,8 @@ mod tests {
             )
         );
         assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
     }
 
     #[test]
@@ -11388,11 +11402,16 @@ mod tests {
 
     #[test]
     fn test_tcp_api_tunneling_allows_tunnel_owned_http_syn_for_mss_clamp() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
         let src_ip = Ipv4Addr::new(10, 0, 0, 2);
         let cdn_ip = Ipv4Addr::new(23, 61, 202, 142);
         let src_port = 40018;
         let dst_port = 443;
         let tunnel_pid = 1234;
+
+        crate::roblox_proxy::hosts::set_active_bootstrap_ips_for_test([cdn_ip]);
 
         let snapshot = ProcessSnapshot {
             connections: HashMap::new(),
@@ -11433,6 +11452,60 @@ mod tests {
             )
         );
         assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_rejects_tunnel_owned_unrelated_http_syn() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let unrelated_ip = Ipv4Addr::new(93, 184, 216, 34);
+        let src_port = 40020;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, unrelated_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(tunnel_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == tunnel_pid {
+                        Some("RobloxPlayerBeta.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.is_empty());
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -6985,12 +6985,19 @@ where
             && matches!(dst_port, 80 | 443)
             && (super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
                 || crate::roblox_proxy::hosts::is_active_bootstrap_ip(dst_ip));
-        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn && !snapshot_tunnel_hit {
+        let tcp_api_bootstrap_published_port =
+            is_tcp_api_bootstrap_syn && snapshot.explicit_tunnel_tcp_ports.contains(&src_port);
+        let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn
+            && !snapshot_tunnel_hit
+            && !tcp_api_bootstrap_published_port
+        {
             tcp_owner_lookup(src_ip, src_port)
         } else {
             None
         };
-        let tcp_api_bootstrap_owned_by_tunnel = if is_tcp_api_bootstrap_syn && snapshot_tunnel_hit {
+        let tcp_api_bootstrap_owned_by_tunnel = if is_tcp_api_bootstrap_syn
+            && (snapshot_tunnel_hit || tcp_api_bootstrap_published_port)
+        {
             true
         } else {
             tcp_api_bootstrap_owner
@@ -7019,7 +7026,7 @@ where
                 });
                 if spec_count < 20 {
                     log::info!(
-                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={}, route_assist_http_dst={})",
+                        "TCP API SPECULATIVE TUNNEL: {}:{} -> {}:{} (initial_syn={}, bootstrap_owner={:?}, owner_is_tunnel={}, route_assist_http_dst={}, published_port={})",
                         src_ip,
                         src_port,
                         dst_ip,
@@ -7027,7 +7034,8 @@ where
                         is_tcp_initial_syn,
                         tcp_api_bootstrap_owner,
                         tcp_api_bootstrap_owned_by_tunnel,
-                        is_route_assist_http_dst
+                        is_route_assist_http_dst,
+                        tcp_api_bootstrap_published_port
                     );
                 }
             } else {
@@ -11505,6 +11513,42 @@ mod tests {
                 },
             )
         );
+        assert!(inline_cache.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_rejects_published_port_to_unrelated_http_syn() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let unrelated_ip = Ipv4Addr::new(93, 184, 216, 34);
+        let src_port = 40021;
+        let dst_port = 443;
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: ["robloxplayerbeta.exe".to_string()].into_iter().collect(),
+            tunnel_pids: HashSet::new(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: [src_port].into_iter().collect(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: [src_port].into_iter().collect(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame = build_ipv4_tcp_frame_with_flags(src_ip, unrelated_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(!should_route_to_vpn_with_inline_cache_and_tcp_owner_lookup(
+            &frame,
+            &snapshot,
+            &mut inline_cache,
+            true,
+            |_ip, _port| None,
+        ));
         assert!(inline_cache.is_empty());
     }
 

--- a/swifttunnel-core/src/vpn/process_cache.rs
+++ b/swifttunnel-core/src/vpn/process_cache.rs
@@ -384,8 +384,8 @@ impl ProcessSnapshot {
 
         // Process not detected - use strict IP range check for speculative tunneling.
         // This remains UDP-only in the snapshot cache. The packet classifier
-        // handles TCP API tunneling separately so owner-table checks can keep
-        // browser routing scoped to Roblox HTTP(S) instead of all web traffic.
+        // handles TCP API tunneling separately so owner-table checks keep Route
+        // Assist tied to configured tunnel processes.
         protocol == Protocol::Udp && is_game_server(dst_ip, dst_port, protocol, api_tunneling)
     }
 

--- a/swifttunnel-desktop/src-tauri/resources/tools/goodbyedpi/README.md
+++ b/swifttunnel-desktop/src-tauri/resources/tools/goodbyedpi/README.md
@@ -1,0 +1,11 @@
+Place the bundled GoodbyeDPI release payload here for Windows builds.
+
+SwiftTunnel looks for:
+
+- `goodbyedpi.exe`
+- `x86_64/goodbyedpi.exe`
+- `x86/goodbyedpi.exe`
+
+Keep the matching WinDivert files from the GoodbyeDPI release beside the executable.
+Include the upstream GoodbyeDPI and WinDivert license/readme files with the payload.
+The helper is launched only with SwiftTunnel's generated Roblox hostlist.

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -397,6 +397,7 @@ pub async fn vpn_connect(
         forced_servers,
         game_process_performance,
         enable_api_tunneling,
+        enable_country_ban,
     ) = (
         if settings_snapshot.custom_relay_server.is_empty() {
             None
@@ -408,6 +409,7 @@ pub async fn vpn_connect(
         settings_snapshot.forced_servers.clone(),
         settings_snapshot.game_process_performance,
         settings_snapshot.enable_api_tunneling,
+        settings_snapshot.enable_country_ban,
     );
     if custom_relay.is_some() && auto_routing {
         log::info!("Auto-routing disabled for this session because custom_relay_server is set");
@@ -465,6 +467,7 @@ pub async fn vpn_connect(
             binding_preference,
             game_process_performance,
             enable_api_tunneling,
+            enable_country_ban,
         ),
     )
     .await;

--- a/swifttunnel-desktop/src-tauri/src/harness.rs
+++ b/swifttunnel-desktop/src-tauri/src/harness.rs
@@ -33,6 +33,7 @@ struct HarnessCli {
     password: Option<String>,
     custom_relay_server: Option<String>,
     enable_api_tunneling: bool,
+    enable_country_ban: bool,
     connect: bool,
     connect_wait_ms: u64,
     game_presets: Vec<String>,
@@ -465,6 +466,7 @@ async fn run_connect_flow(state: &AppState, cli: &HarnessCli) -> Result<ConnectS
         binding_preference,
         game_process_performance,
         enable_api_tunneling,
+        enable_country_ban,
     ) = {
         let mut settings = state.settings.lock();
         apply_adapter_override(&mut settings, cli);
@@ -494,6 +496,7 @@ async fn run_connect_flow(state: &AppState, cli: &HarnessCli) -> Result<ConnectS
             binding_preference,
             snapshot.game_process_performance,
             cli.enable_api_tunneling || snapshot.enable_api_tunneling,
+            cli.enable_country_ban || snapshot.enable_country_ban,
         )
     };
 
@@ -524,6 +527,7 @@ async fn run_connect_flow(state: &AppState, cli: &HarnessCli) -> Result<ConnectS
             binding_preference,
             game_process_performance,
             enable_api_tunneling,
+            enable_country_ban,
         )
         .await
         .map_err(|err| swifttunnel_core::vpn::user_friendly_error(&err))?;
@@ -717,6 +721,7 @@ fn parse_cli(raw_args: &[String]) -> Result<HarnessCli, ParseOutcome> {
             "--password" => cli.password = Some(next(flag, &mut idx)?),
             "--custom-relay" => cli.custom_relay_server = Some(next(flag, &mut idx)?),
             "--enable-api-tunneling" => cli.enable_api_tunneling = true,
+            "--enable-country-ban" => cli.enable_country_ban = true,
             "--connect" => cli.connect = true,
             "--connect-wait-ms" => {
                 let value = next(flag, &mut idx)?;

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -147,6 +147,14 @@ fn sync_runtime_assets(app: &tauri::App) {
             ]),
             exe_dir.join("tools").join("nvidiaProfileInspector"),
         ),
+        (
+            "goodbyedpi",
+            first_existing(vec![
+                resource_dir.join("tools").join("goodbyedpi"),
+                resource_dir.join("goodbyedpi"),
+            ]),
+            exe_dir.join("tools").join("goodbyedpi"),
+        ),
     ];
 
     for (name, source, destination) in targets {

--- a/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
+++ b/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
@@ -202,6 +202,11 @@ export function ConnectTab() {
     saveDebounced();
   }
 
+  function setCountryBan(enabled: boolean) {
+    update({ enable_country_ban: enabled });
+    saveDebounced();
+  }
+
   const canConnect =
     isIdle &&
     (settings.auto_routing_enabled || Boolean(settings.selected_region));
@@ -411,6 +416,11 @@ export function ConnectTab() {
         enabled={settings.enable_api_tunneling}
         disabled={isConnected || isTransitioning}
         onChange={setRouteAssist}
+      />
+      <CountryBanPanel
+        enabled={settings.enable_country_ban}
+        disabled={isConnected || isTransitioning}
+        onChange={setCountryBan}
       />
 
       {/* ── Throughput (connected) ── */}
@@ -694,7 +704,7 @@ function RouteAssistPanel({
           >
             Roblox Route Assist
           </h3>
-          <Tooltip content="Routes Roblox login/API HTTP(S) through the selected relay, including browser-owned Roblox auth traffic. Non-Roblox browser traffic still bypasses SwiftTunnel.">
+          <Tooltip content="Routes Roblox-owned login/API HTTP(S) through the selected relay.">
             <span className="inline-flex">
               <InfoIcon />
             </span>
@@ -713,13 +723,92 @@ function RouteAssistPanel({
           )}
         </div>
         <p className="mt-1 max-w-[640px] text-[11.5px] leading-snug text-text-muted">
-          Use this when bypassing a network ban, or to increase the chance Roblox places you near your tunneled region.
+          Use this for Roblox-owned TCP/API relay routing and region placement.
         </p>
       </div>
       <Toggle
         enabled={enabled}
         disabled={disabled}
         ariaLabel="Roblox Route Assist"
+        onChange={onChange}
+      />
+    </section>
+  );
+}
+
+function CountryBanPanel({
+  enabled,
+  disabled,
+  onChange,
+}: {
+  enabled: boolean;
+  disabled: boolean;
+  onChange: (enabled: boolean) => void;
+}) {
+  return (
+    <section
+      className="flex items-center justify-between gap-4 rounded-[var(--radius-card)] px-4 py-3 transition-colors"
+      style={{
+        backgroundColor: enabled
+          ? "var(--color-accent-primary-soft-8)"
+          : "var(--color-bg-card)",
+        border: `1px solid ${
+          enabled
+            ? "var(--color-accent-primary-soft-20)"
+            : "var(--color-border-subtle)"
+        }`,
+        boxShadow: enabled
+          ? "inset 0 1px 0 rgba(255,255,255,0.04)"
+          : "inset 0 1px 0 rgba(255,255,255,0.025)",
+      }}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={enabled ? "var(--color-text-primary)" : "var(--color-text-muted)"}
+            strokeWidth="1.85"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 3v18" />
+            <path d="M5 7h10a4 4 0 0 1 0 8H5" />
+          </svg>
+          <h3
+            className="text-[12.5px] font-semibold text-text-primary"
+            style={{ letterSpacing: "-0.005em" }}
+          >
+            Bypass country bans
+          </h3>
+          <Tooltip content="Starts the scoped GoodbyeDPI helper for Roblox hostnames. It applies to both browser and Roblox app traffic.">
+            <span className="inline-flex">
+              <InfoIcon />
+            </span>
+          </Tooltip>
+          {enabled && (
+            <span
+              className="pill-base"
+              style={{
+                backgroundColor: "var(--color-bg-base)",
+                color: "var(--color-text-primary)",
+                border: "1px solid var(--color-border-default)",
+              }}
+            >
+              ON
+            </span>
+          )}
+        </div>
+        <p className="mt-1 max-w-[640px] text-[11.5px] leading-snug text-text-muted">
+          Use this when Roblox is blocked by country-level DPI. Applies to browser launch/login and the Roblox app.
+        </p>
+      </div>
+      <Toggle
+        enabled={enabled}
+        disabled={disabled}
+        ariaLabel="Bypass country bans"
         onChange={onChange}
       />
     </section>

--- a/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
+++ b/swifttunnel-desktop/src/components/settings/SettingsTab.tsx
@@ -467,7 +467,7 @@ export function SettingsTab() {
           label="Roblox Route Assist"
           desc="Use when bypassing a network ban or to improve region-matching odds"
           tooltip={
-            <Tooltip content="Routes Roblox login/API HTTP(S), including browser-owned Roblox auth traffic, through the relay. Non-Roblox browser traffic still bypasses SwiftTunnel.">
+            <Tooltip content="Routes Roblox-owned login/API HTTP(S) through the relay.">
               <span className="inline-flex">
                 <InfoIcon />
               </span>
@@ -478,6 +478,24 @@ export function SettingsTab() {
             enabled={settings.enable_api_tunneling}
             ariaLabel="Roblox Route Assist"
             onChange={(v) => set({ enable_api_tunneling: v })}
+          />
+        </Row>
+
+        <Row
+          label="Bypass country bans"
+          desc="Use when Roblox is blocked by country-level DPI"
+          tooltip={
+            <Tooltip content="Starts the scoped GoodbyeDPI helper for Roblox hostnames. It applies to both browser and Roblox app traffic.">
+              <span className="inline-flex">
+                <InfoIcon />
+              </span>
+            </Tooltip>
+          }
+        >
+          <Toggle
+            enabled={settings.enable_country_ban}
+            ariaLabel="Bypass country bans"
+            onChange={(v) => set({ enable_country_ban: v })}
           />
         </Row>
 

--- a/swifttunnel-desktop/src/lib/settings.contract.test.ts
+++ b/swifttunnel-desktop/src/lib/settings.contract.test.ts
@@ -31,6 +31,7 @@ const RUST_SETTINGS_FIELDS = [
   "adapter_binding_mode",
   "game_process_performance",
   "enable_api_tunneling",
+  "enable_country_ban",
 ];
 
 function extractInterfaceFields(source: string, interfaceName: string): string[] {

--- a/swifttunnel-desktop/src/lib/settings.ts
+++ b/swifttunnel-desktop/src/lib/settings.ts
@@ -68,6 +68,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     unbind_cpu0: false,
   },
   enable_api_tunneling: false,
+  enable_country_ban: false,
 };
 
 type LegacyNetworkConfig = Partial<NetworkConfig> & {

--- a/swifttunnel-desktop/src/lib/types.ts
+++ b/swifttunnel-desktop/src/lib/types.ts
@@ -385,6 +385,7 @@ export interface AppSettings {
   adapter_binding_mode: "smart_auto" | "manual";
   game_process_performance: GameProcessPerformanceSettings;
   enable_api_tunneling: boolean;
+  enable_country_ban: boolean;
 }
 
 // ── System ──

--- a/swifttunnel-desktop/src/mocks/tauri-core.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-core.ts
@@ -70,6 +70,7 @@ const MOCK_SETTINGS: AppSettings = {
     unbind_cpu0: false,
   },
   enable_api_tunneling: false,
+  enable_country_ban: false,
 };
 
 let mockVpnConnected = false;


### PR DESCRIPTION
## Summary
- remove browser-owned Roblox HTTP(S) from Route Assist relay classification
- add a separate `Bypass country bans` setting and UI control that starts scoped GoodbyeDPI for Roblox hostnames
- wire the new setting through Rust settings, Tauri connect, harness/testbench CLI, desktop defaults, and docs

## Web research
Checked the official GoodbyeDPI README and WinDivert repository. GoodbyeDPI supports a `--blacklist <txtfile>` hostlist and modern `-9` mode, and it operates at the packet-divert layer rather than per-browser ownership. That makes a separate process-agnostic helper the right fit for both browser and Roblox app traffic.

## Failure-mode plan
Primary success is that Route Assist remains relay-scoped to Roblox-owned TCP/API traffic while `Bypass country bans` independently controls GoodbyeDPI. Missing or failed GoodbyeDPI startup is diagnostic-only and does not block VPN connect. Cleanup is best-effort on disconnect/drop, and the helper is scoped by an exact Roblox hostlist rather than process-name substring matching.

## Validation
- `cargo fmt --check`
- `npm test -- --run`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

`cargo test -p swifttunnel-core goodbyedpi` is blocked locally by the existing `windows-future` / `windows_core::imp` dependency mismatch before local crate code compiles.