### PR TITLE
Skip IPv6 block when adapter has no IPv6

### DIFF
--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -58,8 +58,8 @@ use serde::Serialize;
 use crate::process_names::process_name_matches_any_tunnel_app;
 
 use super::ipv6_recovery::{
-    IPV6_BLOCK_REMOTE_IPS, IPV6_BLOCK_RULE_NAME, delete_ipv6_marker, restore_ipv6_from_marker,
-    write_ipv6_marker_firewall,
+    IPV6_BLOCK_REMOTE_IPS, IPV6_BLOCK_RULE_NAME, delete_ipv6_marker, has_ipv6_binding_native,
+    restore_ipv6_from_marker, write_ipv6_marker_firewall,
 };
 use super::process_cache::{DNS_PORT, LockFreeProcessCache, ProcessSnapshot};
 use super::process_tracker::{ConnectionKey, Protocol};
@@ -3757,6 +3757,18 @@ impl ParallelInterceptor {
     where
         F: Fn(&[&str], u64) -> CommandRunOutput,
     {
+        self.disable_ipv6_with_runner_and_probe(runner, has_ipv6_binding_native)
+    }
+
+    fn disable_ipv6_with_runner_and_probe<F, P>(
+        &mut self,
+        runner: F,
+        ipv6_probe: P,
+    ) -> VpnResult<()>
+    where
+        F: Fn(&[&str], u64) -> CommandRunOutput,
+        P: Fn(u32) -> Option<bool>,
+    {
         let friendly_name = match &self.physical_adapter_friendly_name {
             Some(name) => name.clone(),
             None => {
@@ -3779,6 +3791,34 @@ impl ParallelInterceptor {
                 "IPv6-only network: SwiftTunnel needs IPv4 connectivity to tunnel game traffic."
                     .to_string(),
             ));
+        }
+
+        if let Some(if_index) = self.physical_adapter_if_index {
+            match ipv6_probe(if_index) {
+                Some(true) => {
+                    log::debug!(
+                        "Selected adapter {} (if_index={}) has IPv6; installing block rule",
+                        friendly_name,
+                        if_index
+                    );
+                }
+                Some(false) => {
+                    log::info!(
+                        "Skipping IPv6 firewall block on {} (if_index={}): selected adapter has no IPv6 address/binding",
+                        friendly_name,
+                        if_index
+                    );
+                    self.ipv6_was_disabled = false;
+                    return Ok(());
+                }
+                None => {
+                    log::debug!(
+                        "Could not determine IPv6 state for {} (if_index={}); falling back to firewall block",
+                        friendly_name,
+                        if_index
+                    );
+                }
+            }
         }
 
         let firewall_interface_type =
@@ -10585,6 +10625,73 @@ mod tests {
         assert!(args.contains(&format!("remoteip={IPV6_BLOCK_REMOTE_IPS}")));
         assert!(args.contains(&"interfacetype=lan".to_string()));
         assert!(!args.contains(&"remoteip=::/0".to_string()));
+    }
+
+    #[test]
+    fn test_disable_ipv6_skips_firewall_when_selected_adapter_has_no_ipv6() {
+        delete_ipv6_marker();
+        let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
+        interceptor.physical_adapter_if_index = Some(42);
+
+        let runner_calls = std::cell::Cell::new(0);
+        interceptor
+            .disable_ipv6_with_runner_and_probe(
+                |_, _| {
+                    runner_calls.set(runner_calls.get() + 1);
+                    CommandRunOutput {
+                        success: false,
+                        timed_out: false,
+                        exit_code: Some(1),
+                        stdout: String::new(),
+                        stderr: "runner should not be called".to_string(),
+                    }
+                },
+                |if_index| {
+                    assert_eq!(if_index, 42);
+                    Some(false)
+                },
+            )
+            .unwrap();
+
+        assert_eq!(runner_calls.get(), 0);
+        assert!(!interceptor.ipv6_was_disabled);
+        delete_ipv6_marker();
+    }
+
+    #[test]
+    fn test_disable_ipv6_probe_unknown_still_attempts_firewall_block() {
+        delete_ipv6_marker();
+        let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
+        interceptor.physical_adapter_if_index = Some(42);
+
+        let runner_calls = std::cell::Cell::new(0);
+        let error = interceptor
+            .disable_ipv6_with_runner_and_probe(
+                |_, _| {
+                    runner_calls.set(runner_calls.get() + 1);
+                    CommandRunOutput {
+                        success: false,
+                        timed_out: false,
+                        exit_code: Some(1),
+                        stdout: String::new(),
+                        stderr:
+                            "The following command was not found: advfirewall firewall add rule."
+                                .to_string(),
+                    }
+                },
+                |if_index| {
+                    assert_eq!(if_index, 42);
+                    None
+                },
+            )
+            .expect_err("unknown IPv6 probe must not skip the firewall block");
+
+        assert_eq!(runner_calls.get(), 2);
+        assert!(error.to_string().contains("IPv6 block firewall rule"));
+        assert!(interceptor.ipv6_was_disabled);
+        delete_ipv6_marker();
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -3808,7 +3808,6 @@ impl ParallelInterceptor {
                         friendly_name,
                         if_index
                     );
-                    self.ipv6_was_disabled = false;
                     return Ok(());
                 }
                 None => {
@@ -10656,6 +10655,28 @@ mod tests {
 
         assert_eq!(runner_calls.get(), 0);
         assert!(!interceptor.ipv6_was_disabled);
+        delete_ipv6_marker();
+    }
+
+    #[test]
+    fn test_disable_ipv6_skip_preserves_existing_restore_state() {
+        delete_ipv6_marker();
+        let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
+        interceptor.physical_adapter_if_index = Some(42);
+        interceptor.ipv6_was_disabled = true;
+
+        interceptor
+            .disable_ipv6_with_runner_and_probe(
+                |_, _| panic!("runner should not be called"),
+                |if_index| {
+                    assert_eq!(if_index, 42);
+                    Some(false)
+                },
+            )
+            .unwrap();
+
+        assert!(interceptor.ipv6_was_disabled);
         delete_ipv6_marker();
     }
 

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -10681,6 +10681,38 @@ mod tests {
     }
 
     #[test]
+    fn test_disable_ipv6_probe_true_installs_firewall_block() {
+        delete_ipv6_marker();
+        let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
+        interceptor.physical_adapter_if_index = Some(42);
+
+        let runner_calls = std::cell::Cell::new(0);
+        interceptor
+            .disable_ipv6_with_runner_and_probe(
+                |_, _| {
+                    runner_calls.set(runner_calls.get() + 1);
+                    CommandRunOutput {
+                        success: true,
+                        timed_out: false,
+                        exit_code: Some(0),
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    }
+                },
+                |if_index| {
+                    assert_eq!(if_index, 42);
+                    Some(true)
+                },
+            )
+            .unwrap();
+
+        assert_eq!(runner_calls.get(), 2);
+        assert!(interceptor.ipv6_was_disabled);
+        delete_ipv6_marker();
+    }
+
+    #[test]
     fn test_disable_ipv6_probe_unknown_still_attempts_firewall_block() {
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());


### PR DESCRIPTION
## Summary

- Skip installing the IPv6 firewall block rule when the selected Windows interface has no IPv6 address/binding.
- Keep the existing fail-closed `netsh` block path when the native IPv6 probe says IPv6 exists or cannot determine state.
- Add targeted tests for skip, restore-state preservation, `Some(true)`, and unknown-probe fallback behavior.

## Web research

- Checked Microsoft `netsh advfirewall` docs for firewall rule management and current Windows support: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/netsh-advfirewall
- Checked Microsoft `New-NetFirewallRule` docs for `RemoteAddress` and `InterfaceType` as an alternate implementation path: https://learn.microsoft.com/en-us/powershell/module/netsecurity/new-netfirewallrule
- Checked Microsoft `GetAdaptersAddresses` docs for `AF_INET6` and `ERROR_NO_DATA` behavior: https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses

Options considered:

- Keep direct `netsh`, but first use the existing native IPv6-address probe to skip systems/adapters with no IPv6 path.
- Switch to PowerShell `New-NetFirewallRule`, which supports IPv6 subnets and interface types but reintroduces the slower PowerShell/CIM path this code avoided.
- Split the two IPv6 prefixes into separate `netsh` rules, which may help list parsing but would still fail on hosts where IPv6 rule parsing is unavailable because IPv6 is disabled.
- Remove IPv6 blocking entirely, which would allow IPv6 game traffic to bypass the IPv4-only tunnel.

Chosen approach: keep direct `netsh` and add the no-new-dependency native pre-check. This preserves the current fast path and fail-closed behavior while avoiding the reported failure for users who already disabled IPv6 on the active adapter.

## Failure-mode plan

- Primary success: if the selected physical adapter has IPv6, SwiftTunnel must install the outbound IPv6 block before split tunnel setup can succeed. If the adapter has no IPv6 address/binding, success is skipping firewall mutation without writing a recovery marker.
- Failure classes: stale-rule delete remains best-effort and idempotent; native probe failure is diagnostic-only and falls through to `netsh`; `netsh` add failure remains fatal.
- Trigger signals: use the structured `Option<bool>` from the native IPv6 probe, not substring matching on localized or incidental `netsh` text.
- Partial success and races: the recovery marker is still written only when firewall mutation is attempted. Add failures preserve restore state so startup/disconnect cleanup can retry.
- Tests: `Some(false)` skips netsh without marking IPv6 disabled, skip preserves any existing restore state, `Some(true)` still installs the block, and `None` still attempts the firewall block and preserves the fatal error path.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `npm ci`
- `npm test -- --run` (123 tests)
- `npx tsc --noEmit`
- `npm run build`
- GitHub CI on latest head: Frontend Build, Rust Check (GitHub Windows), Split Tunnel Testbench Availability
- Greptile on latest head: completed successfully, confidence 5/5, safe to merge

Known local caveat:

- `cargo test -p swifttunnel-core test_disable_ipv6 -- --nocapture` cannot compile locally on macOS because the repo hits the known `windows-future` / `windows-core` mismatch before SwiftTunnel tests run (`windows_core::imp::IMarshal`, `windows_core::imp::marshaler`, and `windows_threading::submit` missing). GitHub Windows CI is the authoritative Rust gate for this change.
