### PR TITLE
[codex] Fix repair driver binding refresh

### DIFF
--- a/swifttunnel-desktop/src/lib/repairCenter.test.ts
+++ b/swifttunnel-desktop/src/lib/repairCenter.test.ts
@@ -106,14 +106,37 @@ function makeDeps(overrides: Partial<RepairCenterDeps> = {}): RepairCenterDeps {
 }
 
 describe("repair center logic", () => {
-  it("does not run driver repair when structured health is already ready", async () => {
-    const deps = makeDeps();
+  it("runs driver repair even when global health is ready so adapter bindings can be refreshed", async () => {
+    const deps = makeDeps({
+      systemRepairDriver: vi.fn().mockResolvedValue(readyDriver),
+    });
 
     const report = await runRepairIssue("driver", deps, {
       settings: DEFAULT_SETTINGS,
     });
 
-    expect(report.status).toBe("healthy");
+    expect(report.status).toBe("fixed");
+    expect(report.changed).toBe(true);
+    expect(deps.systemRepairDriver).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run driver repair when Windows requires a reboot first", async () => {
+    const deps = makeDeps({
+      systemCheckDriver: vi.fn().mockResolvedValue({
+        ...readyDriver,
+        ready: false,
+        status: "reboot_required",
+        message: "Reboot required to finish driver installation.",
+        reboot_required: true,
+        recommended_action: "reboot",
+      }),
+    });
+
+    const report = await runRepairIssue("driver", deps, {
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(report.status).toBe("needs_reboot");
     expect(deps.systemRepairDriver).not.toHaveBeenCalled();
   });
 

--- a/swifttunnel-desktop/src/lib/repairCenter.ts
+++ b/swifttunnel-desktop/src/lib/repairCenter.ts
@@ -310,10 +310,6 @@ async function repairDriver(deps: RepairCenterDeps): Promise<RepairReport> {
     return driverReport(deps, before, "unsupported", "Driver repair is unsupported.", false, admin);
   }
 
-  if (before.ready) {
-    return driverReport(deps, before, "healthy", "Split tunnel driver is healthy.", false, admin);
-  }
-
   if (before.reboot_required || before.recommended_action === "reboot") {
     return driverReport(
       deps,


### PR DESCRIPTION
## Summary
- make Repair Center driver repair run even when the global WinpkFilter driver health check is already ready
- keep reboot-required driver states as a stop condition before repair
- update Repair Center tests for the adapter-binding regression and reboot negative path

## Root cause
The connect screen reports `winpkfilter_binding_missing` when the active adapter is missing the `nt_ndisrd` binding, but Repair Center short-circuited as Healthy when the global NDISRD service check passed. That made the user-facing “Repair driver” path skip the backend repair command that refreshes adapter bindings.

## Failure-mode plan
- Primary success: running the backend driver repair path so adapter binding refresh can happen; global driver readiness alone is not sufficient.
- Repairable: active-adapter WinpkFilter binding missing while the driver service is globally ready.
- Fatal/blocked: unsupported platform or reboot-required driver state.
- Diagnostic-only: adapter routing checks remain separate and non-mutating.
- Loop guard: this change only affects explicit Repair Center driver repair; existing connect one-shot repair guards are unchanged.

## Validation
- `npm test -- --run src/lib/repairCenter.test.ts`