### PR TITLE
[codex] Harden repair center error handling

### DIFF
--- a/swifttunnel-desktop/src-tauri/src/commands/system.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/system.rs
@@ -1734,6 +1734,24 @@ pub async fn system_cleanup() -> Result<(), String> {
     .map_err(|e| format!("Cleanup task failed: {}", e))?
 }
 
+/// Cleanup tunnel-specific runtime leftovers without removing install-time
+/// state such as the driver package, startup registration, optimizer settings,
+/// hosts entries, or Roblox settings.
+#[tauri::command]
+pub async fn system_cleanup_tunnel_state() -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        log::info!("Running tunnel-state cleanup");
+        swifttunnel_core::vpn::recover_tso_on_startup();
+        swifttunnel_core::vpn::recover_ipv6_on_startup();
+        swifttunnel_core::vpn::wfp_block::cleanup_stale();
+        swifttunnel_core::vpn::wfp_block::cleanup();
+        swifttunnel_core::vpn::SplitTunnelDriver::cleanup_stale_state();
+        Ok::<(), String>(())
+    })
+    .await
+    .map_err(|e| format!("Tunnel-state cleanup task failed: {}", e))?
+}
+
 /// Stop + start the NDISRD kernel service without reinstalling the driver.
 ///
 /// Intended for the "wedged NDIS state" case: driver is installed, service

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -408,6 +408,7 @@ pub fn run() {
             commands::system::system_show_notification,
             commands::system::system_launched_from_startup,
             commands::system::system_cleanup,
+            commands::system::system_cleanup_tunnel_state,
             commands::system::system_uninstall,
             commands::system::system_copy_log_to_clipboard,
         ])

--- a/swifttunnel-desktop/src/components/repair/RepairTab.tsx
+++ b/swifttunnel-desktop/src/components/repair/RepairTab.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSettingsStore } from "../../stores/settingsStore";
 import { useToastStore } from "../../stores/toastStore";
+import { formatErrorMessage } from "../../lib/errors";
 import {
   serverGetLatencies,
   serverRefresh,
   systemCheckDriver,
-  systemCleanup,
+  systemCleanupTunnelState,
   systemGetStartupRegistration,
   systemIsAdmin,
   systemRepairDriver,
@@ -20,6 +21,7 @@ import {
 import {
   formatRepairForSupport,
   makeInitialRepairReports,
+  parseSavedRepairResult,
   REPAIR_ISSUES,
   restoreRepairRollback,
   runRepairIssue,
@@ -30,6 +32,7 @@ import {
   type RepairIssueId,
   type RepairReport,
   type RepairStatus,
+  type SavedRepairResult,
 } from "../../lib/repairCenter";
 import { SupportSection } from "../support/SupportSection";
 import { SupportToolsSection } from "../support/SupportToolsSection";
@@ -42,7 +45,7 @@ const repairDeps: RepairCenterDeps = {
   serverGetLatencies,
   serverRefresh,
   systemCheckDriver,
-  systemCleanup,
+  systemCleanupTunnelState,
   systemGetStartupRegistration,
   systemIsAdmin,
   systemRepairDriver,
@@ -53,11 +56,6 @@ const repairDeps: RepairCenterDeps = {
   vpnGetPing,
   vpnGetState,
   vpnListNetworkAdapters,
-};
-
-type SavedRepairResult = {
-  issue: RepairIssueId;
-  report: RepairReport;
 };
 
 export function RepairTab() {
@@ -141,7 +139,7 @@ export function RepairTab() {
     } catch (error) {
       addToast({
         type: "error",
-        message: `Could not copy repair details: ${String(error)}`,
+        message: `Could not copy repair details: ${formatErrorMessage(error)}`,
       });
     }
   }
@@ -452,24 +450,20 @@ function statusBorderColor(status: RepairStatus): string {
 }
 
 function saveRepairResult(issue: RepairIssueId, report: RepairReport) {
-  localStorage.setItem(
-    LAST_REPAIR_STORAGE_KEY,
-    JSON.stringify({ issue, report }),
-  );
+  try {
+    localStorage.setItem(
+      LAST_REPAIR_STORAGE_KEY,
+      JSON.stringify({ issue, report }),
+    );
+  } catch {
+    // Non-fatal: repair reporting should still work when storage is blocked.
+  }
 }
 
 function loadSavedRepairResult(): SavedRepairResult | null {
   try {
     const raw = localStorage.getItem(LAST_REPAIR_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<SavedRepairResult>;
-    if (!parsed.issue || !parsed.report) return null;
-    if (!REPAIR_ISSUES.some((issue) => issue.id === parsed.issue)) return null;
-    if (!Array.isArray(parsed.report.entries)) return null;
-    return {
-      issue: parsed.issue,
-      report: parsed.report,
-    };
+    return parseSavedRepairResult(raw);
   } catch {
     return null;
   }

--- a/swifttunnel-desktop/src/lib/commands.test.ts
+++ b/swifttunnel-desktop/src/lib/commands.test.ts
@@ -14,6 +14,7 @@ import {
   settingsGenerateNetworkDiagnosticsBundle,
   systemCopyLogToClipboard,
   systemCleanup,
+  systemCleanupTunnelState,
   systemGetStartupRegistration,
   systemRestartAsAdmin,
   systemInstallDriver,
@@ -91,6 +92,12 @@ describe("lib/commands", () => {
     invoke.mockResolvedValue(undefined);
     await expect(systemCleanup()).resolves.toBeUndefined();
     expect(invoke).toHaveBeenCalledWith("system_cleanup");
+  });
+
+  it("systemCleanupTunnelState invokes backend", async () => {
+    invoke.mockResolvedValue(undefined);
+    await expect(systemCleanupTunnelState()).resolves.toBeUndefined();
+    expect(invoke).toHaveBeenCalledWith("system_cleanup_tunnel_state");
   });
 
   it("startup registration commands invoke backend with expected args", async () => {

--- a/swifttunnel-desktop/src/lib/commands.ts
+++ b/swifttunnel-desktop/src/lib/commands.ts
@@ -179,6 +179,9 @@ export const systemRepairDriver = () =>
 export const systemCleanup = () =>
   invoke<void>("system_cleanup");
 
+export const systemCleanupTunnelState = () =>
+  invoke<void>("system_cleanup_tunnel_state");
+
 /**
  * Restart the NDISRD kernel service without reinstalling the driver.
  *

--- a/swifttunnel-desktop/src/lib/repairCenter.test.ts
+++ b/swifttunnel-desktop/src/lib/repairCenter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_SETTINGS } from "./settings";
 import {
+  parseSavedRepairResult,
   restoreRepairRollback,
   runRepairIssue,
   type RepairCenterDeps,
@@ -71,7 +72,7 @@ function makeDeps(overrides: Partial<RepairCenterDeps> = {}): RepairCenterDeps {
     serverGetLatencies: vi.fn().mockResolvedValue([{ region: "Singapore", latency_ms: 18 }]),
     serverRefresh: vi.fn().mockResolvedValue("ok"),
     systemCheckDriver: vi.fn().mockResolvedValue(readyDriver),
-    systemCleanup: vi.fn().mockResolvedValue(undefined),
+    systemCleanupTunnelState: vi.fn().mockResolvedValue(undefined),
     systemGetStartupRegistration: vi.fn().mockResolvedValue({
       exists: false,
       value: null,
@@ -155,6 +156,47 @@ describe("repair center logic", () => {
     expect(deps.systemRepairDriver).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps driver context when the repair command rejects", async () => {
+    const systemCheckDriver = vi.fn().mockResolvedValue(readyDriver);
+    const deps = makeDeps({
+      systemCheckDriver,
+      systemRepairDriver: vi.fn().mockRejectedValue(new Error("repair crashed")),
+    });
+
+    const report = await runRepairIssue("driver", deps, {
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(report.status).toBe("partial");
+    expect(report.summary).toContain("command failed");
+    expect(report.entries).toContainEqual({
+      label: "Repair error",
+      value: "repair crashed",
+      tone: "bad",
+    });
+    expect(systemCheckDriver).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports failed when adapter inventory cannot be read", async () => {
+    const deps = makeDeps({
+      vpnListNetworkAdapters: vi
+        .fn()
+        .mockRejectedValue(new Error("adapter API unavailable")),
+    });
+
+    const report = await runRepairIssue("adapter", deps, {
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(report.status).toBe("failed");
+    expect(report.changed).toBe(false);
+    expect(report.entries).toContainEqual({
+      label: "Adapter inventory",
+      value: "adapter API unavailable",
+      tone: "bad",
+    });
+  });
+
   it("does not cleanup for superficially similar healthy diagnostic text", async () => {
     const deps = makeDeps();
 
@@ -164,16 +206,34 @@ describe("repair center logic", () => {
 
     expect(report.status).toBe("checked");
     expect(deps.vpnDisconnect).not.toHaveBeenCalled();
-    expect(deps.systemCleanup).not.toHaveBeenCalled();
+    expect(deps.systemCleanupTunnelState).not.toHaveBeenCalled();
+  });
+
+  it("does not cleanup when VPN state cannot be read", async () => {
+    const deps = makeDeps({
+      vpnGetState: vi.fn().mockRejectedValue(new Error("state unavailable")),
+      vpnGetDiagnostics: vi.fn().mockResolvedValue(errorDiagnostics),
+    });
+
+    const report = await runRepairIssue("tunnel_cleanup", deps, {
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(report.status).toBe("failed");
+    expect(report.summary).toContain("could not read VPN state");
+    expect(deps.systemCleanupTunnelState).not.toHaveBeenCalled();
   });
 
   it("runs cleanup for structured tunnel error state", async () => {
     const deps = makeDeps({
-      vpnGetState: vi.fn().mockResolvedValue({
-        ...disconnectedState,
-        state: "error",
-        error: "Split tunnel driver not available",
-      }),
+      vpnGetState: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ...disconnectedState,
+          state: "error",
+          error: "Split tunnel driver not available",
+        })
+        .mockResolvedValueOnce(disconnectedState),
     });
 
     const report = await runRepairIssue("tunnel_cleanup", deps, {
@@ -181,7 +241,27 @@ describe("repair center logic", () => {
     });
 
     expect(report.status).toBe("fixed");
-    expect(deps.systemCleanup).toHaveBeenCalledTimes(1);
+    expect(deps.systemCleanupTunnelState).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops cleanup when disconnect fails for an active error state", async () => {
+    const deps = makeDeps({
+      vpnGetState: vi.fn().mockResolvedValue({
+        ...disconnectedState,
+        state: "error",
+        split_tunnel_active: true,
+        error: "reader failed",
+      }),
+      vpnDisconnect: vi.fn().mockRejectedValue(new Error("disconnect denied")),
+    });
+
+    const report = await runRepairIssue("tunnel_cleanup", deps, {
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(report.status).toBe("failed");
+    expect(report.summary).toContain("disconnect failed");
+    expect(deps.systemCleanupTunnelState).not.toHaveBeenCalled();
   });
 
   it("reports partial when cleanup leaves structured diagnostic errors", async () => {
@@ -198,12 +278,48 @@ describe("repair center logic", () => {
 
     expect(report.status).toBe("partial");
     expect(report.summary).toContain("diagnostics still show an error");
-    expect(deps.systemCleanup).toHaveBeenCalledTimes(1);
+    expect(deps.systemCleanupTunnelState).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports partial when cleanup verification cannot read diagnostics", async () => {
+    const deps = makeDeps({
+      vpnGetDiagnostics: vi
+        .fn()
+        .mockResolvedValueOnce(errorDiagnostics)
+        .mockRejectedValueOnce(new Error("diagnostics unavailable")),
+    });
+
+    const report = await runRepairIssue("tunnel_cleanup", deps, {
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(report.status).toBe("partial");
+    expect(report.summary).toContain("verification could not finish");
+  });
+
+  it("reports partial when cleanup leaves the driver needing repair", async () => {
+    const deps = makeDeps({
+      systemCheckDriver: vi.fn().mockResolvedValue(missingDriver),
+      vpnGetDiagnostics: vi
+        .fn()
+        .mockResolvedValueOnce(errorDiagnostics)
+        .mockResolvedValueOnce(healthyDiagnostics),
+    });
+
+    const report = await runRepairIssue("tunnel_cleanup", deps, {
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(report.status).toBe("partial");
+    expect(report.summary).toContain("driver needs repair");
+    expect(report.nextStep).toContain("driver repair");
   });
 
   it("keeps cleanup context when system cleanup fails", async () => {
     const deps = makeDeps({
-      systemCleanup: vi.fn().mockRejectedValue(new Error("cleanup denied")),
+      systemCleanupTunnelState: vi.fn().mockRejectedValue(
+        new Error("cleanup denied"),
+      ),
       vpnGetDiagnostics: vi
         .fn()
         .mockResolvedValueOnce(errorDiagnostics)
@@ -217,7 +333,7 @@ describe("repair center logic", () => {
     expect(report.status).toBe("failed");
     expect(report.entries).toContainEqual({
       label: "Cleanup",
-      value: "Error: cleanup denied",
+      value: "cleanup denied",
       tone: "bad",
     });
   });
@@ -270,5 +386,67 @@ describe("repair center logic", () => {
     expect(restored.status).toBe("failed");
     expect(restored.summary).toBe("Unknown rollback kind");
     expect(deps.systemRestoreStartupRegistration).not.toHaveBeenCalled();
+  });
+
+  it("parses a valid saved repair result", () => {
+    const parsed = parseSavedRepairResult(
+      JSON.stringify({
+        issue: "driver",
+        report: {
+          status: "checked",
+          summary: "ok",
+          nextStep: "next",
+          changed: false,
+          reversible: false,
+          ranAt: 1_800_000_000_000,
+          entries: [],
+        },
+      }),
+    );
+
+    expect(parsed?.issue).toBe("driver");
+    expect(parsed?.report.status).toBe("checked");
+  });
+
+  it("ignores stale saved repair statuses", () => {
+    const parsed = parseSavedRepairResult(
+      JSON.stringify({
+        issue: "driver",
+        report: {
+          status: "legacy_success",
+          summary: "ok",
+          nextStep: "next",
+          changed: false,
+          reversible: false,
+          ranAt: 1_800_000_000_000,
+          entries: [],
+        },
+      }),
+    );
+
+    expect(parsed).toBeNull();
+  });
+
+  it("ignores stale saved rollback kinds", () => {
+    const parsed = parseSavedRepairResult(
+      JSON.stringify({
+        issue: "startup",
+        report: {
+          status: "failed",
+          summary: "failed",
+          nextStep: "next",
+          changed: true,
+          reversible: true,
+          ranAt: 1_800_000_000_000,
+          entries: [],
+          rollback: {
+            kind: "legacy_startup_registration",
+            snapshot: { exists: true, value: "legacy" },
+          },
+        },
+      }),
+    );
+
+    expect(parsed).toBeNull();
   });
 });

--- a/swifttunnel-desktop/src/lib/repairCenter.ts
+++ b/swifttunnel-desktop/src/lib/repairCenter.ts
@@ -7,6 +7,7 @@ import type {
   VpnStateResponse,
 } from "./types";
 import type { StartupRegistrationSnapshot } from "./commands";
+import { formatErrorMessage } from "./errors";
 
 export type RepairIssueId =
   | "driver"
@@ -28,6 +29,17 @@ export type RepairStatus =
   | "needs_reboot"
   | "failed"
   | "unsupported";
+
+const REPAIR_STATUSES: readonly RepairStatus[] = [
+  "not_checked",
+  "healthy",
+  "checked",
+  "fixed",
+  "partial",
+  "needs_reboot",
+  "failed",
+  "unsupported",
+];
 
 export interface RepairIssueDefinition {
   id: RepairIssueId;
@@ -60,6 +72,11 @@ export interface RepairReport {
   rollback?: RepairRollback;
 }
 
+export type SavedRepairResult = {
+  issue: RepairIssueId;
+  report: RepairReport;
+};
+
 export interface RepairContext {
   settings: AppSettings;
 }
@@ -69,7 +86,7 @@ export interface RepairCenterDeps {
   serverGetLatencies: () => Promise<LatencyEntry[]>;
   serverRefresh: () => Promise<string>;
   systemCheckDriver: () => Promise<DriverCheckResponse>;
-  systemCleanup: () => Promise<void>;
+  systemCleanupTunnelState: () => Promise<void>;
   systemGetStartupRegistration: () => Promise<StartupRegistrationSnapshot>;
   systemIsAdmin: () => Promise<{ is_admin: boolean }>;
   systemRepairDriver: () => Promise<DriverCheckResponse>;
@@ -176,6 +193,94 @@ export function makeInitialRepairReports(
   );
 }
 
+export function parseSavedRepairResult(raw: string | null): SavedRepairResult | null {
+  if (!raw) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+
+    const issue = parsed.issue;
+    const report = parsed.report;
+    if (!isRepairIssueId(issue) || !isRepairReport(report)) return null;
+
+    return { issue, report };
+  } catch {
+    return null;
+  }
+}
+
+function isRepairIssueId(value: unknown): value is RepairIssueId {
+  return (
+    typeof value === "string" &&
+    REPAIR_ISSUES.some((issue) => issue.id === value)
+  );
+}
+
+function isRepairReport(value: unknown): value is RepairReport {
+  if (!isRecord(value)) return false;
+  if (!isRepairStatus(value.status)) return false;
+  if (typeof value.summary !== "string") return false;
+  if (typeof value.nextStep !== "string") return false;
+  if (typeof value.changed !== "boolean") return false;
+  if (typeof value.reversible !== "boolean") return false;
+  if (typeof value.ranAt !== "number" || !Number.isFinite(value.ranAt)) {
+    return false;
+  }
+  if (!Array.isArray(value.entries) || !value.entries.every(isRepairEntry)) {
+    return false;
+  }
+  if (
+    value.rollback !== undefined &&
+    !isRepairRollback(value.rollback)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isRepairStatus(value: unknown): value is RepairStatus {
+  return (
+    typeof value === "string" &&
+    REPAIR_STATUSES.includes(value as RepairStatus)
+  );
+}
+
+function isRepairEntry(value: unknown): value is RepairEntry {
+  if (!isRecord(value)) return false;
+  if (typeof value.label !== "string") return false;
+  if (typeof value.value !== "string") return false;
+  if (
+    value.tone !== undefined &&
+    value.tone !== "default" &&
+    value.tone !== "good" &&
+    value.tone !== "warn" &&
+    value.tone !== "bad"
+  ) {
+    return false;
+  }
+  if (value.mono !== undefined && typeof value.mono !== "boolean") {
+    return false;
+  }
+  return true;
+}
+
+function isRepairRollback(value: unknown): value is RepairRollback {
+  if (!isRecord(value)) return false;
+  if (value.kind !== "startup_registration") return false;
+  return isStartupRegistrationSnapshot(value.snapshot);
+}
+
+function isStartupRegistrationSnapshot(
+  value: unknown,
+): value is StartupRegistrationSnapshot {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.exists === "boolean" &&
+    (value.value === null || typeof value.value === "string")
+  );
+}
+
 export async function runRepairIssue(
   issue: RepairIssueId,
   deps: RepairCenterDeps,
@@ -211,7 +316,7 @@ export async function runRepairIssue(
         return await checkInstaller(deps);
     }
   } catch (error) {
-    return errorReport(deps, "Repair failed", String(error));
+    return errorReport(deps, "Repair failed", formatErrorMessage(error));
   }
 }
 
@@ -251,7 +356,7 @@ export async function restoreRepairRollback(
         return errorReport(deps, "Unknown rollback kind", rollback.kind);
     }
   } catch (error) {
-    return errorReport(deps, "Revert failed", String(error));
+    return errorReport(deps, "Revert failed", formatErrorMessage(error));
   }
 }
 
@@ -321,7 +426,20 @@ async function repairDriver(deps: RepairCenterDeps): Promise<RepairReport> {
     );
   }
 
-  const after = await deps.systemRepairDriver();
+  let after: DriverCheckResponse;
+  try {
+    after = await deps.systemRepairDriver();
+  } catch (error) {
+    const [afterCheck] = await Promise.allSettled([deps.systemCheckDriver()]);
+    return driverRepairCommandFailedReport(
+      deps,
+      before,
+      admin,
+      formatErrorMessage(error),
+      commandOutcome(afterCheck),
+    );
+  }
+
   const status = after.ready
     ? "fixed"
     : after.reboot_required
@@ -345,10 +463,32 @@ async function checkAdapterRouting(
   deps: RepairCenterDeps,
   settings: AppSettings,
 ): Promise<RepairReport> {
-  const [adapters, diagnostics] = await Promise.all([
+  const [adaptersResult, diagnosticsResult] = await Promise.allSettled([
     deps.vpnListNetworkAdapters(),
-    deps.vpnGetDiagnostics().catch(() => null),
+    deps.vpnGetDiagnostics(),
   ]);
+  const diagnostics = resultValueOrNull(diagnosticsResult);
+
+  if (adaptersResult.status === "rejected") {
+    return {
+      status: "failed",
+      summary: "Adapter routing check failed.",
+      nextStep: "Copy this result and the log file for support.",
+      changed: false,
+      reversible: false,
+      ranAt: deps.now(),
+      entries: [
+        {
+          label: "Adapter inventory",
+          value: formatErrorMessage(adaptersResult.reason),
+          tone: "bad",
+        },
+        ...diagnosticEntriesFromResult(diagnosticsResult),
+      ],
+    };
+  }
+
+  const adapters = adaptersResult.value;
   const selectedAdapter = settings.preferred_physical_adapter_guid
     ? adapters.find((a) => a.guid === settings.preferred_physical_adapter_guid)
     : null;
@@ -385,7 +525,7 @@ async function checkAdapterRouting(
           (settings.preferred_physical_adapter_guid ? "missing" : "auto"),
         tone: manualAdapterMissing ? "bad" : "default",
       },
-      ...diagnosticEntries(diagnostics),
+      ...diagnosticEntriesFromResult(diagnosticsResult, diagnostics),
     ],
   };
 }
@@ -393,13 +533,37 @@ async function checkAdapterRouting(
 async function repairTunnelCleanup(
   deps: RepairCenterDeps,
 ): Promise<RepairReport> {
-  const [state, diagnosticsBefore] = await Promise.all([
+  const [stateResult, diagnosticsBeforeResult] = await Promise.allSettled([
     deps.vpnGetState(),
-    deps.vpnGetDiagnostics().catch(() => null),
+    deps.vpnGetDiagnostics(),
   ]);
+  const diagnosticsBefore = resultValueOrNull(diagnosticsBeforeResult);
+
+  if (stateResult.status === "rejected") {
+    return {
+      status: "failed",
+      summary: "Tunnel cleanup could not read VPN state.",
+      nextStep: "Copy this result and the log file for support.",
+      changed: false,
+      reversible: false,
+      ranAt: deps.now(),
+      entries: [
+        {
+          label: "State",
+          value: formatErrorMessage(stateResult.reason),
+          tone: "bad",
+        },
+        ...diagnosticEntriesFromResult(
+          diagnosticsBeforeResult,
+          diagnosticsBefore,
+        ),
+      ],
+    };
+  }
+
+  const state = stateResult.value;
   const cleanupNeeded =
-    state.state === "error" ||
-    state.error !== null ||
+    hasTunnelCleanupStateError(state) ||
     hasTunnelCleanupDiagnosticError(diagnosticsBefore);
   const baseEntries: RepairEntry[] = [
     { label: "State", value: state.state },
@@ -407,7 +571,7 @@ async function repairTunnelCleanup(
       label: "Split tunnel active",
       value: state.split_tunnel_active ? "yes" : "no",
     },
-    ...diagnosticEntries(diagnosticsBefore),
+    ...diagnosticEntriesFromResult(diagnosticsBeforeResult, diagnosticsBefore),
   ];
 
   if (!cleanupNeeded) {
@@ -428,22 +592,53 @@ async function repairTunnelCleanup(
       await deps.vpnDisconnect();
       repairEntries.push({ label: "Disconnect", value: "completed", tone: "good" });
     } catch (error) {
-      repairEntries.push({ label: "Disconnect", value: String(error), tone: "warn" });
+      repairEntries.push({
+        label: "Disconnect",
+        value: formatErrorMessage(error),
+        tone: "bad",
+      });
+      return {
+        status: "failed",
+        summary: "Tunnel cleanup stopped because disconnect failed.",
+        nextStep: "Disconnect manually, then run tunnel cleanup again.",
+        changed: true,
+        reversible: false,
+        ranAt: deps.now(),
+        entries: baseEntries.concat(repairEntries),
+      };
     }
   }
 
   let cleanupError: unknown = null;
   try {
-    await deps.systemCleanup();
+    await deps.systemCleanupTunnelState();
   } catch (error) {
     cleanupError = error;
   }
-  const diagnosticsAfter = await deps.vpnGetDiagnostics().catch(() => null);
+  const [stateAfterResult, diagnosticsAfterResult, driverAfterResult] =
+    await Promise.allSettled([
+      deps.vpnGetState(),
+      deps.vpnGetDiagnostics(),
+      deps.systemCheckDriver(),
+    ]);
+  const stateAfter = resultValueOrNull(stateAfterResult);
+  const diagnosticsAfter = resultValueOrNull(diagnosticsAfterResult);
+  const driverAfter = resultValueOrNull(driverAfterResult);
+  const stateStillErrored =
+    stateAfter !== null && hasTunnelCleanupStateError(stateAfter);
   const diagnosticsStillErrored =
     hasTunnelCleanupDiagnosticError(diagnosticsAfter);
+  const driverNeedsRepair = driverAfter !== null && !driverAfter.ready;
+  const verificationUnavailable =
+    stateAfterResult.status === "rejected" ||
+    diagnosticsAfterResult.status === "rejected" ||
+    driverAfterResult.status === "rejected";
   const status: RepairStatus = cleanupError
     ? "failed"
-    : diagnosticsStillErrored
+    : stateStillErrored ||
+        diagnosticsStillErrored ||
+        driverNeedsRepair ||
+        verificationUnavailable
       ? "partial"
       : "fixed";
 
@@ -451,12 +646,23 @@ async function repairTunnelCleanup(
     status,
     summary: cleanupError
       ? "Tunnel cleanup failed."
+      : stateStillErrored
+      ? "Tunnel cleanup completed, but VPN state still reports an error."
       : diagnosticsStillErrored
       ? "Tunnel cleanup completed, but diagnostics still show an error."
+      : driverNeedsRepair
+      ? "Tunnel cleanup completed, but the split tunnel driver needs repair."
+      : verificationUnavailable
+      ? "Tunnel cleanup completed, but verification could not finish."
       : "Tunnel cleanup completed.",
-    nextStep: cleanupError || diagnosticsStillErrored
-      ? "Copy this result and the log file for support."
-      : "Try connecting again. Copy this result for support if the error returns.",
+    nextStep: driverNeedsRepair
+      ? "Run split tunnel driver repair next, then try connecting again."
+      : cleanupError ||
+          stateStillErrored ||
+          diagnosticsStillErrored ||
+          verificationUnavailable
+        ? "Copy this result and the log file for support."
+        : "Try connecting again. Copy this result for support if the error returns.",
     changed: true,
     reversible: false,
     ranAt: deps.now(),
@@ -465,13 +671,28 @@ async function repairTunnelCleanup(
       {
         label: "Cleanup",
         value: cleanupError
-          ? String(cleanupError)
+          ? formatErrorMessage(cleanupError)
+          : stateStillErrored
+          ? "completed; VPN state still reports error"
           : diagnosticsStillErrored
           ? "completed; diagnostics still show error"
+          : driverNeedsRepair
+          ? "completed; driver needs repair"
+          : verificationUnavailable
+          ? "completed; verification unavailable"
           : "completed",
-        tone: cleanupError ? "bad" : diagnosticsStillErrored ? "warn" : "good",
+        tone: cleanupError || driverNeedsRepair
+          ? "bad"
+          : stateStillErrored || diagnosticsStillErrored || verificationUnavailable
+            ? "warn"
+            : "good",
       },
-      ...diagnosticEntries(diagnosticsAfter),
+      ...prefixEntries("After", stateEntriesFromResult(stateAfterResult, stateAfter)),
+      ...prefixEntries(
+        "After",
+        diagnosticEntriesFromResult(diagnosticsAfterResult, diagnosticsAfter),
+      ),
+      ...prefixEntries("After driver", driverEntriesFromResult(driverAfterResult)),
     ),
   };
 }
@@ -516,7 +737,7 @@ function checkBoostSettings(
     entries: [
       {
         label: "Config",
-        value: JSON.stringify(config),
+        value: formatJsonValue(config),
         mono: true,
       },
     ],
@@ -527,8 +748,58 @@ async function repairStartupRegistration(
   deps: RepairCenterDeps,
   settings: AppSettings,
 ): Promise<RepairReport> {
-  const before = await deps.systemGetStartupRegistration();
-  const after = await deps.systemRepairStartupRegistration(settings.run_on_startup);
+  let before: StartupRegistrationSnapshot;
+  try {
+    before = await deps.systemGetStartupRegistration();
+  } catch (error) {
+    return {
+      status: "failed",
+      summary: "Startup registration repair could not capture a rollback snapshot.",
+      nextStep: "Copy this result and the log file for support.",
+      changed: false,
+      reversible: false,
+      ranAt: deps.now(),
+      entries: [
+        {
+          label: "Snapshot",
+          value: formatErrorMessage(error),
+          tone: "bad",
+        },
+      ],
+    };
+  }
+
+  let after: StartupRegistrationSnapshot;
+  try {
+    after = await deps.systemRepairStartupRegistration(settings.run_on_startup);
+  } catch (error) {
+    return {
+      status: "failed",
+      summary: "Startup registration repair failed.",
+      nextStep: "Use Revert to restore the captured startup snapshot, or copy this result for support.",
+      changed: true,
+      reversible: true,
+      rollback: { kind: "startup_registration", snapshot: before },
+      ranAt: deps.now(),
+      entries: [
+        {
+          label: "Run on startup",
+          value: settings.run_on_startup ? "enabled" : "disabled",
+        },
+        {
+          label: "Before",
+          value: formatStartupRegistration(before),
+          mono: true,
+        },
+        {
+          label: "Repair",
+          value: formatErrorMessage(error),
+          tone: "bad",
+        },
+      ],
+    };
+  }
+
   const changed = !startupSnapshotsEqual(before, after);
   const expectedSatisfied = settings.run_on_startup ? after.exists : !after.exists;
 
@@ -620,6 +891,126 @@ async function checkInstaller(deps: RepairCenterDeps): Promise<RepairReport> {
   };
 }
 
+type CommandOutcome<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+function commandOutcome<T>(
+  result: PromiseSettledResult<T>,
+): CommandOutcome<T> {
+  if (result.status === "fulfilled") {
+    return { ok: true, value: result.value };
+  }
+  return { ok: false, error: formatErrorMessage(result.reason) };
+}
+
+function resultValueOrNull<T>(result: PromiseSettledResult<T>): T | null {
+  return result.status === "fulfilled" ? result.value : null;
+}
+
+function diagnosticEntriesFromResult(
+  result: PromiseSettledResult<DiagnosticsResponse | null>,
+  diagnostics = resultValueOrNull(result),
+): RepairEntry[] {
+  if (result.status === "rejected") {
+    return [
+      {
+        label: "Diagnostics",
+        value: `read failed: ${formatErrorMessage(result.reason)}`,
+        tone: "warn",
+      },
+    ];
+  }
+
+  return diagnosticEntries(diagnostics);
+}
+
+function stateEntriesFromResult(
+  result: PromiseSettledResult<VpnStateResponse>,
+  state = resultValueOrNull(result),
+): RepairEntry[] {
+  if (result.status === "rejected") {
+    return [
+      {
+        label: "State",
+        value: `read failed: ${formatErrorMessage(result.reason)}`,
+        tone: "warn",
+      },
+    ];
+  }
+
+  if (!state) {
+    return [{ label: "State", value: "not available", tone: "warn" }];
+  }
+
+  return [
+    {
+      label: "State",
+      value: state.state,
+      tone: hasTunnelCleanupStateError(state) ? "bad" : "good",
+    },
+    {
+      label: "Error",
+      value: state.error ?? "none",
+      tone: state.error ? "bad" : "default",
+    },
+  ];
+}
+
+function driverEntriesFromResult(
+  result: PromiseSettledResult<DriverCheckResponse>,
+): RepairEntry[] {
+  if (result.status === "rejected") {
+    return [
+      {
+        label: "Check",
+        value: `read failed: ${formatErrorMessage(result.reason)}`,
+        tone: "warn",
+      },
+    ];
+  }
+
+  return driverEntries(result.value);
+}
+
+function driverRepairCommandFailedReport(
+  deps: RepairCenterDeps,
+  before: DriverCheckResponse,
+  admin: { is_admin: boolean },
+  error: string,
+  afterCheck: CommandOutcome<DriverCheckResponse>,
+): RepairReport {
+  const afterReady = afterCheck.ok && afterCheck.value.ready;
+  const afterEntries = afterCheck.ok
+    ? prefixEntries("After", driverEntries(afterCheck.value))
+    : [
+        {
+          label: "After check",
+          value: afterCheck.error,
+          tone: "warn" as const,
+        },
+      ];
+
+  return {
+    status: afterReady ? "partial" : "failed",
+    summary: afterReady
+      ? "Driver repair command failed, but the driver now reports ready."
+      : "Driver repair command failed.",
+    nextStep: afterReady
+      ? "Try connecting once. If the issue continues, copy this result and the log file for support."
+      : "Copy this result and the log file for support.",
+    changed: true,
+    reversible: false,
+    ranAt: deps.now(),
+    entries: [
+      { label: "Admin", value: admin.is_admin ? "elevated" : "standard user" },
+      ...prefixEntries("Before", driverEntries(before)),
+      { label: "Repair error", value: error, tone: "bad" },
+      ...afterEntries,
+    ],
+  };
+}
+
 function driverReport(
   deps: RepairCenterDeps,
   driver: DriverCheckResponse,
@@ -632,11 +1023,7 @@ function driverReport(
   return {
     status,
     summary,
-    nextStep: driver.ready
-      ? "Try connecting again. Copy this result for support if the issue continues."
-      : driver.reboot_required
-        ? "Restart Windows, then run the driver check again."
-        : driver.message || "Copy this result and the log file for support.",
+    nextStep: driverNextStep(driver, status),
     changed,
     reversible: false,
     ranAt: deps.now(),
@@ -646,6 +1033,22 @@ function driverReport(
       ...(before ? prefixEntries("After", driverEntries(driver)) : driverEntries(driver)),
     ],
   };
+}
+
+function driverNextStep(
+  driver: DriverCheckResponse,
+  status: RepairStatus,
+): string {
+  if (status === "unsupported" || driver.status === "unsupported") {
+    return "Split tunnel driver repair is only available on Windows.";
+  }
+  if (driver.ready) {
+    return "Try connecting again. Copy this result for support if the issue continues.";
+  }
+  if (driver.reboot_required) {
+    return "Restart Windows, then run the driver check again.";
+  }
+  return driver.message || "Copy this result and the log file for support.";
 }
 
 function driverEntries(driver: DriverCheckResponse): RepairEntry[] {
@@ -709,6 +1112,10 @@ function hasTunnelCleanupDiagnosticError(
   );
 }
 
+function hasTunnelCleanupStateError(state: VpnStateResponse): boolean {
+  return state.state === "error" || state.error !== null;
+}
+
 function errorReport(
   deps: Pick<RepairCenterDeps, "now">,
   summary: string,
@@ -747,4 +1154,16 @@ function startupSnapshotsEqual(
 function formatStartupRegistration(snapshot: StartupRegistrationSnapshot): string {
   if (!snapshot.exists) return "absent";
   return snapshot.value || "present with empty value";
+}
+
+function formatJsonValue(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "undefined";
+  } catch (error) {
+    return `Could not serialize config: ${formatErrorMessage(error)}`;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/swifttunnel-desktop/src/mocks/tauri-core.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-core.ts
@@ -385,6 +385,7 @@ const handlers: Record<string, (...args: unknown[]) => unknown> = {
     recommended_action: "none",
   }),
   system_cleanup: () => {},
+  system_cleanup_tunnel_state: () => {},
   system_get_startup_registration: () => ({
     exists: true,
     value: "\"C:\\Program Files\\SwiftTunnel\\SwiftTunnel.exe\" --startup",


### PR DESCRIPTION
## Summary

- Adds a narrow `system_cleanup_tunnel_state` command for Repair Center tunnel cleanup so the repair flow no longer calls the full uninstall-style `system_cleanup` path.
- Hardens Repair Center reports around driver repair failures, adapter inventory failures, startup rollback capture, tunnel cleanup verification, and stale saved `localStorage` payloads.
- Expands Repair Center unit coverage for positive and negative recovery triggers, verification failures, driver-needs-repair outcomes, and stale saved report shapes.

## Web research

Checked before editing:

- Tauri v2 command docs for `invoke` and `Result` rejection behavior.
- MDN `Promise.allSettled` docs for independent async reads that should retain partial results.
- React `useState` updater docs for state updates based on existing state.
- `p-limit` README as a possible dependency-based concurrency option.

Options considered:

- Keep the existing `Promise.all`/local `.catch()` pattern and only patch individual failures.
- Use local `Promise.allSettled` helpers with no new dependency.
- Add a queue/concurrency dependency such as `p-limit`.
- Change Rust/Tauri commands to a larger structured error-enum contract.

Chosen approach: no new dependency, stable Tauri command contracts, plus small local helpers that preserve partial diagnostics while keeping primary repair commands as explicit success/failure gates.

## Failure-mode plan

- Primary success: Repair Center reports must reflect verified repair outcomes; a completed helper command must not mask failed post-checks.
- Repairable failures: driver repair, startup registration rewrite, and tunnel cleanup only when structured state/diagnostics indicate it is needed.
- Retryable/partial failures: optional diagnostics, relay ping, and after-cleanup verification reads.
- Fatal failures: primary command rejections and unknown VPN state before cleanup.
- Diagnostic-only failures: supporting reads are captured as report entries instead of dropping all context.
- Trigger signals: cleanup uses structured `state === "error"`, non-null state error, `binding_stage === "error"`, and `last_validation_result === "error"`; tests cover superficially similar non-repairable text.
- Partial states/races: cleanup verifies VPN state, diagnostics, and driver health afterward; missing verification or remaining errors mark the report partial instead of fixed.

## Verification

- `npm test -- --run src/lib/repairCenter.test.ts src/lib/commands.test.ts`
- `npx tsc --noEmit`
- `npm test -- --run`
- `npm run build`
- `cargo fmt --check`
- `git diff --check`
- `coderabbit review --agent -t uncommitted` raised 0 issues.

`cargo check -p swifttunnel-desktop` was attempted on macOS and failed before SwiftTunnel code compiled with the known local `windows-future` / `windows-core` mismatch (`IMarshal`, `marshaler`, `windows_threading::submit`). GitHub Windows CI remains the authoritative Rust compile gate for this path.