### PR TITLE
Keep critical Roblox bootstrap hosts direct

### DIFF
--- a/swifttunnel-core/src/roblox_proxy/hosts.rs
+++ b/swifttunnel-core/src/roblox_proxy/hosts.rs
@@ -27,6 +27,17 @@ const DNS_REPAIR_RESOLVERS: &[&str] = &[
 ];
 
 static ACTIVE_BOOTSTRAP_IPS: OnceLock<RwLock<HashSet<Ipv4Addr>>> = OnceLock::new();
+static DIRECT_ONLY_BOOTSTRAP_IPS: OnceLock<RwLock<HashSet<Ipv4Addr>>> = OnceLock::new();
+
+// Keep DNS repair for these launch-critical hosts, but do not publish their IPs
+// to Route Assist. Roblox fails startup with "Failed to download or apply
+// critical settings" if these bootstrap HTTPS requests are relayed unreliably.
+const DIRECT_ONLY_BOOTSTRAP_DOMAINS: &[&str] = &[
+    "clientsettingscdn.roblox.com",
+    "clientsettings.roblox.com",
+    "clientsettings.api.roblox.com",
+    "versioncompatibility.api.roblox.com",
+];
 
 /// Exact Roblox hostnames repaired when API tunneling is enabled.
 ///
@@ -100,18 +111,27 @@ struct DohJsonAnswer {
 /// Existing SwiftTunnel entries are removed first (idempotent).
 pub async fn apply_bootstrap_overrides() -> Result<(), String> {
     let overrides = resolve_bootstrap_overrides().await?;
-    let active_ips: HashSet<Ipv4Addr> = overrides.iter().map(|entry| entry.ip).collect();
+    let active_ips = route_assist_active_ips_from_overrides(&overrides);
+    let direct_only_ips = direct_only_ips_from_overrides(&overrides);
 
     tokio::task::spawn_blocking(move || write_overrides(&overrides))
         .await
         .map_err(|e| format!("Failed to join hosts repair task: {e}"))??;
 
     set_active_bootstrap_ips(active_ips);
+    set_direct_only_bootstrap_ips(direct_only_ips);
     Ok(())
 }
 
 pub fn is_active_bootstrap_ip(ip: Ipv4Addr) -> bool {
     active_bootstrap_ips()
+        .read()
+        .map(|ips| ips.contains(&ip))
+        .unwrap_or(false)
+}
+
+pub fn is_direct_only_bootstrap_ip(ip: Ipv4Addr) -> bool {
+    direct_only_bootstrap_ips()
         .read()
         .map(|ips| ips.contains(&ip))
         .unwrap_or(false)
@@ -260,7 +280,7 @@ fn write_overrides(overrides: &[HostOverride]) -> Result<(), String> {
 /// Call `remove_overrides_async` from async contexts.
 pub fn remove_overrides() -> Result<(), String> {
     let result = remove_overrides_inner();
-    clear_active_bootstrap_ips();
+    clear_bootstrap_ip_sets();
     result
 }
 
@@ -285,6 +305,10 @@ fn active_bootstrap_ips() -> &'static RwLock<HashSet<Ipv4Addr>> {
     ACTIVE_BOOTSTRAP_IPS.get_or_init(|| RwLock::new(HashSet::new()))
 }
 
+fn direct_only_bootstrap_ips() -> &'static RwLock<HashSet<Ipv4Addr>> {
+    DIRECT_ONLY_BOOTSTRAP_IPS.get_or_init(|| RwLock::new(HashSet::new()))
+}
+
 fn set_active_bootstrap_ips(ips: HashSet<Ipv4Addr>) {
     match active_bootstrap_ips().write() {
         Ok(mut active) => *active = ips,
@@ -292,10 +316,46 @@ fn set_active_bootstrap_ips(ips: HashSet<Ipv4Addr>) {
     }
 }
 
-fn clear_active_bootstrap_ips() {
+fn set_direct_only_bootstrap_ips(ips: HashSet<Ipv4Addr>) {
+    match direct_only_bootstrap_ips().write() {
+        Ok(mut direct_only) => *direct_only = ips,
+        Err(e) => warn!("Failed to publish direct-only Roblox bootstrap IPs: {e}"),
+    }
+}
+
+fn route_assist_active_ips_from_overrides(overrides: &[HostOverride]) -> HashSet<Ipv4Addr> {
+    let direct_only_ips = direct_only_ips_from_overrides(overrides);
+
+    overrides
+        .iter()
+        .filter(|entry| !is_direct_only_bootstrap_domain(&entry.domain))
+        .filter(|entry| !direct_only_ips.contains(&entry.ip))
+        .map(|entry| entry.ip)
+        .collect()
+}
+
+fn direct_only_ips_from_overrides(overrides: &[HostOverride]) -> HashSet<Ipv4Addr> {
+    overrides
+        .iter()
+        .filter(|entry| is_direct_only_bootstrap_domain(&entry.domain))
+        .map(|entry| entry.ip)
+        .collect()
+}
+
+fn is_direct_only_bootstrap_domain(domain: &str) -> bool {
+    DIRECT_ONLY_BOOTSTRAP_DOMAINS
+        .iter()
+        .any(|direct_only| domain.eq_ignore_ascii_case(direct_only))
+}
+
+fn clear_bootstrap_ip_sets() {
     match active_bootstrap_ips().write() {
         Ok(mut active) => active.clear(),
         Err(e) => warn!("Failed to clear Roblox bootstrap route IPs: {e}"),
+    }
+    match direct_only_bootstrap_ips().write() {
+        Ok(mut direct_only) => direct_only.clear(),
+        Err(e) => warn!("Failed to clear direct-only Roblox bootstrap IPs: {e}"),
     }
 }
 
@@ -305,8 +365,13 @@ pub(crate) fn set_active_bootstrap_ips_for_test(ips: impl IntoIterator<Item = Ip
 }
 
 #[cfg(test)]
+pub(crate) fn set_direct_only_bootstrap_ips_for_test(ips: impl IntoIterator<Item = Ipv4Addr>) {
+    set_direct_only_bootstrap_ips(ips.into_iter().collect());
+}
+
+#[cfg(test)]
 pub(crate) fn clear_active_bootstrap_ips_for_test() {
-    clear_active_bootstrap_ips();
+    clear_bootstrap_ip_sets();
 }
 
 /// Remove any SwiftTunnel Roblox Proxy entries without blocking a Tokio worker.
@@ -567,6 +632,51 @@ mod tests {
     }
 
     #[test]
+    fn route_assist_active_ips_exclude_launch_critical_settings_hosts() {
+        let overrides = vec![
+            HostOverride {
+                ip: Ipv4Addr::new(65, 9, 168, 80),
+                domain: "clientsettingscdn.roblox.com".to_string(),
+            },
+            HostOverride {
+                ip: Ipv4Addr::new(128, 116, 46, 3),
+                domain: "clientsettings.roblox.com".to_string(),
+            },
+            HostOverride {
+                ip: Ipv4Addr::new(128, 116, 121, 3),
+                domain: "www.roblox.com".to_string(),
+            },
+            HostOverride {
+                ip: Ipv4Addr::new(23, 61, 202, 142),
+                domain: "setup.rbxcdn.com".to_string(),
+            },
+            HostOverride {
+                ip: Ipv4Addr::new(65, 9, 168, 80),
+                domain: "apis.roblox.com".to_string(),
+            },
+        ];
+
+        let active_ips = route_assist_active_ips_from_overrides(&overrides);
+        let direct_only_ips = direct_only_ips_from_overrides(&overrides);
+
+        assert!(!active_ips.contains(&Ipv4Addr::new(65, 9, 168, 80)));
+        assert!(!active_ips.contains(&Ipv4Addr::new(128, 116, 46, 3)));
+        assert!(active_ips.contains(&Ipv4Addr::new(128, 116, 121, 3)));
+        assert!(active_ips.contains(&Ipv4Addr::new(23, 61, 202, 142)));
+        assert!(direct_only_ips.contains(&Ipv4Addr::new(65, 9, 168, 80)));
+        assert!(direct_only_ips.contains(&Ipv4Addr::new(128, 116, 46, 3)));
+        assert!(!direct_only_ips.contains(&Ipv4Addr::new(128, 116, 121, 3)));
+    }
+
+    #[test]
+    fn direct_only_bootstrap_domain_match_is_case_insensitive() {
+        assert!(is_direct_only_bootstrap_domain(
+            "ClientSettingsCDN.Roblox.com"
+        ));
+        assert!(!is_direct_only_bootstrap_domain("www.roblox.com"));
+    }
+
+    #[test]
     fn active_bootstrap_ips_are_exact_and_clearable() {
         clear_active_bootstrap_ips_for_test();
 
@@ -574,10 +684,26 @@ mod tests {
         set_active_bootstrap_ips_for_test([bootstrap_ip]);
 
         assert!(is_active_bootstrap_ip(bootstrap_ip));
+        assert!(!is_direct_only_bootstrap_ip(bootstrap_ip));
         assert!(!is_active_bootstrap_ip(Ipv4Addr::new(65, 9, 168, 81)));
 
         clear_active_bootstrap_ips_for_test();
         assert!(!is_active_bootstrap_ip(bootstrap_ip));
+    }
+
+    #[test]
+    fn direct_only_bootstrap_ips_are_exact_and_clearable() {
+        clear_active_bootstrap_ips_for_test();
+
+        let bootstrap_ip = Ipv4Addr::new(128, 116, 46, 3);
+        set_direct_only_bootstrap_ips_for_test([bootstrap_ip]);
+
+        assert!(is_direct_only_bootstrap_ip(bootstrap_ip));
+        assert!(!is_active_bootstrap_ip(bootstrap_ip));
+        assert!(!is_direct_only_bootstrap_ip(Ipv4Addr::new(128, 116, 46, 4)));
+
+        clear_active_bootstrap_ips_for_test();
+        assert!(!is_direct_only_bootstrap_ip(bootstrap_ip));
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -7107,9 +7107,12 @@ where
         let can_speculate_tcp_api = protocol == Protocol::Tcp && api_tunneling && has_tunnel_scope;
         let is_tcp_api_bootstrap_syn =
             can_speculate_tcp_api && is_tcp_initial_syn && matches!(dst_port, 80 | 443);
+        let is_direct_only_bootstrap_dst =
+            crate::roblox_proxy::hosts::is_direct_only_bootstrap_ip(dst_ip);
         let is_route_assist_http_dst = can_speculate_tcp_api
             && is_tcp_initial_syn
             && matches!(dst_port, 80 | 443)
+            && !is_direct_only_bootstrap_dst
             && (super::process_cache::is_game_server(dst_ip, dst_port, protocol, api_tunneling)
                 || crate::roblox_proxy::hosts::is_active_bootstrap_ip(dst_ip));
         let tcp_api_bootstrap_owner = if is_tcp_api_bootstrap_syn && !snapshot_tunnel_hit {
@@ -7138,6 +7141,7 @@ where
         // Known tunnel-owned TCP bootstraps keep v2.1.8's relay/MSS-clamp behavior.
         // Owner-missing SYNs are only repairable for Roblox or active bootstrap IPs.
         let tcp_api_bootstrap_allowed = is_tcp_api_bootstrap_syn
+            && !is_direct_only_bootstrap_dst
             && !tcp_api_bootstrap_known_unrelated
             && (!tcp_api_bootstrap_owner_missing || is_route_assist_http_dst);
         let is_game_dst = if protocol == Protocol::Udp {
@@ -11972,6 +11976,64 @@ mod tests {
             )
         );
         assert!(inline_cache.contains_key(&(src_ip, src_port, Protocol::Tcp)));
+
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+    }
+
+    #[test]
+    fn test_tcp_api_tunneling_keeps_direct_only_bootstrap_roblox_range_direct() {
+        let _guard = BOOTSTRAP_ROUTE_IP_TEST_LOCK.lock().unwrap();
+        crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
+
+        let src_ip = Ipv4Addr::new(10, 0, 0, 2);
+        let critical_settings_ip = Ipv4Addr::new(128, 116, 46, 3);
+        let src_port = 40018;
+        let dst_port = 443;
+        let tunnel_pid = 1234;
+
+        crate::roblox_proxy::hosts::set_active_bootstrap_ips_for_test([critical_settings_ip]);
+        crate::roblox_proxy::hosts::set_direct_only_bootstrap_ips_for_test([critical_settings_ip]);
+
+        let snapshot = ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: [tunnel_pid].into_iter().collect(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: HashSet::new(),
+            tunnel_tcp_ports: HashSet::new(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        };
+
+        let frame =
+            build_ipv4_tcp_frame_with_flags(src_ip, critical_settings_ip, src_port, dst_port, 0x02);
+        let mut inline_cache: InlineCache = HashMap::new();
+
+        assert!(
+            !should_route_to_vpn_with_inline_cache_and_tcp_owner_process_lookup(
+                &frame,
+                &snapshot,
+                &mut inline_cache,
+                true,
+                |ip, port| {
+                    if ip == src_ip && port == src_port {
+                        Some(tunnel_pid)
+                    } else {
+                        None
+                    }
+                },
+                |pid| {
+                    if pid == tunnel_pid {
+                        Some("RobloxPlayerBeta.exe".to_string())
+                    } else {
+                        None
+                    }
+                },
+            )
+        );
+        assert!(inline_cache.is_empty());
 
         crate::roblox_proxy::hosts::clear_active_bootstrap_ips_for_test();
     }


### PR DESCRIPTION
﻿## Summary
- Keep DNS repair entries for Roblox launch-critical settings hosts.
- Exclude critical-settings/version-compatibility hosts from the Route Assist active IP set.
- Preserve Route Assist routing for other repaired Roblox bootstrap/API hosts.

## Why
With Route Assist enabled, Roblox can fail launch with "Failed to download or apply critical settings" when critical-settings HTTPS requests are routed through the relay. These hosts still need DNS repair, but their startup downloads are safer direct-only.

## Verification
- `git diff --check`
- Could not run `cargo fmt` or `cargo test` locally because no Rust toolchain is installed in this shell.
