### PR TITLE
[codex] Enable country ban bypass outside VPN

### DIFF
--- a/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
+++ b/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
@@ -69,6 +69,108 @@ impl Drop for GoodbyeDpiGuard {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CountryBanBypassSyncOutcome {
+    Started,
+    AlreadyRunning,
+    Stopped,
+    AlreadyStopped,
+    Unavailable(String),
+    Failed(String),
+}
+
+pub trait CountryBanBypassLauncher {
+    type Guard;
+
+    fn start_for_roblox(&mut self) -> Result<Option<Self::Guard>, String>;
+    fn stop(&mut self, guard: &mut Self::Guard);
+}
+
+#[derive(Debug, Default)]
+pub struct GoodbyeDpiLauncher;
+
+impl CountryBanBypassLauncher for GoodbyeDpiLauncher {
+    type Guard = GoodbyeDpiGuard;
+
+    fn start_for_roblox(&mut self) -> Result<Option<Self::Guard>, String> {
+        start_for_roblox()
+    }
+
+    fn stop(&mut self, guard: &mut Self::Guard) {
+        guard.stop();
+    }
+}
+
+#[derive(Debug)]
+pub struct CountryBanBypassController<L: CountryBanBypassLauncher = GoodbyeDpiLauncher> {
+    launcher: L,
+    guard: Option<L::Guard>,
+}
+
+impl CountryBanBypassController<GoodbyeDpiLauncher> {
+    pub fn new() -> Self {
+        Self {
+            launcher: GoodbyeDpiLauncher,
+            guard: None,
+        }
+    }
+}
+
+impl Default for CountryBanBypassController<GoodbyeDpiLauncher> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<L: CountryBanBypassLauncher> CountryBanBypassController<L> {
+    #[cfg(test)]
+    fn with_launcher(launcher: L) -> Self {
+        Self {
+            launcher,
+            guard: None,
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.guard.is_some()
+    }
+
+    pub fn sync(&mut self, enabled: bool) -> CountryBanBypassSyncOutcome {
+        match (enabled, self.guard.is_some()) {
+            (true, true) => CountryBanBypassSyncOutcome::AlreadyRunning,
+            (false, false) => CountryBanBypassSyncOutcome::AlreadyStopped,
+            (false, true) => {
+                self.stop();
+                CountryBanBypassSyncOutcome::Stopped
+            }
+            (true, false) => match self.launcher.start_for_roblox() {
+                Ok(Some(guard)) => {
+                    self.guard = Some(guard);
+                    CountryBanBypassSyncOutcome::Started
+                }
+                Ok(None) => CountryBanBypassSyncOutcome::Unavailable(
+                    "Bypass country bans helper unavailable; Roblox traffic will continue without GoodbyeDPI".to_string(),
+                ),
+                Err(e) => CountryBanBypassSyncOutcome::Failed(e),
+            },
+        }
+    }
+
+    pub fn stop(&mut self) -> bool {
+        let Some(mut guard) = self.guard.take() else {
+            return false;
+        };
+        self.launcher.stop(&mut guard);
+        true
+    }
+}
+
+impl<L: CountryBanBypassLauncher> Drop for CountryBanBypassController<L> {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
 pub fn start_for_roblox() -> Result<Option<GoodbyeDpiGuard>, String> {
     if !cfg!(windows) {
         debug!("GoodbyeDPI helper skipped: supported only on Windows");
@@ -338,6 +440,42 @@ fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+
+    #[derive(Debug)]
+    struct FakeGuard;
+
+    #[derive(Debug)]
+    struct FakeLauncher {
+        starts: usize,
+        stops: usize,
+        results: VecDeque<Result<Option<FakeGuard>, String>>,
+    }
+
+    impl FakeLauncher {
+        fn with_results(results: Vec<Result<Option<FakeGuard>, String>>) -> Self {
+            Self {
+                starts: 0,
+                stops: 0,
+                results: VecDeque::from(results),
+            }
+        }
+    }
+
+    impl CountryBanBypassLauncher for FakeLauncher {
+        type Guard = FakeGuard;
+
+        fn start_for_roblox(&mut self) -> Result<Option<Self::Guard>, String> {
+            self.starts += 1;
+            self.results
+                .pop_front()
+                .unwrap_or_else(|| Ok(Some(FakeGuard)))
+        }
+
+        fn stop(&mut self, _guard: &mut Self::Guard) {
+            self.stops += 1;
+        }
+    }
 
     #[test]
     fn goodbyedpi_args_use_requested_mode_and_blacklist() {
@@ -379,5 +517,81 @@ mod tests {
         assert!(paths.contains(&PathBuf::from(
             "C:/Program Files/SwiftTunnel/tools/goodbyedpi/x86_64/goodbyedpi.exe"
         )));
+    }
+
+    #[test]
+    fn controller_starts_once_when_enabled() {
+        let mut controller = CountryBanBypassController::with_launcher(FakeLauncher::with_results(
+            vec![Ok(Some(FakeGuard))],
+        ));
+
+        assert_eq!(controller.sync(true), CountryBanBypassSyncOutcome::Started);
+        assert_eq!(
+            controller.sync(true),
+            CountryBanBypassSyncOutcome::AlreadyRunning
+        );
+        assert!(controller.is_running());
+        assert_eq!(controller.launcher.starts, 1);
+        assert_eq!(controller.launcher.stops, 0);
+    }
+
+    #[test]
+    fn controller_disabled_without_guard_is_noop() {
+        let mut controller = CountryBanBypassController::with_launcher(FakeLauncher::with_results(
+            vec![Ok(Some(FakeGuard))],
+        ));
+
+        assert_eq!(
+            controller.sync(false),
+            CountryBanBypassSyncOutcome::AlreadyStopped
+        );
+        assert!(!controller.is_running());
+        assert_eq!(controller.launcher.starts, 0);
+        assert_eq!(controller.launcher.stops, 0);
+    }
+
+    #[test]
+    fn controller_stops_running_guard_when_disabled() {
+        let mut controller = CountryBanBypassController::with_launcher(FakeLauncher::with_results(
+            vec![Ok(Some(FakeGuard))],
+        ));
+
+        assert_eq!(controller.sync(true), CountryBanBypassSyncOutcome::Started);
+        assert_eq!(controller.sync(false), CountryBanBypassSyncOutcome::Stopped);
+        assert!(!controller.is_running());
+        assert_eq!(controller.launcher.starts, 1);
+        assert_eq!(controller.launcher.stops, 1);
+    }
+
+    #[test]
+    fn controller_unavailable_start_does_not_mark_running_or_retry_in_same_sync() {
+        let mut controller =
+            CountryBanBypassController::with_launcher(FakeLauncher::with_results(vec![Ok(None)]));
+
+        let outcome = controller.sync(true);
+
+        assert!(matches!(
+            outcome,
+            CountryBanBypassSyncOutcome::Unavailable(message)
+                if message.contains("helper unavailable")
+        ));
+        assert!(!controller.is_running());
+        assert_eq!(controller.launcher.starts, 1);
+        assert_eq!(controller.launcher.stops, 0);
+    }
+
+    #[test]
+    fn controller_failed_start_does_not_mark_running() {
+        let mut controller = CountryBanBypassController::with_launcher(FakeLauncher::with_results(
+            vec![Err("spawn failed".to_string())],
+        ));
+
+        assert_eq!(
+            controller.sync(true),
+            CountryBanBypassSyncOutcome::Failed("spawn failed".to_string())
+        );
+        assert!(!controller.is_running());
+        assert_eq!(controller.launcher.starts, 1);
+        assert_eq!(controller.launcher.stops, 0);
     }
 }

--- a/swifttunnel-core/src/roblox_proxy/mod.rs
+++ b/swifttunnel-core/src/roblox_proxy/mod.rs
@@ -6,6 +6,6 @@
 //! repair for launch/API endpoints and also removes stale entries from older
 //! local-proxy builds.
 
-pub(crate) mod goodbyedpi;
+pub mod goodbyedpi;
 pub mod hosts;
 pub(crate) mod legacy_goodbyedpi;

--- a/swifttunnel-desktop/src-tauri/src/commands/auth.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/auth.rs
@@ -120,6 +120,9 @@ pub(crate) async fn cleanup_banned_session(state: &AppState) -> bool {
     if let Err(e) = crate::commands::vpn::disconnect_and_persist(state).await {
         log::warn!("Failed to disconnect VPN after ban detection: {}", e);
     }
+    if crate::commands::country_ban::stop_country_ban_bypass_controller(state) {
+        log::info!("Stopped country ban bypass helper after ban detection");
+    }
 
     let roblox_pid = {
         let mut monitor = state.performance_monitor.lock();

--- a/swifttunnel-desktop/src-tauri/src/commands/country_ban.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/country_ban.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use swifttunnel_core::roblox_proxy::goodbyedpi::{
+    CountryBanBypassController, CountryBanBypassSyncOutcome,
+};
+use tauri::{AppHandle, Emitter};
+
+use crate::events::COUNTRY_BAN_BYPASS_UNAVAILABLE;
+use crate::state::AppState;
+
+pub(crate) fn sync_country_ban_bypass_controller(
+    controller: &Arc<Mutex<CountryBanBypassController>>,
+    enabled: bool,
+) -> CountryBanBypassSyncOutcome {
+    controller.lock().sync(enabled)
+}
+
+pub(crate) fn stop_country_ban_bypass_controller(state: &AppState) -> bool {
+    state.country_ban_bypass.lock().stop()
+}
+
+pub(crate) fn log_and_emit_country_ban_bypass_outcome(
+    app: &AppHandle,
+    source: &str,
+    outcome: &CountryBanBypassSyncOutcome,
+) {
+    match outcome {
+        CountryBanBypassSyncOutcome::Started => {
+            log::info!("Country ban bypass helper started from {source}");
+        }
+        CountryBanBypassSyncOutcome::AlreadyRunning => {
+            log::debug!("Country ban bypass helper already running from {source}");
+        }
+        CountryBanBypassSyncOutcome::Stopped => {
+            log::info!("Country ban bypass helper stopped from {source}");
+        }
+        CountryBanBypassSyncOutcome::AlreadyStopped => {
+            log::debug!("Country ban bypass helper already stopped from {source}");
+        }
+        CountryBanBypassSyncOutcome::Unavailable(message)
+        | CountryBanBypassSyncOutcome::Failed(message) => {
+            log::warn!("Country ban bypass unavailable from {source}: {message}");
+            let _ = app.emit(COUNTRY_BAN_BYPASS_UNAVAILABLE, ());
+        }
+    }
+}
+
+pub(crate) async fn sync_country_ban_bypass_from_state(
+    app: &AppHandle,
+    state: &AppState,
+    source: &'static str,
+) {
+    let enabled = state.settings.lock().enable_country_ban;
+    let controller = state.country_ban_bypass.clone();
+    match tauri::async_runtime::spawn_blocking(move || {
+        sync_country_ban_bypass_controller(&controller, enabled)
+    })
+    .await
+    {
+        Ok(outcome) => log_and_emit_country_ban_bypass_outcome(app, source, &outcome),
+        Err(e) => {
+            log::warn!("Country ban bypass sync task failed from {source}: {e}");
+            let _ = app.emit(COUNTRY_BAN_BYPASS_UNAVAILABLE, ());
+        }
+    }
+}

--- a/swifttunnel-desktop/src-tauri/src/commands/mod.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod country_ban;
 pub mod network;
 pub mod optimization;
 pub mod optimizer;

--- a/swifttunnel-desktop/src-tauri/src/commands/settings.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/settings.rs
@@ -3,6 +3,7 @@ use std::process::Output;
 use tauri::{AppHandle, Manager, State};
 
 use crate::state::AppState;
+use swifttunnel_core::roblox_proxy::goodbyedpi::CountryBanBypassSyncOutcome;
 use swifttunnel_core::settings::AppSettings;
 
 use serde::Serialize;
@@ -58,37 +59,40 @@ pub async fn settings_save(
     let country_ban_bypass = state.country_ban_bypass.clone();
     let app_handle = app.clone();
 
-    let country_ban_outcome = tauri::async_runtime::spawn_blocking(move || {
-        let mut new_settings = settings;
-        new_settings.sanitize_in_place();
-        swifttunnel_core::settings::save_settings(&new_settings)?;
-        let enable_country_ban = new_settings.enable_country_ban;
+    let country_ban_outcome = tauri::async_runtime::spawn_blocking(
+        move || -> Result<CountryBanBypassSyncOutcome, String> {
+            let mut new_settings = settings;
+            new_settings.sanitize_in_place();
+            swifttunnel_core::settings::save_settings(&new_settings)?;
+            let enable_country_ban = new_settings.enable_country_ban;
 
-        {
-            let mut discord = discord_manager.lock();
-            discord.set_enabled(new_settings.enable_discord_rpc);
-        }
+            {
+                let mut discord = discord_manager.lock();
+                discord.set_enabled(new_settings.enable_discord_rpc);
+            }
 
-        let run_on_startup = {
-            let mut s = settings_arc.lock();
-            *s = new_settings;
-            s.run_on_startup
-        };
+            let run_on_startup = {
+                let mut s = settings_arc.lock();
+                *s = new_settings;
+                s.run_on_startup
+            };
 
-        if let Err(e) = crate::autostart::sync_run_on_startup(&app_handle, run_on_startup) {
-            log::warn!(
-                "Failed to sync startup registration after settings save: {}",
-                e
-            );
-        }
+            if let Err(e) = crate::autostart::sync_run_on_startup(&app_handle, run_on_startup) {
+                log::warn!(
+                    "Failed to sync startup registration after settings save: {}",
+                    e
+                );
+            }
 
-        let country_ban_outcome = crate::commands::country_ban::sync_country_ban_bypass_controller(
-            &country_ban_bypass,
-            enable_country_ban,
-        );
+            let country_ban_outcome =
+                crate::commands::country_ban::sync_country_ban_bypass_controller(
+                    &country_ban_bypass,
+                    enable_country_ban,
+                );
 
-        Ok(country_ban_outcome)
-    })
+            Ok(country_ban_outcome)
+        },
+    )
     .await
     .map_err(|e| format!("Settings save task failed: {}", e))??;
 

--- a/swifttunnel-desktop/src-tauri/src/commands/settings.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/settings.rs
@@ -55,12 +55,14 @@ pub async fn settings_save(
 ) -> Result<(), String> {
     let settings_arc = state.settings.clone();
     let discord_manager = state.discord_manager.clone();
+    let country_ban_bypass = state.country_ban_bypass.clone();
     let app_handle = app.clone();
 
-    tauri::async_runtime::spawn_blocking(move || {
+    let country_ban_outcome = tauri::async_runtime::spawn_blocking(move || {
         let mut new_settings = settings;
         new_settings.sanitize_in_place();
         swifttunnel_core::settings::save_settings(&new_settings)?;
+        let enable_country_ban = new_settings.enable_country_ban;
 
         {
             let mut discord = discord_manager.lock();
@@ -80,10 +82,23 @@ pub async fn settings_save(
             );
         }
 
-        Ok(())
+        let country_ban_outcome = crate::commands::country_ban::sync_country_ban_bypass_controller(
+            &country_ban_bypass,
+            enable_country_ban,
+        );
+
+        Ok(country_ban_outcome)
     })
     .await
-    .map_err(|e| format!("Settings save task failed: {}", e))?
+    .map_err(|e| format!("Settings save task failed: {}", e))??;
+
+    crate::commands::country_ban::log_and_emit_country_ban_bypass_outcome(
+        &app,
+        "settings save",
+        &country_ban_outcome,
+    );
+
+    Ok(())
 }
 
 fn current_timestamp_utc() -> String {

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -442,6 +442,25 @@ pub async fn vpn_connect(
         discord.set_connecting(&connect_region);
     }
 
+    if enable_country_ban {
+        let controller = state.country_ban_bypass.clone();
+        match tauri::async_runtime::spawn_blocking(move || {
+            crate::commands::country_ban::sync_country_ban_bypass_controller(&controller, true)
+        })
+        .await
+        {
+            Ok(outcome) => crate::commands::country_ban::log_and_emit_country_ban_bypass_outcome(
+                &app,
+                "vpn connect",
+                &outcome,
+            ),
+            Err(e) => {
+                log::warn!("Country ban bypass sync task failed before VPN connect: {e}");
+                let _ = app.emit(COUNTRY_BAN_BYPASS_UNAVAILABLE, ());
+            }
+        }
+    }
+
     // Get access token
     let access_token = {
         let auth = state.auth_manager.lock().await;
@@ -469,12 +488,10 @@ pub async fn vpn_connect(
             binding_preference,
             game_process_performance,
             enable_api_tunneling,
-            enable_country_ban,
+            false,
         ),
     )
     .await;
-
-    let country_ban_bypass_failure = vpn.take_country_ban_bypass_failure();
 
     let mut connect_ban_reason = None;
     let result = match connect_result {
@@ -507,13 +524,6 @@ pub async fn vpn_connect(
             Err(message)
         }
     };
-
-    if result.is_ok() {
-        if let Some(reason) = country_ban_bypass_failure {
-            log::warn!("Country ban bypass unavailable after connect: {reason}");
-            let _ = app.emit(COUNTRY_BAN_BYPASS_UNAVAILABLE, ());
-        }
-    }
 
     if result.is_ok() {
         // Publish the inner split-tunnel driver handle so polling commands

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -469,7 +469,13 @@ pub fn run() {
                 reapply_saved_roblox_fflags(&app_state);
             }
 
-            let run_on_startup_enabled = app_state.settings.lock().run_on_startup;
+            let (run_on_startup_enabled, country_ban_enabled) = {
+                let settings = app_state.settings.lock();
+                (
+                    settings.run_on_startup,
+                    !account_is_banned && settings.enable_country_ban,
+                )
+            };
             let vpn_state_rx = app_state.vpn_state_handle.clone();
             app.manage(app_state);
 
@@ -483,6 +489,20 @@ pub fn run() {
 
             if let Err(e) = autostart::sync_run_on_startup(app.handle(), run_on_startup_enabled) {
                 log::warn!("Failed to sync startup registration: {}", e);
+            }
+
+            if country_ban_enabled {
+                let app_handle = app.handle().clone();
+                runtime.spawn(async move {
+                    if let Some(state) = app_handle.try_state::<AppState>() {
+                        commands::country_ban::sync_country_ban_bypass_from_state(
+                            &app_handle,
+                            &state,
+                            "startup",
+                        )
+                        .await;
+                    }
+                });
             }
 
             // Window starts hidden via tauri.conf.json ("visible": false).
@@ -577,6 +597,9 @@ pub fn run() {
                     recover_stale_network_state();
                     // Restore network booster modifications (registry, MTU, firewall)
                     if let Some(state) = _app.try_state::<crate::state::AppState>() {
+                        if commands::country_ban::stop_country_ban_bypass_controller(&state) {
+                            log::info!("Stopped country ban bypass helper on app exit");
+                        }
                         let roblox_pid = {
                             let mut monitor = state.performance_monitor.lock();
                             monitor.get_roblox_pid().unwrap_or(0)

--- a/swifttunnel-desktop/src-tauri/src/state.rs
+++ b/swifttunnel-desktop/src-tauri/src/state.rs
@@ -7,6 +7,7 @@ use swifttunnel_core::discord_rpc::DiscordManager;
 use swifttunnel_core::network_booster::NetworkBooster;
 use swifttunnel_core::performance_monitor::PerformanceMonitor;
 use swifttunnel_core::roblox_optimizer::RobloxOptimizer;
+use swifttunnel_core::roblox_proxy::goodbyedpi::CountryBanBypassController;
 use swifttunnel_core::settings::AppSettings;
 use swifttunnel_core::system_optimizer::SystemOptimizer;
 use swifttunnel_core::vpn::SplitTunnelDriver;
@@ -44,6 +45,7 @@ pub struct AppState {
     pub system_optimizer: Arc<Mutex<SystemOptimizer>>,
     pub roblox_optimizer: Arc<Mutex<RobloxOptimizer>>,
     pub network_booster: Arc<Mutex<NetworkBooster>>,
+    pub country_ban_bypass: Arc<Mutex<CountryBanBypassController>>,
     pub discord_manager: Arc<Mutex<DiscordManager>>,
     pub runtime: Arc<tokio::runtime::Runtime>,
     pub launched_from_startup: bool,
@@ -87,6 +89,7 @@ impl AppState {
             system_optimizer: Arc::new(Mutex::new(SystemOptimizer::new())),
             roblox_optimizer: Arc::new(Mutex::new(roblox_optimizer)),
             network_booster: Arc::new(Mutex::new(NetworkBooster::new())),
+            country_ban_bypass: Arc::new(Mutex::new(CountryBanBypassController::new())),
             discord_manager: Arc::new(Mutex::new(DiscordManager::new(enable_discord_rpc))),
             runtime,
             launched_from_startup,

--- a/swifttunnel-desktop/src/components/boost/BoostTab.tsx
+++ b/swifttunnel-desktop/src/components/boost/BoostTab.tsx
@@ -419,7 +419,7 @@ export function BoostTab() {
         <SettingRow
           title="Bypass Country Bans"
           desc="Local DPI bypass for Roblox website/login and app"
-          tooltip="Starts SwiftTunnel's scoped GoodbyeDPI helper on the next connect. It is separate from Route Assist and does not route traffic through relays."
+          tooltip="Starts SwiftTunnel's scoped GoodbyeDPI helper for Roblox hostnames. It works without connecting the VPN and does not route traffic through relays."
           enabled={draftCountryBan}
           onChange={setDraftCountryBan}
         />


### PR DESCRIPTION
## Summary

- Move the Roblox country-ban GoodbyeDPI helper into app-managed state so it can run independently of VPN/tunnel sessions.
- Sync the helper on settings save, app startup, and VPN connect, while keeping VPN disconnect from stopping the standalone helper.
- Stop the helper on app exit and banned-session cleanup, and update the Roblox tab tooltip to describe the standalone behavior.

## Web research

Checked official Tauri command/state docs, Rust `std::process::Child` docs, and the GoodbyeDPI README. Options considered were keeping the VPN-only lifecycle, adding a new service/dependency wrapper, or reusing the existing scoped GoodbyeDPI launcher from app-managed state. Chose the no-new-dependency app-state controller because Tauri supports managed state access from commands and Rust `Child` requires explicit cleanup rather than relying on drop.

Sources:
- https://v2.tauri.app/develop/calling-rust/
- https://doc.rust-lang.org/std/process/struct.Child.html
- https://github.com/ValdikSS/GoodbyeDPI/blob/master/README.md

## Failure-mode plan

Primary success: when `enable_country_ban` is true, the Roblox-scoped GoodbyeDPI helper starts and remains active even when SwiftTunnel is disconnected; when false or during app shutdown/ban cleanup, SwiftTunnel stops the helper it owns.

Failure classes: missing helper or non-Windows support is diagnostic-only and does not block settings save or VPN connect. Spawn/escalation failure emits the existing country-ban unavailable event. VPN disconnect failures remain tunnel-specific and no longer mask or stop the standalone helper.

Trigger signals: lifecycle uses the structured `enable_country_ban` setting and explicit sync calls, not log text or substring matching.

Partial success and races: the controller is idempotent, avoids duplicate starts, serializes start/stop through one mutex, and does not retry in a loop inside one sync call.

Tests: added controller tests for start-on-enable, no duplicate start, stop-on-disable, disabled no-op, unavailable start, and failed start.

## Verification

- `cargo fmt --check` passed.
- `git diff --check` passed.
- `npm test -- --run` passed: 20 files, 146 tests.
- `npx tsc --noEmit` passed.
- `npm run build` passed, with the existing Vite chunk-size warning.
- `cargo test -p swifttunnel-core roblox_proxy::goodbyedpi --lib` could not reach SwiftTunnel tests locally on macOS because `windows-future` / `windows-core` failed first with missing `windows_core::imp::IMarshal`, `windows_core::imp::marshaler`, and `windows_threading::submit`, matching the project checklist caveat. Windows CI is the authoritative Rust gate for that dependency path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a managed Country Ban Bypass controller with start/stop and sync behavior.
  * Controller auto-syncs from settings at startup, during settings save, before VPN connect, and on shutdown.
  * App now stops the bypass during banned-session cleanup and when exiting; exposes stop/sync outcomes for UI/events.

* **Documentation**
  * Updated "Bypass Country Bans" tooltip to clarify it runs for Roblox hostnames without VPN or relay routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->