### PR TITLE
Add Windows ARM64 release support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,54 @@ jobs:
       - name: Test desktop backend
         run: cargo test -p swifttunnel-desktop -- --nocapture
 
+  rust-arm64:
+    name: Rust Check (GitHub Windows ARM64)
+    runs-on: windows-11-arm
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Ensure Git Bash
+        shell: powershell
+        run: |
+          $gitBashPaths = @(
+            'C:\Program Files\Git\bin',
+            'C:\Program Files\Git\usr\bin'
+          ) | Where-Object { Test-Path $_ }
+
+          if ($gitBashPaths.Count -eq 0) {
+            throw 'Git Bash was not found on the GitHub-hosted Windows ARM64 runner.'
+          }
+
+          foreach ($path in $gitBashPaths) {
+            $path | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            $env:Path = "$path;$env:Path"
+          }
+
+          bash --version
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-pc-windows-msvc
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check core
+        run: cargo check -p swifttunnel-core --target aarch64-pc-windows-msvc
+
+      - name: Check desktop backend
+        run: cargo check -p swifttunnel-desktop --target aarch64-pc-windows-msvc
+
+      - name: Test core
+        run: cargo test -p swifttunnel-core --target aarch64-pc-windows-msvc -- --nocapture
+
+      - name: Test desktop backend
+        run: cargo test -p swifttunnel-desktop --target aarch64-pc-windows-msvc -- --nocapture
+
   split-tunnel-testbench-availability:
     name: Split Tunnel Testbench Availability
     runs-on: ubuntu-latest
@@ -188,7 +236,11 @@ jobs:
           git clean -ffdx -e target/ -e swifttunnel-desktop/src-tauri/target/
           $bundleDirs = @(
             "target/release/bundle",
-            "swifttunnel-desktop/src-tauri/target/release/bundle"
+            "target/x86_64-pc-windows-msvc/release/bundle",
+            "target/aarch64-pc-windows-msvc/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/aarch64-pc-windows-msvc/release/bundle"
           )
           Remove-Item -Path $bundleDirs -Recurse -Force -ErrorAction SilentlyContinue
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,11 @@ jobs:
         run: cargo test -p swifttunnel-desktop -- --nocapture
 
   rust-arm64:
-    name: Rust Check (GitHub Windows ARM64)
+    name: Rust Check (Windows ARM64 native)
+    # Run natively on Windows ARM64. The default host toolchain targets
+    # aarch64-pc-windows-msvc, so there's no cross-compile import-lib pain
+    # (windows-rs resolves its native windows.lib instead of LNK1181) and the
+    # ARM64 tests actually execute instead of only compiling with --no-run.
     runs-on: windows-11-arm
     timeout-minutes: 60
 
@@ -138,7 +142,7 @@ jobs:
           ) | Where-Object { Test-Path $_ }
 
           if ($gitBashPaths.Count -eq 0) {
-            throw 'Git Bash was not found on the GitHub-hosted Windows ARM64 runner.'
+            throw 'Git Bash was not found on the GitHub-hosted Windows runner.'
           }
 
           foreach ($path in $gitBashPaths) {
@@ -151,22 +155,30 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-pc-windows-msvc
+          components: rustfmt
+
+      - name: Cache Rust build outputs
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+          cache-on-failure: true
+          save-if: ${{ github.event_name != 'pull_request' }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Check core
-        run: cargo check -p swifttunnel-core --target aarch64-pc-windows-msvc
+        run: cargo check -p swifttunnel-core
 
       - name: Check desktop backend
-        run: cargo check -p swifttunnel-desktop --target aarch64-pc-windows-msvc
+        run: cargo check -p swifttunnel-desktop
 
       - name: Test core
-        run: cargo test -p swifttunnel-core --target aarch64-pc-windows-msvc -- --nocapture
+        run: cargo test -p swifttunnel-core -- --nocapture
 
       - name: Test desktop backend
-        run: cargo test -p swifttunnel-desktop --target aarch64-pc-windows-msvc -- --nocapture
+        run: cargo test -p swifttunnel-desktop -- --nocapture
 
   split-tunnel-testbench-availability:
     name: Split Tunnel Testbench Availability

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,11 @@ jobs:
           git clean -ffdx -e target/ -e swifttunnel-desktop/src-tauri/target/
           $bundleDirs = @(
             "target/release/bundle",
-            "swifttunnel-desktop/src-tauri/target/release/bundle"
+            "target/x86_64-pc-windows-msvc/release/bundle",
+            "target/aarch64-pc-windows-msvc/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle",
+            "swifttunnel-desktop/src-tauri/target/aarch64-pc-windows-msvc/release/bundle"
           )
           Remove-Item -Path $bundleDirs -Recurse -Force -ErrorAction SilentlyContinue
 
@@ -286,6 +290,31 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+
+      - name: Verify Windows ARM64 build tools
+        shell: powershell
+        run: |
+          $programFilesX86 = [Environment]::GetEnvironmentVariable("ProgramFiles(x86)")
+          if ([string]::IsNullOrWhiteSpace($programFilesX86)) {
+            $programFilesX86 = "C:\Program Files (x86)"
+          }
+          $vswhere = Join-Path $programFilesX86 "Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe was not found; install Visual Studio Build Tools with MSVC x64 and ARM64 components on the release runner."
+          }
+
+          $installPath = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
+            -property installationPath
+
+          if ([string]::IsNullOrWhiteSpace($installPath)) {
+            throw "Visual Studio Build Tools with both MSVC x64 and ARM64 components were not found. Install Microsoft.VisualStudio.Component.VC.Tools.x86.x64 and Microsoft.VisualStudio.Component.VC.Tools.ARM64 on the release runner."
+          }
+
+          Write-Host "Found Visual Studio toolchain with ARM64 support at $installPath"
 
       # No GitHub-backed Rust cache. Tag-triggered runs are scoped to their
       # own ref, so each tag would always miss caches saved by prior tags.
@@ -636,8 +665,8 @@ jobs:
           [System.IO.File]::WriteAllText($confPath, ($config | ConvertTo-Json -Depth 32), $utf8NoBom)
           Write-Host "::notice::Authenticode signCommand injected - Tauri will sign SwiftTunnel.exe and the MSI installer"
 
-      - name: Build and publish release
-        uses: tauri-apps/tauri-action@v0
+      - name: Build and publish x64 release
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_UPDATER_LEGACY_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_LEGACY_PUBLIC_KEY }}
@@ -666,6 +695,127 @@ jobs:
           generateReleaseNotes: false
           includeUpdaterJson: true
           updaterJsonPreferNsis: false
+          args: --target x86_64-pc-windows-msvc
+
+      - name: Build and publish ARM64 release
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_UPDATER_LEGACY_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_LEGACY_PUBLIC_KEY }}
+          SWIFTTUNNEL_UPDATE_MANIFEST_PUBLIC_KEY_B64: ${{ secrets.SWIFTTUNNEL_UPDATE_MANIFEST_PUBLIC_KEY_B64 }}
+          # Code signing passthrough - all optional. Populate whichever secrets
+          # your signing provider needs so the signCommand injected above can
+          # reference them as %VAR% (cmd.exe) or $env:VAR (PowerShell).
+          SMCTL_KEYPAIR_ALIAS: ${{ secrets.SMCTL_KEYPAIR_ALIAS }}
+          SMCTL_API_KEY: ${{ secrets.SMCTL_API_KEY }}
+          SMCTL_HOST: ${{ secrets.SMCTL_HOST }}
+          SMCTL_CLIENT_CERT_FILE: ${{ secrets.SMCTL_CLIENT_CERT_FILE }}
+          SMCTL_CLIENT_CERT_PASSWORD: ${{ secrets.SMCTL_CLIENT_CERT_PASSWORD }}
+          ESIGNER_USER: ${{ secrets.ESIGNER_USER }}
+          ESIGNER_PASS: ${{ secrets.ESIGNER_PASS }}
+          ESIGNER_CRED: ${{ secrets.ESIGNER_CRED }}
+          ESIGNER_TOTP: ${{ secrets.ESIGNER_TOTP }}
+          PFX_PATH: ${{ secrets.PFX_PATH }}
+          PFX_PASSWORD: ${{ secrets.PFX_PASSWORD }}
+        with:
+          projectPath: swifttunnel-desktop
+          tagName: ${{ steps.meta.outputs.tag }}
+          releaseName: SwiftTunnel v${{ steps.meta.outputs.version }}
+          releaseBody: ${{ steps.release_notes.outputs.body }}
+          releaseDraft: false
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          generateReleaseNotes: false
+          includeUpdaterJson: false
+          updaterJsonPreferNsis: false
+          args: --target aarch64-pc-windows-msvc
+
+      - name: Merge ARM64 updater metadata
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          $outDir = Join-Path $env:RUNNER_TEMP "swifttunnel_latest"
+          Remove-Item -Path $outDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+          gh release download $env:TAG --repo $env:GITHUB_REPOSITORY --pattern "latest.json" --dir $outDir --clobber
+          $latestPath = Join-Path $outDir "latest.json"
+          if (-not (Test-Path $latestPath)) {
+            throw "latest.json was not found in release assets for $env:TAG after the x64 build"
+          }
+
+          $latest = Get-Content $latestPath -Raw | ConvertFrom-Json
+          if (-not $latest.platforms) {
+            throw "latest.json does not contain a platforms object"
+          }
+          if (-not $latest.platforms.PSObject.Properties["windows-x86_64"]) {
+            throw "latest.json does not contain windows-x86_64 metadata"
+          }
+
+          $releaseJson = gh release view $env:TAG --repo $env:GITHUB_REPOSITORY --json assets
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($releaseJson)) {
+            throw "Failed to inspect release assets for $env:TAG"
+          }
+
+          $assets = ($releaseJson | ConvertFrom-Json).assets
+          $armUpdaterBundle = $assets |
+            Where-Object { $_.name -match '(?i)(aarch64|arm64).*\.msi$' -and $_.name -notmatch '(?i)\.sig$' } |
+            Select-Object -First 1
+          if (-not $armUpdaterBundle) {
+            $armUpdaterBundle = $assets |
+              Where-Object { $_.name -match '(?i)(aarch64|arm64).*\.zip$' -and $_.name -notmatch '(?i)\.sig$' } |
+              Select-Object -First 1
+          }
+          if (-not $armUpdaterBundle) {
+            throw "Could not find an ARM64 updater asset in release $env:TAG"
+          }
+
+          $armSignatureAsset = $assets |
+            Where-Object { $_.name -eq "$($armUpdaterBundle.name).sig" } |
+            Select-Object -First 1
+          if (-not $armSignatureAsset) {
+            $armSignatureAsset = $assets |
+              Where-Object { $_.name -match '(?i)(aarch64|arm64).*\.(msi|zip)\.sig$' } |
+              Select-Object -First 1
+          }
+          if (-not $armSignatureAsset) {
+            throw "Could not find an ARM64 updater signature asset for $($armUpdaterBundle.name)"
+          }
+
+          $armSignatureName = $armSignatureAsset.name
+          gh release download $env:TAG --repo $env:GITHUB_REPOSITORY --pattern $armSignatureName --dir $outDir --clobber
+          $signaturePath = Join-Path $outDir $armSignatureName
+          if (-not (Test-Path $signaturePath)) {
+            throw "Downloaded ARM64 updater signature was not found at $signaturePath"
+          }
+
+          $signature = (Get-Content $signaturePath -Raw).Trim()
+          if ([string]::IsNullOrWhiteSpace($signature)) {
+            throw "ARM64 updater signature asset $($armSignatureAsset.name) is empty"
+          }
+
+          $encodedAssetName = [System.Uri]::EscapeDataString($armUpdaterBundle.name).Replace("%2F", "/")
+          $armUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/$env:TAG/$encodedAssetName"
+
+          $armPlatform = [ordered]@{
+            signature = $signature
+            url = $armUrl
+          }
+
+          $latest.platforms | Add-Member -NotePropertyName "windows-aarch64" -NotePropertyValue $armPlatform -Force
+          $latest.platforms | Add-Member -NotePropertyName "windows-aarch64-msi" -NotePropertyValue $armPlatform -Force
+
+          if (-not $latest.platforms.PSObject.Properties["windows-aarch64"]) {
+            throw "Failed to add windows-aarch64 metadata to latest.json"
+          }
+          if (-not $latest.platforms.PSObject.Properties["windows-aarch64-msi"]) {
+            throw "Failed to add windows-aarch64-msi metadata to latest.json"
+          }
+
+          $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+          [System.IO.File]::WriteAllText($latestPath, ($latest | ConvertTo-Json -Depth 32), $utf8NoBom)
+          gh release upload $env:TAG $latestPath --repo $env:GITHUB_REPOSITORY --clobber
 
       - name: Generate and upload signed release manifest
         shell: powershell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,15 +1652,6 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -3025,7 +3016,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3178,6 +3169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4229,27 +4229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,13 +4274,13 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysinfo",
+ "tauri-winrt-notification",
  "thiserror 1.0.69",
  "tiny_http",
  "tokio",
  "url",
  "windows 0.62.2",
  "winreg 0.52.0",
- "winrt-notification",
 ]
 
 [[package]]
@@ -4763,6 +4742,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -5703,18 +5694,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f39345ae0c8ab072c0ac7fe8a8b411636aa34f89be19ddd0d9226544f13944"
-dependencies = [
- "windows_i686_gnu 0.24.0",
- "windows_i686_msvc 0.24.0",
- "windows_x86_64_gnu 0.24.0",
- "windows_x86_64_msvc 0.24.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -6141,12 +6120,6 @@ checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0866510a3eca9aed73a077490bbbf03e5eaac4e1fd70849d89539e5830501fd"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
@@ -6183,12 +6156,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0ffed56b7e9369a29078d2ab3aaeceea48eb58999d2cff3aa2494a275b95c6"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -6210,12 +6177,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384a173630588044205a2993b6864a2f56e5a8c1e7668c07b93ec18cf4888dc4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6264,12 +6225,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd8f062d8ca5446358159d79a90be12c543b3a965c847c8f3eedf14b321d399"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6340,17 +6295,6 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "winrt-notification"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007a0353840b23e0c6dc73e5b962ff58ed7f6bc9ceff3ce7fe6fbad8d496edf4"
-dependencies = [
- "strum",
- "windows 0.24.0",
- "xml-rs",
 ]
 
 [[package]]
@@ -6498,12 +6442,6 @@ dependencies = [
  "libc",
  "rustix",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yoke"

--- a/swifttunnel-core/Cargo.toml
+++ b/swifttunnel-core/Cargo.toml
@@ -122,4 +122,6 @@ discord-rich-presence = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
-winrt-notification = "0.5"
+# Maintained fork of winrt-notification; the original 0.5 pulls in windows 0.24,
+# which ships no aarch64 import libraries and fails ARM64 linking (LNK1181).
+tauri-winrt-notification = "0.7"

--- a/swifttunnel-core/src/notification.rs
+++ b/swifttunnel-core/src/notification.rs
@@ -6,7 +6,7 @@
 #[cfg(windows)]
 use std::path::Path;
 #[cfg(windows)]
-use winrt_notification::{Duration, IconCrop, Sound, Toast};
+use tauri_winrt_notification::{Duration, IconCrop, Sound, Toast};
 
 /// SwiftTunnel's App User Model ID for Windows notifications.
 /// Only works when the app is installed with a matching Start menu shortcut.

--- a/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
+++ b/swifttunnel-core/src/roblox_proxy/goodbyedpi.rs
@@ -19,6 +19,13 @@ const ROBLOX_REACHABILITY_TARGET: (&str, u16) = ("www.roblox.com", 443);
 const GOODBYEDPI_MODE_STARTUP_WAIT: Duration = Duration::from_secs(3);
 const ROBLOX_REACHABILITY_TIMEOUT: Duration = Duration::from_millis(1500);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GoodbyeDpiNativeArch {
+    X86,
+    X64,
+    Arm64,
+}
+
 #[derive(Debug)]
 #[must_use = "dropping GoodbyeDpiGuard stops the GoodbyeDPI subprocess"]
 pub struct GoodbyeDpiGuard {
@@ -72,6 +79,15 @@ impl Drop for GoodbyeDpiGuard {
 pub fn start_for_roblox() -> Result<Option<GoodbyeDpiGuard>, String> {
     if !cfg!(windows) {
         debug!("GoodbyeDPI helper skipped: supported only on Windows");
+        return Ok(None);
+    }
+
+    let native_arch = current_goodbyedpi_native_arch();
+    if !bundled_goodbyedpi_supports_arch(native_arch) {
+        warn!(
+            "GoodbyeDPI helper skipped: bundled WinDivert payload is not compatible with {:?}",
+            native_arch
+        );
         return Ok(None);
     }
 
@@ -145,6 +161,23 @@ pub fn start_for_roblox() -> Result<Option<GoodbyeDpiGuard>, String> {
         "GoodbyeDPI could not make Roblox reachable after trying modes -1 through -9 ({})",
         failures.join("; ")
     ))
+}
+
+fn current_goodbyedpi_native_arch() -> GoodbyeDpiNativeArch {
+    match crate::vpn::winpkfilter::detect_native_arch() {
+        crate::vpn::winpkfilter::WinpkFilterMsiArch::X64 => {
+            if cfg!(all(windows, target_arch = "x86")) {
+                GoodbyeDpiNativeArch::X86
+            } else {
+                GoodbyeDpiNativeArch::X64
+            }
+        }
+        crate::vpn::winpkfilter::WinpkFilterMsiArch::Arm64 => GoodbyeDpiNativeArch::Arm64,
+    }
+}
+
+pub(crate) fn bundled_goodbyedpi_supports_arch(arch: GoodbyeDpiNativeArch) -> bool {
+    matches!(arch, GoodbyeDpiNativeArch::X86 | GoodbyeDpiNativeArch::X64)
 }
 
 fn locate_goodbyedpi_executable() -> Option<PathBuf> {
@@ -379,5 +412,18 @@ mod tests {
         assert!(paths.contains(&PathBuf::from(
             "C:/Program Files/SwiftTunnel/tools/goodbyedpi/x86_64/goodbyedpi.exe"
         )));
+    }
+
+    #[test]
+    fn bundled_goodbyedpi_supports_x86_and_x64_payloads() {
+        assert!(bundled_goodbyedpi_supports_arch(GoodbyeDpiNativeArch::X86));
+        assert!(bundled_goodbyedpi_supports_arch(GoodbyeDpiNativeArch::X64));
+    }
+
+    #[test]
+    fn bundled_goodbyedpi_rejects_arm64_payloads() {
+        assert!(!bundled_goodbyedpi_supports_arch(
+            GoodbyeDpiNativeArch::Arm64
+        ));
     }
 }

--- a/swifttunnel-desktop/src-tauri/src/lib.rs
+++ b/swifttunnel-desktop/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ const APP_ICON: tauri::image::Image<'static> = tauri::include_image!("./icons/ic
 fn sync_runtime_assets(app: &tauri::App) {
     use std::fs;
     use std::path::{Path, PathBuf};
+    use swifttunnel_core::vpn::winpkfilter::WinpkFilterMsiArch;
 
     fn first_existing(candidates: Vec<PathBuf>) -> Option<PathBuf> {
         candidates.into_iter().find(|p| p.exists())
@@ -105,49 +106,56 @@ fn sync_runtime_assets(app: &tauri::App) {
         }
     };
 
-    let targets: Vec<(&str, Option<PathBuf>, PathBuf)> = vec![
+    let native_arch = swifttunnel_core::vpn::winpkfilter::detect_native_arch();
+    let mut targets: Vec<(&str, Option<PathBuf>, PathBuf)> = vec![{
+        let msi_name = swifttunnel_core::vpn::winpkfilter::native_msi_package().msi_name;
         (
-            "wintun.dll",
+            msi_name,
             first_existing(vec![
-                resource_dir.join("drivers").join("wintun.dll"),
-                resource_dir.join("wintun.dll"),
+                resource_dir.join("drivers").join(msi_name),
+                resource_dir.join(msi_name),
             ]),
-            exe_dir.join("wintun.dll"),
-        ),
-        {
-            let msi_name = swifttunnel_core::vpn::winpkfilter::native_msi_package().msi_name;
+            exe_dir.join("drivers").join(msi_name),
+        )
+    }];
+
+    if native_arch == WinpkFilterMsiArch::Arm64 {
+        log::debug!("Skipping x64-only legacy driver runtime assets on Windows ARM64");
+    } else {
+        targets.extend([
             (
-                msi_name,
+                "wintun.dll",
                 first_existing(vec![
-                    resource_dir.join("drivers").join(msi_name),
-                    resource_dir.join(msi_name),
+                    resource_dir.join("drivers").join("wintun.dll"),
+                    resource_dir.join("wintun.dll"),
                 ]),
-                exe_dir.join("drivers").join(msi_name),
-            )
-        },
-        (
-            "winfw.dll",
-            first_existing(vec![resource_dir.join("drivers").join("winfw.dll")]),
-            exe_dir.join("drivers").join("winfw.dll"),
-        ),
-        (
-            "mullvad-split-tunnel.sys",
-            first_existing(vec![
-                resource_dir
-                    .join("drivers")
-                    .join("mullvad-split-tunnel.sys"),
-            ]),
-            exe_dir.join("drivers").join("mullvad-split-tunnel.sys"),
-        ),
-        (
-            "nvidiaProfileInspector",
-            first_existing(vec![
-                resource_dir.join("tools").join("nvidiaProfileInspector"),
-                resource_dir.join("nvidiaProfileInspector"),
-            ]),
-            exe_dir.join("tools").join("nvidiaProfileInspector"),
-        ),
-    ];
+                exe_dir.join("wintun.dll"),
+            ),
+            (
+                "winfw.dll",
+                first_existing(vec![resource_dir.join("drivers").join("winfw.dll")]),
+                exe_dir.join("drivers").join("winfw.dll"),
+            ),
+            (
+                "mullvad-split-tunnel.sys",
+                first_existing(vec![
+                    resource_dir
+                        .join("drivers")
+                        .join("mullvad-split-tunnel.sys"),
+                ]),
+                exe_dir.join("drivers").join("mullvad-split-tunnel.sys"),
+            ),
+        ]);
+    }
+
+    targets.push((
+        "nvidiaProfileInspector",
+        first_existing(vec![
+            resource_dir.join("tools").join("nvidiaProfileInspector"),
+            resource_dir.join("nvidiaProfileInspector"),
+        ]),
+        exe_dir.join("tools").join("nvidiaProfileInspector"),
+    ));
 
     for (name, source, destination) in targets {
         let Some(source) = source else {


### PR DESCRIPTION
## Summary
- Add a native Windows ARM64 CI job on `windows-11-arm` with formatting, check, and test coverage for the Rust backend crates.
- Build x64 and ARM64 Windows release artifacts, preflight ARM64 MSVC tools, and merge `windows-aarch64` / `windows-aarch64-msi` updater metadata into `latest.json` before signing the outer SwiftTunnel manifest.
- Skip the bundled GoodbyeDPI WinDivert helper on ARM64 machines and avoid staging x64-only legacy driver assets there, while continuing to stage the native WinpkFilter MSI.

## Web research
- Tauri updater docs: static updater JSON uses architecture-specific platform keys such as `windows-x86_64` and `windows-aarch64`.
- Tauri action metadata: the pinned `v0` action uses `includeUpdaterJson`, so ARM64 publishing disables updater JSON and the workflow merges metadata itself.
- GitHub hosted runner docs: public repositories can use `windows-11-arm` for Windows ARM64 CI.
- Microsoft Windows on Arm docs: driver-backed features need native ARM64 driver payloads, so x86/x64 WinDivert payloads must not be used as recovery behavior on ARM64.

## Verification
- `cargo fmt --all -- --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- `git diff --check`
- `npm test` from `swifttunnel-desktop`
- `npm run build` from `swifttunnel-desktop`
- `coderabbit review --agent` twice; addressed the major findings. The remaining minor suggestion to pin all existing CI actions is broader than this ARM64 support change, so only the newly duplicated Tauri release action was pinned.

Local Rust `cargo check` / `cargo test` for `swifttunnel-core` are blocked on this macOS host by an existing `windows-future 0.3.2` compile failure before SwiftTunnel code is reached; Windows CI is expected to cover the Rust backend path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native Windows ARM64 support with architecture-aware asset staging so only compatible components are deployed.
  * Launcher avoids starting incompatible bundled components on unsupported architectures.

* **Chores**
  * CI expanded to validate, format-check, build, and test Windows ARM64 artifacts alongside x64.
  * Release process split per-architecture; ARM64 artifacts and updater metadata are published and merged.

* **Bug Fixes**
  * Workspace cleanup updated to preserve and remove the correct bundle outputs for both architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->