### PR TITLE
Use WinpkFilter for IPv6 leak blocking

### DIFF
--- a/swifttunnel-core/src/vpn/ipv6_recovery.rs
+++ b/swifttunnel-core/src/vpn/ipv6_recovery.rs
@@ -1,12 +1,12 @@
 //! IPv6 leak-prevention crash recovery
 //!
-//! While connected, SwiftTunnel installs a Windows Firewall rule that blocks
-//! outbound IPv6. The marker file records that we did so (and which method we
-//! used) so a startup recovery pass can clean up after a crash without
-//! guessing at adapter state. Old installations used a different method
-//! (`Disable-NetAdapterBinding ms_tcpip6`); we keep the deserialization shape
-//! backwards-compatible so an upgrade across that boundary still recovers
-//! cleanly.
+//! While connected, SwiftTunnel installs a WinpkFilter static drop filter that
+//! blocks outbound public IPv6/NAT64. The marker file records that we did so
+//! (and which method we used) so a startup recovery pass can clean up after a
+//! crash without guessing at adapter state. Old installations used different
+//! methods (`Disable-NetAdapterBinding ms_tcpip6` and a Windows Firewall rule);
+//! we keep the deserialization shape backwards-compatible so an upgrade across
+//! those boundaries still recovers cleanly.
 
 pub const IPV6_BLOCK_RULE_NAME: &str = "SwiftTunnel-Block-IPv6-Outbound";
 pub const IPV6_BLOCK_REMOTE_IPS: &str = "2000::/3,64:ff9b::/96";
@@ -29,10 +29,14 @@ pub enum DisableMethod {
     /// markers that predate the method field.
     #[default]
     BindingDisable,
-    /// Current method: a Windows Firewall outbound block rule named
+    /// Intermediate method: a Windows Firewall outbound block rule named
     /// [`IPV6_BLOCK_RULE_NAME`] that drops public IPv6/NAT64 traffic. No
     /// adapter rebind, no WMI involvement.
     FirewallRule,
+    /// Current method: WinpkFilter static filters drop outbound public
+    /// IPv6/NAT64 traffic on the selected adapter. No Windows Firewall policy
+    /// writes and no adapter rebind.
+    WinpkFilterStaticFilter,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -57,6 +61,14 @@ impl Ipv6Marker {
             adapter_name,
             originally_enabled: None,
             method: DisableMethod::FirewallRule,
+        }
+    }
+
+    pub(crate) fn for_winpkfilter_static_filter(adapter_name: String) -> Self {
+        Self {
+            adapter_name,
+            originally_enabled: None,
+            method: DisableMethod::WinpkFilterStaticFilter,
         }
     }
 
@@ -92,6 +104,9 @@ impl Ipv6Marker {
         "#,
                 IPV6_BLOCK_RULE_NAME
             ),
+            DisableMethod::WinpkFilterStaticFilter => {
+                "Write-Host 'WinpkFilter IPv6 filters are restored natively'".to_string()
+            }
             DisableMethod::BindingDisable => match self.originally_enabled {
                 Some(false) => {
                     "Disable-NetAdapterBinding -Name $adapter -ComponentId ms_tcpip6 -Confirm:$false 2>$null".to_string()
@@ -264,10 +279,18 @@ pub fn write_ipv6_marker(adapter_name: &str) {
 }
 
 /// Write a marker indicating the firewall-rule method was used to block IPv6.
-/// Used by the modern disable path so a crash-recovery pass can run
+/// Kept for legacy callers/markers so crash recovery can still run
 /// `netsh advfirewall firewall delete rule` to clean up.
 pub fn write_ipv6_marker_firewall(adapter_name: &str) {
     let marker = Ipv6Marker::for_firewall_rule(adapter_name.trim().to_string());
+    write_marker(&marker);
+}
+
+/// Write a marker indicating WinpkFilter static filters were used to block
+/// IPv6. Used by the modern disable path so a crash-recovery pass can clear
+/// the driver filter table.
+pub fn write_ipv6_marker_winpkfilter(adapter_name: &str) {
+    let marker = Ipv6Marker::for_winpkfilter_static_filter(adapter_name.trim().to_string());
     write_marker(&marker);
 }
 
@@ -400,9 +423,47 @@ fn restore_firewall_rule_marker(adapter_name: &str) -> bool {
     true
 }
 
+#[cfg(target_os = "windows")]
+pub fn reset_winpkfilter_ipv6_block_filters() -> Result<(), String> {
+    let driver = ndisapi::Ndisapi::new("NDISRD")
+        .map_err(|e| format!("Failed to open WinpkFilter driver: {e}"))?;
+    driver
+        .reset_packet_filter_table()
+        .map_err(|e| format!("Failed to reset WinpkFilter static filter table: {e}"))?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn reset_winpkfilter_ipv6_block_filters() -> Result<(), String> {
+    Err("WinpkFilter IPv6 filter cleanup is only available on Windows.".to_string())
+}
+
+fn restore_winpkfilter_static_filter_marker(adapter_name: &str) -> bool {
+    match reset_winpkfilter_ipv6_block_filters() {
+        Ok(()) => {
+            log::info!(
+                "WinpkFilter IPv6 block filters cleared successfully for adapter: {}",
+                adapter_name
+            );
+            true
+        }
+        Err(e) => {
+            log::warn!(
+                "Failed to clear WinpkFilter IPv6 block filters for adapter {}: {}",
+                adapter_name,
+                e
+            );
+            false
+        }
+    }
+}
+
 fn restore_ipv6_for_marker(marker: &Ipv6Marker) -> bool {
     if marker.method() == &DisableMethod::FirewallRule {
         return restore_firewall_rule_marker(marker.adapter_name());
+    }
+    if marker.method() == &DisableMethod::WinpkFilterStaticFilter {
+        return restore_winpkfilter_static_filter_marker(marker.adapter_name());
     }
 
     let script = build_restore_script(marker);
@@ -498,6 +559,16 @@ mod tests {
         assert!(cmd.contains("netsh.exe advfirewall firewall delete rule"));
         assert!(cmd.contains("netsh.exe advfirewall firewall show rule"));
         assert!(cmd.contains("exit 1"));
+    }
+
+    #[test]
+    fn test_winpkfilter_static_filter_marker_round_trips() {
+        let marker = Ipv6Marker::for_winpkfilter_static_filter("Ethernet".to_string());
+        let payload = serde_json::to_vec(&marker).unwrap();
+        let decoded: Ipv6Marker = serde_json::from_slice(&payload).unwrap();
+
+        assert_eq!(decoded.method(), &DisableMethod::WinpkFilterStaticFilter);
+        assert_eq!(decoded.adapter_name(), "Ethernet");
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/ipv6_recovery.rs
+++ b/swifttunnel-core/src/vpn/ipv6_recovery.rs
@@ -15,8 +15,186 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+#[cfg(target_os = "windows")]
+use ndisapi::StaticFilterTable;
+#[cfg(any(test, target_os = "windows"))]
+use ndisapi::{
+    DataLinkLayerFilter, DirectionFlags, FILTER_PACKET_DROP, FilterLayerFlags, IP_SUBNET_V6_TYPE,
+    IPV6, IpAddressV6, IpAddressV6Union, IpSubnetV6, IpV6Filter, IpV6FilterFlags,
+    NetworkLayerFilter, NetworkLayerFilterUnion, StaticFilter, TransportLayerFilter,
+};
+#[cfg(any(test, target_os = "windows"))]
+use windows::Win32::Networking::WinSock::{IN6_ADDR, IN6_ADDR_0};
+
+/// Outbound IPv6 destinations dropped while the IPv4-only tunnel is active:
+/// global unicast (2000::/3), the NAT64 well-known prefix (64:ff9b::/96,
+/// RFC 6052), and the NAT64 local-use prefix (64:ff9b:1::/48, RFC 8215).
+/// Network-specific NAT64 prefixes carved out of provider global unicast
+/// space already fall inside 2000::/3.
+#[cfg(any(test, target_os = "windows"))]
+const IPV6_PUBLIC_NETWORK: [u8; 16] = [0x20, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+#[cfg(any(test, target_os = "windows"))]
+const IPV6_PUBLIC_MASK: [u8; 16] = [0xe0, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+#[cfg(any(test, target_os = "windows"))]
+const IPV6_NAT64_NETWORK: [u8; 16] = [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+#[cfg(any(test, target_os = "windows"))]
+const IPV6_NAT64_MASK: [u8; 16] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0,
+];
+#[cfg(any(test, target_os = "windows"))]
+const IPV6_NAT64_LOCAL_NETWORK: [u8; 16] = [
+    0x00, 0x64, 0xff, 0x9b, 0x00, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+#[cfg(any(test, target_os = "windows"))]
+const IPV6_NAT64_LOCAL_MASK: [u8; 16] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+/// The exact destination subnets SwiftTunnel's IPv6 drop filters use. Filter
+/// ownership during merge/cleanup is decided by matching these subnets plus
+/// the full drop-filter shape — never by adapter handle (stale across
+/// reboots) or table position.
+#[cfg(any(test, target_os = "windows"))]
+const SWIFTTUNNEL_IPV6_BLOCK_SUBNETS: [([u8; 16], [u8; 16]); 3] = [
+    (IPV6_PUBLIC_NETWORK, IPV6_PUBLIC_MASK),
+    (IPV6_NAT64_NETWORK, IPV6_NAT64_MASK),
+    (IPV6_NAT64_LOCAL_NETWORK, IPV6_NAT64_LOCAL_MASK),
+];
+
+/// Generous upper bound for reading/merging the driver's static filter table.
+/// SwiftTunnel installs 3 entries; anything near this limit means another
+/// WinpkFilter consumer filled the table.
+#[cfg(target_os = "windows")]
+const STATIC_FILTER_TABLE_CAPACITY: usize = 256;
+
+#[cfg(any(test, target_os = "windows"))]
+fn in6_addr(bytes: [u8; 16]) -> IN6_ADDR {
+    IN6_ADDR {
+        u: IN6_ADDR_0 { Byte: bytes },
+    }
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn ipv6_subnet_filter_address(network: [u8; 16], mask: [u8; 16]) -> IpAddressV6 {
+    IpAddressV6::new(
+        IP_SUBNET_V6_TYPE,
+        IpAddressV6Union {
+            ip_subnet: IpSubnetV6::new(in6_addr(network), in6_addr(mask)),
+        },
+    )
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn build_ipv6_block_filter(adapter_handle: u64, network: [u8; 16], mask: [u8; 16]) -> StaticFilter {
+    StaticFilter::new(
+        adapter_handle,
+        DirectionFlags::PACKET_FLAG_ON_SEND,
+        FILTER_PACKET_DROP,
+        FilterLayerFlags::NETWORK_LAYER_VALID,
+        DataLinkLayerFilter::default(),
+        NetworkLayerFilter::new(
+            IPV6,
+            NetworkLayerFilterUnion {
+                ipv6: IpV6Filter::new(
+                    IpV6FilterFlags::IP_V6_FILTER_DEST_ADDRESS,
+                    IpAddressV6::default(),
+                    ipv6_subnet_filter_address(network, mask),
+                    0,
+                ),
+            },
+        ),
+        TransportLayerFilter::default(),
+    )
+}
+
+/// SwiftTunnel's outbound IPv6 drop filters for the selected adapter.
+#[cfg(any(test, target_os = "windows"))]
+pub(crate) fn swifttunnel_ipv6_block_filters(adapter_handle: u64) -> [StaticFilter; 3] {
+    SWIFTTUNNEL_IPV6_BLOCK_SUBNETS
+        .map(|(network, mask)| build_ipv6_block_filter(adapter_handle, network, mask))
+}
+
+/// Whether a static filter entry is one of SwiftTunnel's IPv6 drop filters.
+///
+/// Matches the full filter shape (outbound, drop, network-layer-only, IPv6
+/// destination subnet equal to one of [`SWIFTTUNNEL_IPV6_BLOCK_SUBNETS`]).
+/// A filter that differs in any of those fields belongs to someone else and
+/// must be preserved.
+#[cfg(any(test, target_os = "windows"))]
+pub(crate) fn is_swifttunnel_ipv6_block_filter(filter: &StaticFilter) -> bool {
+    // Copy fields out of the packed struct; taking references would be UB.
+    let direction_flags = filter.direction_flags;
+    let filter_action = filter.filter_action;
+    let valid_fields = filter.valid_fields;
+    if direction_flags != DirectionFlags::PACKET_FLAG_ON_SEND
+        || filter_action != FILTER_PACKET_DROP
+        || valid_fields != FilterLayerFlags::NETWORK_LAYER_VALID
+    {
+        return false;
+    }
+
+    let network_filter = filter.network_filter;
+    if network_filter.union_selector != IPV6 {
+        return false;
+    }
+
+    // SAFETY: union_selector == IPV6 guarantees the ipv6 arm is the live one.
+    let ipv6_filter = unsafe { network_filter.network_layer.ipv6 };
+    let ipv6_valid_fields = ipv6_filter.valid_fields;
+    if ipv6_valid_fields != IpV6FilterFlags::IP_V6_FILTER_DEST_ADDRESS {
+        return false;
+    }
+
+    let dest_address = ipv6_filter.dest_address;
+    if dest_address.address_type != IP_SUBNET_V6_TYPE {
+        return false;
+    }
+
+    // SAFETY: address_type == IP_SUBNET_V6_TYPE guarantees the subnet arm.
+    let subnet = unsafe { dest_address.address.ip_subnet };
+    let network = unsafe { subnet.ip.u.Byte };
+    let mask = unsafe { subnet.ip_mask.u.Byte };
+    SWIFTTUNNEL_IPV6_BLOCK_SUBNETS
+        .iter()
+        .any(|(n, m)| network == *n && mask == *m)
+}
+
+/// Split a filter table into (entries to keep, count of SwiftTunnel IPv6
+/// drop entries removed).
+#[cfg(any(test, target_os = "windows"))]
+pub(crate) fn entries_without_swifttunnel_ipv6_block(
+    entries: Vec<StaticFilter>,
+) -> (Vec<StaticFilter>, usize) {
+    let original = entries.len();
+    let kept: Vec<StaticFilter> = entries
+        .into_iter()
+        .filter(|filter| !is_swifttunnel_ipv6_block_filter(filter))
+        .collect();
+    let removed = original - kept.len();
+    (kept, removed)
+}
+
+/// Merge SwiftTunnel's IPv6 drop filters into an existing table snapshot,
+/// replacing any stale SwiftTunnel entries (e.g. from a previous session)
+/// while preserving everything else.
+#[cfg(any(test, target_os = "windows"))]
+pub(crate) fn merged_ipv6_block_entries(
+    existing: Vec<StaticFilter>,
+    adapter_handle: u64,
+) -> Vec<StaticFilter> {
+    let (mut entries, _) = entries_without_swifttunnel_ipv6_block(existing);
+    entries.extend(swifttunnel_ipv6_block_filters(adapter_handle));
+    entries
+}
+
 /// Marker file name stored in %LOCALAPPDATA%/SwiftTunnel/
 const IPV6_MARKER_FILE: &str = "ipv6_disabled.marker";
+
+/// Serializes tests (across modules) that touch the shared on-disk IPv6
+/// marker file; without it, parallel test execution makes marker tests delete
+/// each other's state and flake.
+#[cfg(test)]
+pub(crate) static IPV6_MARKER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// How SwiftTunnel prevented IPv6 leakage during the session this marker
 /// belongs to.
@@ -423,33 +601,135 @@ fn restore_firewall_rule_marker(adapter_name: &str) -> bool {
     true
 }
 
+/// Read the driver's current static filter table as owned entries.
 #[cfg(target_os = "windows")]
-pub fn reset_winpkfilter_ipv6_block_filters() -> Result<(), String> {
+fn read_static_filter_entries(driver: &ndisapi::Ndisapi) -> Result<Vec<StaticFilter>, String> {
+    let size = driver
+        .get_packet_filter_table_size()
+        .map_err(|e| format!("Failed to query WinpkFilter static filter table size: {e}"))?;
+    if size == 0 {
+        return Ok(Vec::new());
+    }
+    if size > STATIC_FILTER_TABLE_CAPACITY {
+        return Err(format!(
+            "WinpkFilter static filter table has {size} entries, more than the supported {STATIC_FILTER_TABLE_CAPACITY}"
+        ));
+    }
+
+    // Boxed: the fixed-capacity table is ~48KB, too big to keep on the stack.
+    let mut table = Box::new(StaticFilterTable::<STATIC_FILTER_TABLE_CAPACITY>::new());
+    driver
+        .get_packet_filter_table(table.as_mut())
+        .map_err(|e| format!("Failed to read WinpkFilter static filter table: {e}"))?;
+
+    let count = (table.table_size as usize).min(STATIC_FILTER_TABLE_CAPACITY);
+    let base = std::ptr::addr_of!(table.static_filters).cast::<StaticFilter>();
+    let mut entries = Vec::with_capacity(count);
+    for i in 0..count {
+        // SAFETY: i < count <= capacity; unaligned read because the table is
+        // repr(C, packed).
+        entries.push(unsafe { base.add(i).read_unaligned() });
+    }
+    Ok(entries)
+}
+
+/// Replace the driver's static filter table with exactly `entries`.
+#[cfg(target_os = "windows")]
+fn set_static_filter_entries(
+    driver: &ndisapi::Ndisapi,
+    entries: &[StaticFilter],
+) -> Result<(), String> {
+    if entries.len() > STATIC_FILTER_TABLE_CAPACITY {
+        return Err(format!(
+            "Refusing to write {} WinpkFilter static filter entries, more than the supported {STATIC_FILTER_TABLE_CAPACITY}",
+            entries.len()
+        ));
+    }
+
+    let mut table = Box::new(StaticFilterTable::<STATIC_FILTER_TABLE_CAPACITY>::new());
+    table.table_size = entries.len() as u32;
+    let base = std::ptr::addr_of_mut!(table.static_filters).cast::<StaticFilter>();
+    for (i, entry) in entries.iter().enumerate() {
+        // SAFETY: i < entries.len() <= capacity; unaligned write because the
+        // table is repr(C, packed).
+        unsafe { base.add(i).write_unaligned(*entry) };
+    }
+    driver
+        .set_packet_filter_table(table.as_ref())
+        .map_err(|e| format!("Failed to write WinpkFilter static filter table: {e}"))
+}
+
+/// Install SwiftTunnel's IPv6 drop filters, preserving any static filter
+/// entries that are not SwiftTunnel's (another WinpkFilter consumer or a
+/// future SwiftTunnel component may own them).
+#[cfg(target_os = "windows")]
+pub(crate) fn install_winpkfilter_ipv6_block_filters(
+    driver: &ndisapi::Ndisapi,
+    adapter_handle: u64,
+) -> Result<(), String> {
+    let existing = read_static_filter_entries(driver)?;
+    let merged = merged_ipv6_block_entries(existing, adapter_handle);
+    let preserved = merged.len() - SWIFTTUNNEL_IPV6_BLOCK_SUBNETS.len();
+    if preserved > 0 {
+        log::info!(
+            "Preserving {preserved} existing WinpkFilter static filter entries alongside the SwiftTunnel IPv6 block"
+        );
+    }
+    set_static_filter_entries(driver, &merged)
+}
+
+/// Remove SwiftTunnel's IPv6 drop filters from the driver's static filter
+/// table, preserving entries owned by anyone else.
+///
+/// Cleanup must never leave IPv6 blocked: if the table cannot be read, this
+/// falls back to a full table reset (the documented crash-recovery posture is
+/// that recovery may over-clean) rather than leaving drop filters installed.
+#[cfg(target_os = "windows")]
+pub fn remove_winpkfilter_ipv6_block_filters() -> Result<(), String> {
     let driver = ndisapi::Ndisapi::new("NDISRD")
         .map_err(|e| format!("Failed to open WinpkFilter driver: {e}"))?;
-    driver
-        .reset_packet_filter_table()
-        .map_err(|e| format!("Failed to reset WinpkFilter static filter table: {e}"))?;
-    Ok(())
+
+    let entries = match read_static_filter_entries(&driver) {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::warn!(
+                "Could not read WinpkFilter static filter table ({e}); falling back to a full reset"
+            );
+            return driver
+                .reset_packet_filter_table()
+                .map_err(|e| format!("Failed to reset WinpkFilter static filter table: {e}"));
+        }
+    };
+
+    let (remaining, removed) = entries_without_swifttunnel_ipv6_block(entries);
+    if removed == 0 {
+        return Ok(());
+    }
+    if remaining.is_empty() {
+        return driver
+            .reset_packet_filter_table()
+            .map_err(|e| format!("Failed to reset WinpkFilter static filter table: {e}"));
+    }
+    set_static_filter_entries(&driver, &remaining)
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn reset_winpkfilter_ipv6_block_filters() -> Result<(), String> {
+pub fn remove_winpkfilter_ipv6_block_filters() -> Result<(), String> {
     Err("WinpkFilter IPv6 filter cleanup is only available on Windows.".to_string())
 }
 
 fn restore_winpkfilter_static_filter_marker(adapter_name: &str) -> bool {
-    match reset_winpkfilter_ipv6_block_filters() {
+    match remove_winpkfilter_ipv6_block_filters() {
         Ok(()) => {
             log::info!(
-                "WinpkFilter IPv6 block filters cleared successfully for adapter: {}",
+                "WinpkFilter IPv6 block filters removed successfully for adapter: {}",
                 adapter_name
             );
             true
         }
         Err(e) => {
             log::warn!(
-                "Failed to clear WinpkFilter IPv6 block filters for adapter {}: {}",
+                "Failed to remove WinpkFilter IPv6 block filters for adapter {}: {}",
                 adapter_name,
                 e
             );
@@ -533,6 +813,9 @@ mod tests {
 
     #[test]
     fn test_marker_write_read_delete() {
+        let _guard = IPV6_MARKER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let test_adapter = "TestAdapter456";
 
         write_ipv6_marker(test_adapter);
@@ -559,6 +842,196 @@ mod tests {
         assert!(cmd.contains("netsh.exe advfirewall firewall delete rule"));
         assert!(cmd.contains("netsh.exe advfirewall firewall show rule"));
         assert!(cmd.contains("exit 1"));
+    }
+
+    fn dest_subnet(filter: &StaticFilter) -> ([u8; 16], [u8; 16]) {
+        let network_filter = filter.network_filter;
+        let union_selector = network_filter.union_selector;
+        assert_eq!(union_selector, IPV6);
+        let ipv6_filter = unsafe { network_filter.network_layer.ipv6 };
+        let dest_address = ipv6_filter.dest_address;
+        let address_type = dest_address.address_type;
+        assert_eq!(address_type, IP_SUBNET_V6_TYPE);
+        let subnet = unsafe { dest_address.address.ip_subnet };
+        (unsafe { subnet.ip.u.Byte }, unsafe {
+            subnet.ip_mask.u.Byte
+        })
+    }
+
+    fn foreign_ipv4_drop_filter() -> StaticFilter {
+        StaticFilter::new(
+            0xAAAA,
+            DirectionFlags::PACKET_FLAG_ON_SEND,
+            FILTER_PACKET_DROP,
+            FilterLayerFlags::NETWORK_LAYER_VALID,
+            DataLinkLayerFilter::default(),
+            NetworkLayerFilter::new(ndisapi::IPV4, NetworkLayerFilterUnion::default()),
+            TransportLayerFilter::default(),
+        )
+    }
+
+    /// Identical shape to SwiftTunnel's drop filters but for a ULA subnet
+    /// (fc00::/7) SwiftTunnel never blocks — must never be claimed as ours.
+    fn foreign_ipv6_ula_drop_filter() -> StaticFilter {
+        let ula_network: [u8; 16] = [0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let ula_mask: [u8; 16] = [0xfe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        build_ipv6_block_filter(0xBBBB, ula_network, ula_mask)
+    }
+
+    #[test]
+    fn test_swifttunnel_ipv6_block_filters_cover_public_and_nat64_prefixes() {
+        let handle = 0x1234u64;
+        let filters = swifttunnel_ipv6_block_filters(handle);
+
+        assert_eq!(filters.len(), 3);
+        let mut subnets = Vec::new();
+        for filter in &filters {
+            let adapter_handle = filter.adapter_handle;
+            let direction_flags = filter.direction_flags;
+            let filter_action = filter.filter_action;
+            let valid_fields = filter.valid_fields;
+            assert_eq!(adapter_handle, handle);
+            assert_eq!(direction_flags, DirectionFlags::PACKET_FLAG_ON_SEND);
+            assert_eq!(filter_action, FILTER_PACKET_DROP);
+            assert_eq!(valid_fields, FilterLayerFlags::NETWORK_LAYER_VALID);
+            let network_filter = filter.network_filter;
+            let ipv6_filter = unsafe { network_filter.network_layer.ipv6 };
+            let ipv6_valid_fields = ipv6_filter.valid_fields;
+            assert_eq!(
+                ipv6_valid_fields,
+                IpV6FilterFlags::IP_V6_FILTER_DEST_ADDRESS
+            );
+            subnets.push(dest_subnet(filter));
+            assert!(is_swifttunnel_ipv6_block_filter(filter));
+        }
+
+        assert_eq!(subnets.len(), SWIFTTUNNEL_IPV6_BLOCK_SUBNETS.len());
+        for expected in SWIFTTUNNEL_IPV6_BLOCK_SUBNETS {
+            assert!(subnets.contains(&expected), "missing subnet {expected:?}");
+        }
+    }
+
+    #[test]
+    fn test_is_swifttunnel_ipv6_block_filter_rejects_similar_foreign_filters() {
+        // Same drop shape, different subnet: NOT ours.
+        assert!(!is_swifttunnel_ipv6_block_filter(
+            &foreign_ipv6_ula_drop_filter()
+        ));
+        // IPv4 drop filter: NOT ours.
+        assert!(!is_swifttunnel_ipv6_block_filter(
+            &foreign_ipv4_drop_filter()
+        ));
+        // Zeroed/default entry: NOT ours.
+        assert!(!is_swifttunnel_ipv6_block_filter(&StaticFilter::default()));
+
+        // Same subnet but inbound direction: NOT ours.
+        let mut inbound = swifttunnel_ipv6_block_filters(0x1234)[0];
+        inbound.direction_flags = DirectionFlags::PACKET_FLAG_ON_RECEIVE;
+        assert!(!is_swifttunnel_ipv6_block_filter(&inbound));
+    }
+
+    #[test]
+    fn test_merged_ipv6_block_entries_preserve_foreign_and_replace_stale_ours() {
+        let stale_ours = swifttunnel_ipv6_block_filters(0x9999)[0];
+        let existing = vec![
+            foreign_ipv4_drop_filter(),
+            stale_ours,
+            foreign_ipv6_ula_drop_filter(),
+        ];
+
+        let merged = merged_ipv6_block_entries(existing, 0x1234);
+
+        // 2 foreign preserved + 3 ours; the stale entry (old adapter handle)
+        // was replaced, not duplicated.
+        assert_eq!(merged.len(), 5);
+        let ours: Vec<&StaticFilter> = merged
+            .iter()
+            .filter(|f| is_swifttunnel_ipv6_block_filter(f))
+            .collect();
+        assert_eq!(ours.len(), 3);
+        for filter in ours {
+            let adapter_handle = filter.adapter_handle;
+            assert_eq!(adapter_handle, 0x1234);
+        }
+        let foreign_handles: Vec<u64> = merged
+            .iter()
+            .filter(|f| !is_swifttunnel_ipv6_block_filter(f))
+            .map(|f| f.adapter_handle)
+            .collect();
+        assert_eq!(foreign_handles, vec![0xAAAA, 0xBBBB]);
+    }
+
+    #[test]
+    fn test_entries_without_swifttunnel_ipv6_block_removes_only_ours() {
+        let mut entries = vec![foreign_ipv4_drop_filter(), foreign_ipv6_ula_drop_filter()];
+        entries.extend(swifttunnel_ipv6_block_filters(0x1234));
+
+        let (kept, removed) = entries_without_swifttunnel_ipv6_block(entries);
+
+        assert_eq!(removed, 3);
+        assert_eq!(kept.len(), 2);
+        assert!(kept.iter().all(|f| !is_swifttunnel_ipv6_block_filter(f)));
+    }
+
+    #[test]
+    fn test_entries_without_swifttunnel_ipv6_block_keeps_foreign_only_table_intact() {
+        let entries = vec![foreign_ipv4_drop_filter(), foreign_ipv6_ula_drop_filter()];
+
+        let (kept, removed) = entries_without_swifttunnel_ipv6_block(entries);
+
+        assert_eq!(removed, 0);
+        assert_eq!(kept.len(), 2);
+    }
+
+    /// Real-driver smoke test for the install → merge → remove cycle.
+    /// Mutates the machine-global WinpkFilter static filter table, so it is
+    /// manual-run only (`cargo test -- --ignored`) on a box with the NDISRD
+    /// driver, e.g. the split tunnel testbench. All driver operations happen
+    /// before the assertions so a failing assertion cannot leave the IPv6
+    /// drop filters installed.
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[ignore]
+    fn driver_smoke_install_and_remove_ipv6_block_filters() {
+        let driver = ndisapi::Ndisapi::new("NDISRD").expect("WinpkFilter driver not available");
+        let adapters = driver
+            .get_tcpip_bound_adapters_info()
+            .expect("failed to enumerate adapters");
+        let adapter = adapters.first().expect("no TCP/IP-bound adapters");
+        let adapter_handle = adapter.get_handle().0 as usize as u64;
+
+        let before = read_static_filter_entries(&driver).expect("read before install");
+        let install_result = install_winpkfilter_ipv6_block_filters(&driver, adapter_handle);
+        let with_block = read_static_filter_entries(&driver);
+        let remove_result = remove_winpkfilter_ipv6_block_filters();
+        let after = read_static_filter_entries(&driver);
+
+        install_result.expect("install failed");
+        let with_block = with_block.expect("read after install");
+        remove_result.expect("remove failed");
+        let after = after.expect("read after remove");
+
+        let (foreign_before, _) = entries_without_swifttunnel_ipv6_block(before);
+        let ours_installed = with_block
+            .iter()
+            .filter(|f| is_swifttunnel_ipv6_block_filter(f))
+            .count();
+        assert_eq!(ours_installed, 3, "expected all 3 IPv6 drop filters");
+        assert_eq!(
+            with_block.len(),
+            foreign_before.len() + 3,
+            "install must preserve foreign entries"
+        );
+        let ours_after = after
+            .iter()
+            .filter(|f| is_swifttunnel_ipv6_block_filter(f))
+            .count();
+        assert_eq!(ours_after, 0, "remove must clear all SwiftTunnel entries");
+        assert_eq!(
+            after.len(),
+            foreign_before.len(),
+            "remove must keep foreign entries"
+        );
     }
 
     #[test]

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -58,14 +58,24 @@ use serde::Serialize;
 use crate::process_names::process_name_matches_any_tunnel_app;
 
 use super::ipv6_recovery::{
-    IPV6_BLOCK_REMOTE_IPS, IPV6_BLOCK_RULE_NAME, delete_ipv6_marker, has_ipv6_binding_native,
-    restore_ipv6_from_marker, write_ipv6_marker_firewall,
+    delete_ipv6_marker, has_ipv6_binding_native, reset_winpkfilter_ipv6_block_filters,
+    restore_ipv6_from_marker, write_ipv6_marker_winpkfilter,
 };
 use super::process_cache::{DNS_PORT, LockFreeProcessCache, ProcessSnapshot};
 use super::process_tracker::{ConnectionKey, Protocol};
 use super::tso_recovery::{delete_tso_marker, restore_tso_from_marker, write_tso_marker};
 use super::{VpnError, VpnResult};
 use crate::geolocation::is_roblox_game_server_ip;
+
+#[cfg(any(test, target_os = "windows"))]
+use ndisapi::{
+    DataLinkLayerFilter, DirectionFlags, FILTER_PACKET_DROP, FilterLayerFlags, IP_SUBNET_V6_TYPE,
+    IPV6, IpAddressV6, IpAddressV6Union, IpSubnetV6, IpV6Filter, IpV6FilterFlags,
+    NetworkLayerFilter, NetworkLayerFilterUnion, StaticFilter, StaticFilterTable,
+    TransportLayerFilter,
+};
+#[cfg(any(test, target_os = "windows"))]
+use windows::Win32::Networking::WinSock::{IN6_ADDR, IN6_ADDR_0};
 
 // ============================================================================
 // ZERO-ALLOCATION BUFFER MANAGEMENT
@@ -78,6 +88,13 @@ const MAX_PACKET_SIZE: usize = 1600;
 /// unbounded; at this cap we stop recording new IPs for the remainder of the
 /// session (existing IPs still re-register harmlessly).
 const MAX_DETECTED_GAME_SERVERS: usize = 10_000;
+
+const IPV6_PUBLIC_NETWORK: [u8; 16] = [0x20, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+const IPV6_PUBLIC_MASK: [u8; 16] = [0xe0, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+const IPV6_NAT64_NETWORK: [u8; 16] = [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+const IPV6_NAT64_MASK: [u8; 16] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0,
+];
 
 /// Packet reader rebind budget. Transient NDIS glitches (sleep/resume, WLAN
 /// roam, driver reset, ndisrd.sys handle staleness) can make `read_packets`
@@ -2000,15 +2017,6 @@ impl ParallelInterceptor {
         }
     }
 
-    fn firewall_interface_type_for_adapter_kind(kind: Option<&str>) -> &'static str {
-        match kind {
-            Some("wifi") => "wireless",
-            Some("ethernet") => "lan",
-            Some("ppp") => "ras",
-            _ => "any",
-        }
-    }
-
     fn get_adapter_details_for_if_index(if_index: u32) -> Option<(String, String, String)> {
         use windows::Win32::NetworkManagement::IpHelper::{
             GAA_FLAG_INCLUDE_PREFIX, GetAdaptersAddresses, IP_ADAPTER_ADDRESSES_LH,
@@ -3696,85 +3704,125 @@ impl ParallelInterceptor {
         self.tso_was_disabled = false;
     }
 
-    fn build_delete_ipv6_block_rule_args() -> Vec<String> {
-        vec![
-            "advfirewall".to_string(),
-            "firewall".to_string(),
-            "delete".to_string(),
-            "rule".to_string(),
-            format!("name={IPV6_BLOCK_RULE_NAME}"),
-        ]
+    #[cfg(any(test, target_os = "windows"))]
+    fn in6_addr(bytes: [u8; 16]) -> IN6_ADDR {
+        IN6_ADDR {
+            u: IN6_ADDR_0 { Byte: bytes },
+        }
     }
 
-    fn build_add_ipv6_block_rule_args(firewall_interface_type: &str) -> Vec<String> {
-        // Block outbound IPv6 via a Windows Firewall rule using `netsh advfirewall`.
-        //
-        // Why not `Disable-NetAdapterBinding -ComponentId ms_tcpip6` (the
-        // pre-2.0.15 approach):
-        //   That cmdlet rebinds the NDIS stack on the adapter, which
-        //   physically takes the link offline and back. On many real-world
-        //   NICs (Realtek, USB-Ethernet dongles, Parallels VirtIO, some Intel
-        //   variants) the relink takes 2-10 seconds and Windows reports the
-        //   connection as dropped — users see "my Ethernet just turned off
-        //   when I clicked Connect." It also routes through WMI, which hangs
-        //   15s+ on slow-WMI systems and was responsible for "Driver
-        //   initialization timed out" errors on first connect.
-        //
-        // Why direct netsh, not PowerShell or `New-NetFirewallRule`:
-        //   PowerShell startup and firewall CIM/WMI providers can hang on
-        //   slow-WMI systems. `netsh advfirewall` is a native binary, returns
-        //   quickly, and doesn't touch the adapter binding.
-        //
-        // The rule blocks public IPv6 plus the well-known NAT64 prefix. It
-        // deliberately leaves loopback, link-local, multicast, and ULA ranges
-        // alone so local IPv6 IPC and LAN discovery are not broken while
-        // SwiftTunnel is connected. `netsh advfirewall` cannot scope by exact
-        // adapter alias, only by interface type; when we know the selected
-        // adapter kind we use that narrower type to avoid touching unrelated
-        // interface classes.
-        vec![
-            "advfirewall".to_string(),
-            "firewall".to_string(),
-            "add".to_string(),
-            "rule".to_string(),
-            format!("name={IPV6_BLOCK_RULE_NAME}"),
-            "dir=out".to_string(),
-            "action=block".to_string(),
-            format!("remoteip={IPV6_BLOCK_REMOTE_IPS}"),
-            format!("interfacetype={firewall_interface_type}"),
-            "profile=any".to_string(),
-        ]
+    #[cfg(any(test, target_os = "windows"))]
+    fn ipv6_subnet_filter_address(network: [u8; 16], mask: [u8; 16]) -> IpAddressV6 {
+        IpAddressV6::new(
+            IP_SUBNET_V6_TYPE,
+            IpAddressV6Union {
+                ip_subnet: IpSubnetV6::new(Self::in6_addr(network), Self::in6_addr(mask)),
+            },
+        )
     }
 
-    fn run_netsh_with_timeout_capture(args: &[&str], timeout_secs: u64) -> CommandRunOutput {
-        Self::run_command_with_timeout_capture("netsh", args, timeout_secs)
+    #[cfg(any(test, target_os = "windows"))]
+    fn build_ipv6_block_filter(
+        physical_handle: windows::Win32::Foundation::HANDLE,
+        network: [u8; 16],
+        mask: [u8; 16],
+    ) -> StaticFilter {
+        StaticFilter::new(
+            physical_handle.0 as usize as u64,
+            DirectionFlags::PACKET_FLAG_ON_SEND,
+            FILTER_PACKET_DROP,
+            FilterLayerFlags::NETWORK_LAYER_VALID,
+            DataLinkLayerFilter::default(),
+            NetworkLayerFilter::new(
+                IPV6,
+                NetworkLayerFilterUnion {
+                    ipv6: IpV6Filter::new(
+                        IpV6FilterFlags::IP_V6_FILTER_DEST_ADDRESS,
+                        IpAddressV6::default(),
+                        Self::ipv6_subnet_filter_address(network, mask),
+                        0,
+                    ),
+                },
+            ),
+            TransportLayerFilter::default(),
+        )
     }
 
-    fn disable_ipv6_with_runner<F>(&mut self, runner: F) -> VpnResult<()>
+    #[cfg(any(test, target_os = "windows"))]
+    fn build_ipv6_block_filter_table(
+        physical_handle: windows::Win32::Foundation::HANDLE,
+    ) -> StaticFilterTable<2> {
+        StaticFilterTable::from_filters([
+            Self::build_ipv6_block_filter(physical_handle, IPV6_PUBLIC_NETWORK, IPV6_PUBLIC_MASK),
+            Self::build_ipv6_block_filter(physical_handle, IPV6_NAT64_NETWORK, IPV6_NAT64_MASK),
+        ])
+    }
+
+    #[cfg(target_os = "windows")]
+    fn install_winpkfilter_ipv6_block_for_adapter(physical_name: &str) -> Result<(), String> {
+        const MAX_ATTEMPTS: u32 = 5;
+        const RETRY_DELAY: Duration = Duration::from_millis(200);
+
+        let driver = ndisapi::Ndisapi::new("NDISRD")
+            .map_err(|e| format!("Failed to open WinpkFilter driver: {e}"))?;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let adapters = driver
+                .get_tcpip_bound_adapters_info()
+                .map_err(|e| format!("Failed to enumerate WinpkFilter adapters: {e}"))?;
+            if let Some(adapter) = adapters
+                .iter()
+                .find(|adapter| adapter.get_name() == physical_name)
+            {
+                let table = Self::build_ipv6_block_filter_table(adapter.get_handle());
+                return driver
+                    .set_packet_filter_table(&table)
+                    .map_err(|e| format!("Failed to install WinpkFilter IPv6 block filters: {e}"));
+            }
+
+            if attempt < MAX_ATTEMPTS {
+                std::thread::sleep(RETRY_DELAY);
+            }
+        }
+
+        Err(format!(
+            "WinpkFilter adapter '{physical_name}' was not found during IPv6 setup"
+        ))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn install_winpkfilter_ipv6_block_for_adapter(_physical_name: &str) -> Result<(), String> {
+        Err("WinpkFilter IPv6 block filters are only available on Windows.".to_string())
+    }
+
+    fn disable_ipv6_with_filter_installer<F>(&mut self, installer: F) -> VpnResult<()>
     where
-        F: Fn(&[&str], u64) -> CommandRunOutput,
+        F: Fn(&str) -> Result<(), String>,
     {
-        self.disable_ipv6_with_runner_and_probe(runner, has_ipv6_binding_native)
+        self.disable_ipv6_with_filter_installer_and_probe(installer, has_ipv6_binding_native)
     }
 
-    fn disable_ipv6_with_runner_and_probe<F, P>(
+    fn disable_ipv6_with_filter_installer_and_probe<F, P>(
         &mut self,
-        runner: F,
+        installer: F,
         ipv6_probe: P,
     ) -> VpnResult<()>
     where
-        F: Fn(&[&str], u64) -> CommandRunOutput,
+        F: Fn(&str) -> Result<(), String>,
         P: Fn(u32) -> Option<bool>,
     {
-        let friendly_name = match &self.physical_adapter_friendly_name {
+        let physical_name = match &self.physical_adapter_name {
             Some(name) => name.clone(),
             None => {
                 log::warn!(
-                    "No physical adapter friendly name available, skipping IPv6 firewall block"
+                    "No physical adapter device name available, skipping WinpkFilter IPv6 block"
                 );
                 return Ok(());
             }
         };
+        let friendly_name = self
+            .physical_adapter_friendly_name
+            .clone()
+            .unwrap_or_else(|| physical_name.clone());
 
         // IPv4-only ISP guard: SwiftTunnel needs an IPv4 default route to work.
         // If there isn't one, blocking IPv6 would leave the user with no
@@ -3794,14 +3842,14 @@ impl ParallelInterceptor {
             match ipv6_probe(if_index) {
                 Some(true) => {
                     log::debug!(
-                        "Selected adapter {} (if_index={}) has IPv6; installing block rule",
+                        "Selected adapter {} (if_index={}) has IPv6; installing WinpkFilter block filters",
                         friendly_name,
                         if_index
                     );
                 }
                 Some(false) => {
                     log::info!(
-                        "Skipping IPv6 firewall block on {} (if_index={}): selected adapter has no IPv6 address/binding",
+                        "Skipping WinpkFilter IPv6 block on {} (if_index={}): selected adapter has no IPv6 address/binding",
                         friendly_name,
                         if_index
                     );
@@ -3809,7 +3857,7 @@ impl ParallelInterceptor {
                 }
                 None => {
                     log::debug!(
-                        "Could not determine IPv6 state for {} (if_index={}); falling back to firewall block",
+                        "Could not determine IPv6 state for {} (if_index={}); falling back to WinpkFilter block filters",
                         friendly_name,
                         if_index
                     );
@@ -3817,72 +3865,55 @@ impl ParallelInterceptor {
             }
         }
 
-        let firewall_interface_type =
-            Self::firewall_interface_type_for_adapter_kind(self.physical_adapter_kind.as_deref());
-
         log::info!(
-            "Blocking public IPv6 via firewall rule (adapter: {}, interface_type: {}, SwiftTunnel is IPv4-only)",
-            friendly_name,
-            firewall_interface_type
+            "Blocking public IPv6 via WinpkFilter static filters (adapter: {}, SwiftTunnel is IPv4-only)",
+            friendly_name
         );
 
-        // Write the marker BEFORE the netsh add. If we crash between add and
-        // marker write, the rule lingers across reboots and the user has no
-        // way to clean it up other than rerunning SwiftTunnel — which we
-        // accept, because the marker-then-add ordering would have the inverse
-        // race (marker exists but no rule, restore is a no-op, normal). The
-        // current ordering means recovery always over-cleans, never
-        // under-cleans.
-        write_ipv6_marker_firewall(&friendly_name);
+        // Write the marker before installing the driver filters. If SwiftTunnel
+        // crashes after the filter table is loaded, startup recovery can reset
+        // it. The inverse race (marker without filters) is harmless because
+        // reset_packet_filter_table is idempotent for our session.
+        write_ipv6_marker_winpkfilter(&friendly_name);
         self.ipv6_was_disabled = true;
 
-        // netsh.exe completes in ~50-100ms. 5s is generous slack for very
-        // loaded systems; if it actually times out at 5s, something is
-        // seriously wrong with the host's firewall service.
-        let timeout_secs = 5;
-        let delete_args = Self::build_delete_ipv6_block_rule_args();
-        let delete_arg_refs: Vec<&str> = delete_args.iter().map(String::as_str).collect();
-        let _ = runner(&delete_arg_refs, timeout_secs);
-
-        let add_args = Self::build_add_ipv6_block_rule_args(firewall_interface_type);
-        let add_arg_refs: Vec<&str> = add_args.iter().map(String::as_str).collect();
-        let output = runner(&add_arg_refs, timeout_secs);
-
-        if output.success {
-            log::info!(
-                "Public IPv6 blocked on {} via firewall rule '{}' — game traffic will use IPv4",
-                friendly_name,
-                IPV6_BLOCK_RULE_NAME
+        if let Err(e) = reset_winpkfilter_ipv6_block_filters() {
+            log::debug!(
+                "Pre-clearing WinpkFilter IPv6 filters before install did not complete: {}",
+                e
             );
-            return Ok(());
         }
 
-        let details: String = output
-            .summarize_failure(timeout_secs, "netsh")
-            .chars()
-            .take(240)
-            .collect();
-
-        log::warn!(
-            "Failed to install IPv6 block rule on {} (exit={:?}, timed_out={}): stdout='{}' stderr='{}'",
-            friendly_name,
-            output.exit_code,
-            output.timed_out,
-            output.stdout.trim(),
-            output.stderr.trim()
-        );
-
-        log::warn!(
-            "Refusing to continue without IPv6 outbound block. IPv6 traffic may bypass VPN.{}{}",
-            if details.is_empty() { "" } else { " Details: " },
-            details
-        );
-
-        Err(VpnError::SplitTunnelSetupFailed(format!(
-            "Failed to install IPv6 block firewall rule. SwiftTunnel is IPv4-only; leaving IPv6 unblocked could let game traffic bypass the tunnel.{}{}",
-            if details.is_empty() { "" } else { " Details: " },
-            details
-        )))
+        match installer(&physical_name) {
+            Ok(()) => {
+                log::info!(
+                    "Public IPv6 blocked on {} via WinpkFilter static filters — game traffic will use IPv4",
+                    friendly_name
+                );
+                Ok(())
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to install WinpkFilter IPv6 block filters on {}: {}",
+                    friendly_name,
+                    e
+                );
+                if let Err(cleanup_error) = reset_winpkfilter_ipv6_block_filters() {
+                    log::debug!(
+                        "Failed to clean WinpkFilter IPv6 filters after install error: {}",
+                        cleanup_error
+                    );
+                }
+                delete_ipv6_marker();
+                self.ipv6_was_disabled = false;
+                log::warn!(
+                    "Refusing to continue without IPv6 outbound block. IPv6 traffic may bypass VPN."
+                );
+                Err(VpnError::SplitTunnelSetupFailed(format!(
+                    "Failed to install WinpkFilter IPv6 block filters. SwiftTunnel is IPv4-only; leaving IPv6 unblocked could let game traffic bypass the tunnel. Details: {e}"
+                )))
+            }
+        }
     }
 
     /// Block public IPv6 egress while the IPv4-only tunnel is active.
@@ -3894,16 +3925,16 @@ impl ParallelInterceptor {
     /// This is a common cause of "detection works but tunneling fails" - the process is
     /// detected, but its IPv6 traffic bypasses the VPN.
     pub fn disable_ipv6(&mut self) -> VpnResult<()> {
-        self.disable_ipv6_with_runner(Self::run_netsh_with_timeout_capture)
+        self.disable_ipv6_with_filter_installer(Self::install_winpkfilter_ipv6_block_for_adapter)
     }
-
-    /// Restore IPv6 connectivity by removing the outbound block rule.
+    /// Restore IPv6 connectivity by removing the outbound block filters.
     ///
     /// Called when the VPN disconnects. The marker file records which method
-    /// was used to block IPv6 in this session (current code uses a firewall
-    /// rule; legacy markers from older installs used adapter binding). The
-    /// no-marker fallback path also targets the firewall rule because every
-    /// in-progress block this version writes uses that method.
+    /// was used to block IPv6 in this session (current code uses WinpkFilter
+    /// static filters; legacy markers from older installs used adapter binding
+    /// or a Windows Firewall rule). The no-marker fallback also clears
+    /// WinpkFilter static filters because every in-progress block this version
+    /// writes uses that method.
     pub fn enable_ipv6(&mut self) {
         if !self.ipv6_was_disabled {
             return;
@@ -3933,18 +3964,18 @@ impl ParallelInterceptor {
             }
             None => {
                 // No marker found — likely a marker-write race or manual
-                // tampering. Best-effort: try to delete the firewall rule
-                // anyway (idempotent; silently no-ops if absent).
-                let delete_args = Self::build_delete_ipv6_block_rule_args();
-                let delete_arg_refs: Vec<&str> = delete_args.iter().map(String::as_str).collect();
-                if Self::run_netsh_with_timeout_capture(&delete_arg_refs, 5).success {
-                    log::info!("IPv6 block rule removed on {}", friendly_name);
+                // tampering. Best-effort: reset the WinpkFilter static table
+                // anyway (idempotent for the table SwiftTunnel owns while
+                // connected).
+                if reset_winpkfilter_ipv6_block_filters().is_ok() {
+                    log::info!(
+                        "WinpkFilter IPv6 block filters cleared on {}",
+                        friendly_name
+                    );
                     delete_ipv6_marker();
                 } else {
                     log::warn!(
-                        "Failed to remove IPv6 block rule '{}' — run `netsh advfirewall firewall delete rule name=\"{}\"` manually if connectivity is affected",
-                        IPV6_BLOCK_RULE_NAME,
-                        IPV6_BLOCK_RULE_NAME
+                        "Failed to clear WinpkFilter IPv6 block filters — restart SwiftTunnel to retry cleanup if connectivity is affected"
                     );
                 }
             }
@@ -4009,10 +4040,10 @@ impl ParallelInterceptor {
         // restored on app launch by `tso_recovery::recover_tso_on_startup`,
         // so users upgrading from <=2.0.20 don't end up with LSO stuck off.
 
-        // Disable IPv6 on physical adapter - SwiftTunnel is IPv4-only.
-        // This uses a netsh advfirewall rule (non-link-bouncing); the
-        // historical link-bouncing alternative is documented at
-        // `disable_ipv6_with_runner`.
+        // Disable public IPv6 egress on the physical adapter - SwiftTunnel is
+        // IPv4-only. This uses WinpkFilter static drop filters; the historical
+        // link-bouncing adapter-binding and Windows Firewall alternatives are
+        // documented in `ipv6_recovery`.
         self.disable_ipv6()?;
 
         self.stop_flag.store(false, Ordering::Release);
@@ -10788,58 +10819,58 @@ mod tests {
     fn test_disable_ipv6_skips_when_adapter_name_missing() {
         let mut interceptor = ParallelInterceptor::new(Vec::new());
         interceptor
-            .disable_ipv6_with_runner(|_, _| panic!("runner should not be called"))
+            .disable_ipv6_with_filter_installer(|_| panic!("installer should not be called"))
             .unwrap();
         assert!(!interceptor.ipv6_was_disabled);
     }
 
     #[test]
-    fn test_firewall_interface_type_maps_known_adapter_kinds() {
-        assert_eq!(
-            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("ethernet")),
-            "lan"
-        );
-        assert_eq!(
-            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("wifi")),
-            "wireless"
-        );
-        assert_eq!(
-            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("ppp")),
-            "ras"
-        );
-        assert_eq!(
-            ParallelInterceptor::firewall_interface_type_for_adapter_kind(Some("other")),
-            "any"
-        );
+    fn test_winpkfilter_ipv6_block_table_drops_public_and_nat64_ipv6() {
+        let handle = windows::Win32::Foundation::HANDLE(0x1234 as *mut std::ffi::c_void);
+        let table = ParallelInterceptor::build_ipv6_block_filter_table(handle);
+        let table_size = table.table_size;
+        let filters = unsafe { std::ptr::addr_of!(table.static_filters).read_unaligned() };
+
+        assert_eq!(table_size, 2);
+        for filter in filters {
+            let adapter_handle = filter.adapter_handle;
+            let direction_flags = filter.direction_flags;
+            let action = filter.filter_action;
+            let valid_fields = filter.valid_fields;
+            let network_filter = filter.network_filter;
+            let network_selector = network_filter.union_selector;
+            let ipv6_filter = unsafe { network_filter.network_layer.ipv6 };
+            let ipv6_valid_fields = ipv6_filter.valid_fields;
+            let dest_address = ipv6_filter.dest_address;
+            let dest_address_type = dest_address.address_type;
+
+            assert_eq!(adapter_handle, handle.0 as usize as u64);
+            assert_eq!(direction_flags, DirectionFlags::PACKET_FLAG_ON_SEND);
+            assert_eq!(action, FILTER_PACKET_DROP);
+            assert_eq!(valid_fields, FilterLayerFlags::NETWORK_LAYER_VALID);
+            assert_eq!(network_selector, IPV6);
+            assert_eq!(
+                ipv6_valid_fields,
+                IpV6FilterFlags::IP_V6_FILTER_DEST_ADDRESS
+            );
+            assert_eq!(dest_address_type, IP_SUBNET_V6_TYPE);
+        }
     }
 
     #[test]
-    fn test_disable_ipv6_netsh_args_block_public_ipv6_on_interface_type() {
-        let args = ParallelInterceptor::build_add_ipv6_block_rule_args("lan");
-        assert!(args.contains(&format!("remoteip={IPV6_BLOCK_REMOTE_IPS}")));
-        assert!(args.contains(&"interfacetype=lan".to_string()));
-        assert!(!args.contains(&"remoteip=::/0".to_string()));
-    }
-
-    #[test]
-    fn test_disable_ipv6_skips_firewall_when_selected_adapter_has_no_ipv6() {
+    fn test_disable_ipv6_skips_winpkfilter_when_selected_adapter_has_no_ipv6() {
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
         interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
         interceptor.physical_adapter_if_index = Some(42);
 
-        let runner_calls = std::cell::Cell::new(0);
+        let installer_calls = std::cell::Cell::new(0);
         interceptor
-            .disable_ipv6_with_runner_and_probe(
-                |_, _| {
-                    runner_calls.set(runner_calls.get() + 1);
-                    CommandRunOutput {
-                        success: false,
-                        timed_out: false,
-                        exit_code: Some(1),
-                        stdout: String::new(),
-                        stderr: "runner should not be called".to_string(),
-                    }
+            .disable_ipv6_with_filter_installer_and_probe(
+                |_| {
+                    installer_calls.set(installer_calls.get() + 1);
+                    Err("installer should not be called".to_string())
                 },
                 |if_index| {
                     assert_eq!(if_index, 42);
@@ -10848,7 +10879,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(runner_calls.get(), 0);
+        assert_eq!(installer_calls.get(), 0);
         assert!(!interceptor.ipv6_was_disabled);
         delete_ipv6_marker();
     }
@@ -10857,13 +10888,14 @@ mod tests {
     fn test_disable_ipv6_skip_preserves_existing_restore_state() {
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
         interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
         interceptor.physical_adapter_if_index = Some(42);
         interceptor.ipv6_was_disabled = true;
 
         interceptor
-            .disable_ipv6_with_runner_and_probe(
-                |_, _| panic!("runner should not be called"),
+            .disable_ipv6_with_filter_installer_and_probe(
+                |_| panic!("installer should not be called"),
                 |if_index| {
                     assert_eq!(if_index, 42);
                     Some(false)
@@ -10876,24 +10908,20 @@ mod tests {
     }
 
     #[test]
-    fn test_disable_ipv6_probe_true_installs_firewall_block() {
+    fn test_disable_ipv6_probe_true_installs_winpkfilter_block() {
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
         interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
         interceptor.physical_adapter_if_index = Some(42);
 
-        let runner_calls = std::cell::Cell::new(0);
+        let installer_calls = std::cell::Cell::new(0);
         interceptor
-            .disable_ipv6_with_runner_and_probe(
-                |_, _| {
-                    runner_calls.set(runner_calls.get() + 1);
-                    CommandRunOutput {
-                        success: true,
-                        timed_out: false,
-                        exit_code: Some(0),
-                        stdout: String::new(),
-                        stderr: String::new(),
-                    }
+            .disable_ipv6_with_filter_installer_and_probe(
+                |physical_name| {
+                    installer_calls.set(installer_calls.get() + 1);
+                    assert_eq!(physical_name, "\\DEVICE\\{ETHERNET}");
+                    Ok(())
                 },
                 |if_index| {
                     assert_eq!(if_index, 42);
@@ -10902,43 +10930,36 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(runner_calls.get(), 2);
+        assert_eq!(installer_calls.get(), 1);
         assert!(interceptor.ipv6_was_disabled);
         delete_ipv6_marker();
     }
 
     #[test]
-    fn test_disable_ipv6_probe_unknown_still_attempts_firewall_block() {
+    fn test_disable_ipv6_probe_unknown_still_attempts_winpkfilter_block() {
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
         interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
         interceptor.physical_adapter_if_index = Some(42);
 
-        let runner_calls = std::cell::Cell::new(0);
+        let installer_calls = std::cell::Cell::new(0);
         let error = interceptor
-            .disable_ipv6_with_runner_and_probe(
-                |_, _| {
-                    runner_calls.set(runner_calls.get() + 1);
-                    CommandRunOutput {
-                        success: false,
-                        timed_out: false,
-                        exit_code: Some(1),
-                        stdout: String::new(),
-                        stderr:
-                            "The following command was not found: advfirewall firewall add rule."
-                                .to_string(),
-                    }
+            .disable_ipv6_with_filter_installer_and_probe(
+                |_| {
+                    installer_calls.set(installer_calls.get() + 1);
+                    Err("WinpkFilter driver rejected static filter table".to_string())
                 },
                 |if_index| {
                     assert_eq!(if_index, 42);
                     None
                 },
             )
-            .expect_err("unknown IPv6 probe must not skip the firewall block");
+            .expect_err("unknown IPv6 probe must not skip the WinpkFilter block");
 
-        assert_eq!(runner_calls.get(), 2);
-        assert!(error.to_string().contains("IPv6 block firewall rule"));
-        assert!(interceptor.ipv6_was_disabled);
+        assert_eq!(installer_calls.get(), 1);
+        assert!(error.to_string().contains("WinpkFilter IPv6 block filters"));
+        assert!(!interceptor.ipv6_was_disabled);
         delete_ipv6_marker();
     }
 
@@ -10968,15 +10989,10 @@ mod tests {
     fn test_disable_ipv6_sets_flag_on_success() {
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
         interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
         interceptor
-            .disable_ipv6_with_runner(|_, _| CommandRunOutput {
-                success: true,
-                timed_out: false,
-                exit_code: Some(0),
-                stdout: "IPv6 disabled".to_string(),
-                stderr: String::new(),
-            })
+            .disable_ipv6_with_filter_installer(|_| Ok(()))
             .unwrap();
         assert!(interceptor.ipv6_was_disabled);
         delete_ipv6_marker();
@@ -10986,19 +11002,14 @@ mod tests {
     fn test_disable_ipv6_failure_preserves_restore_state() {
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
+        interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
         interceptor.physical_adapter_friendly_name = Some("Ethernet".to_string());
         let error = interceptor
-            .disable_ipv6_with_runner(|_, _| CommandRunOutput {
-                success: false,
-                timed_out: false,
-                exit_code: Some(1),
-                stdout: String::new(),
-                stderr: "Access is denied.".to_string(),
-            })
+            .disable_ipv6_with_filter_installer(|_| Err("Access is denied.".to_string()))
             .expect_err("IPv6 block failure must abort connect");
 
-        assert!(error.to_string().contains("IPv6 block firewall rule"));
-        assert!(interceptor.ipv6_was_disabled);
+        assert!(error.to_string().contains("WinpkFilter IPv6 block filters"));
+        assert!(!interceptor.ipv6_was_disabled);
         delete_ipv6_marker();
     }
 

--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -58,7 +58,7 @@ use serde::Serialize;
 use crate::process_names::process_name_matches_any_tunnel_app;
 
 use super::ipv6_recovery::{
-    delete_ipv6_marker, has_ipv6_binding_native, reset_winpkfilter_ipv6_block_filters,
+    delete_ipv6_marker, has_ipv6_binding_native, remove_winpkfilter_ipv6_block_filters,
     restore_ipv6_from_marker, write_ipv6_marker_winpkfilter,
 };
 use super::process_cache::{DNS_PORT, LockFreeProcessCache, ProcessSnapshot};
@@ -66,16 +66,6 @@ use super::process_tracker::{ConnectionKey, Protocol};
 use super::tso_recovery::{delete_tso_marker, restore_tso_from_marker, write_tso_marker};
 use super::{VpnError, VpnResult};
 use crate::geolocation::is_roblox_game_server_ip;
-
-#[cfg(any(test, target_os = "windows"))]
-use ndisapi::{
-    DataLinkLayerFilter, DirectionFlags, FILTER_PACKET_DROP, FilterLayerFlags, IP_SUBNET_V6_TYPE,
-    IPV6, IpAddressV6, IpAddressV6Union, IpSubnetV6, IpV6Filter, IpV6FilterFlags,
-    NetworkLayerFilter, NetworkLayerFilterUnion, StaticFilter, StaticFilterTable,
-    TransportLayerFilter,
-};
-#[cfg(any(test, target_os = "windows"))]
-use windows::Win32::Networking::WinSock::{IN6_ADDR, IN6_ADDR_0};
 
 // ============================================================================
 // ZERO-ALLOCATION BUFFER MANAGEMENT
@@ -88,13 +78,6 @@ const MAX_PACKET_SIZE: usize = 1600;
 /// unbounded; at this cap we stop recording new IPs for the remainder of the
 /// session (existing IPs still re-register harmlessly).
 const MAX_DETECTED_GAME_SERVERS: usize = 10_000;
-
-const IPV6_PUBLIC_NETWORK: [u8; 16] = [0x20, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-const IPV6_PUBLIC_MASK: [u8; 16] = [0xe0, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-const IPV6_NAT64_NETWORK: [u8; 16] = [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-const IPV6_NAT64_MASK: [u8; 16] = [
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0,
-];
 
 /// Packet reader rebind budget. Transient NDIS glitches (sleep/resume, WLAN
 /// roam, driver reset, ndisrd.sys handle staleness) can make `read_packets`
@@ -3704,60 +3687,6 @@ impl ParallelInterceptor {
         self.tso_was_disabled = false;
     }
 
-    #[cfg(any(test, target_os = "windows"))]
-    fn in6_addr(bytes: [u8; 16]) -> IN6_ADDR {
-        IN6_ADDR {
-            u: IN6_ADDR_0 { Byte: bytes },
-        }
-    }
-
-    #[cfg(any(test, target_os = "windows"))]
-    fn ipv6_subnet_filter_address(network: [u8; 16], mask: [u8; 16]) -> IpAddressV6 {
-        IpAddressV6::new(
-            IP_SUBNET_V6_TYPE,
-            IpAddressV6Union {
-                ip_subnet: IpSubnetV6::new(Self::in6_addr(network), Self::in6_addr(mask)),
-            },
-        )
-    }
-
-    #[cfg(any(test, target_os = "windows"))]
-    fn build_ipv6_block_filter(
-        physical_handle: windows::Win32::Foundation::HANDLE,
-        network: [u8; 16],
-        mask: [u8; 16],
-    ) -> StaticFilter {
-        StaticFilter::new(
-            physical_handle.0 as usize as u64,
-            DirectionFlags::PACKET_FLAG_ON_SEND,
-            FILTER_PACKET_DROP,
-            FilterLayerFlags::NETWORK_LAYER_VALID,
-            DataLinkLayerFilter::default(),
-            NetworkLayerFilter::new(
-                IPV6,
-                NetworkLayerFilterUnion {
-                    ipv6: IpV6Filter::new(
-                        IpV6FilterFlags::IP_V6_FILTER_DEST_ADDRESS,
-                        IpAddressV6::default(),
-                        Self::ipv6_subnet_filter_address(network, mask),
-                        0,
-                    ),
-                },
-            ),
-            TransportLayerFilter::default(),
-        )
-    }
-
-    #[cfg(any(test, target_os = "windows"))]
-    fn build_ipv6_block_filter_table(
-        physical_handle: windows::Win32::Foundation::HANDLE,
-    ) -> StaticFilterTable<2> {
-        StaticFilterTable::from_filters([
-            Self::build_ipv6_block_filter(physical_handle, IPV6_PUBLIC_NETWORK, IPV6_PUBLIC_MASK),
-            Self::build_ipv6_block_filter(physical_handle, IPV6_NAT64_NETWORK, IPV6_NAT64_MASK),
-        ])
-    }
-
     #[cfg(target_os = "windows")]
     fn install_winpkfilter_ipv6_block_for_adapter(physical_name: &str) -> Result<(), String> {
         const MAX_ATTEMPTS: u32 = 5;
@@ -3773,10 +3702,12 @@ impl ParallelInterceptor {
                 .iter()
                 .find(|adapter| adapter.get_name() == physical_name)
             {
-                let table = Self::build_ipv6_block_filter_table(adapter.get_handle());
-                return driver
-                    .set_packet_filter_table(&table)
-                    .map_err(|e| format!("Failed to install WinpkFilter IPv6 block filters: {e}"));
+                let adapter_handle = adapter.get_handle().0 as usize as u64;
+                return super::ipv6_recovery::install_winpkfilter_ipv6_block_filters(
+                    &driver,
+                    adapter_handle,
+                )
+                .map_err(|e| format!("Failed to install WinpkFilter IPv6 block filters: {e}"));
             }
 
             if attempt < MAX_ATTEMPTS {
@@ -3871,18 +3802,13 @@ impl ParallelInterceptor {
         );
 
         // Write the marker before installing the driver filters. If SwiftTunnel
-        // crashes after the filter table is loaded, startup recovery can reset
-        // it. The inverse race (marker without filters) is harmless because
-        // reset_packet_filter_table is idempotent for our session.
+        // crashes after the filter table is loaded, startup recovery can remove
+        // our entries. The inverse race (marker without filters) is harmless
+        // because removal only touches entries matching SwiftTunnel's filter
+        // signature. Stale entries from a previous session are replaced by the
+        // install merge itself.
         write_ipv6_marker_winpkfilter(&friendly_name);
         self.ipv6_was_disabled = true;
-
-        if let Err(e) = reset_winpkfilter_ipv6_block_filters() {
-            log::debug!(
-                "Pre-clearing WinpkFilter IPv6 filters before install did not complete: {}",
-                e
-            );
-        }
 
         match installer(&physical_name) {
             Ok(()) => {
@@ -3898,7 +3824,7 @@ impl ParallelInterceptor {
                     friendly_name,
                     e
                 );
-                if let Err(cleanup_error) = reset_winpkfilter_ipv6_block_filters() {
+                if let Err(cleanup_error) = remove_winpkfilter_ipv6_block_filters() {
                     log::debug!(
                         "Failed to clean WinpkFilter IPv6 filters after install error: {}",
                         cleanup_error
@@ -3964,12 +3890,12 @@ impl ParallelInterceptor {
             }
             None => {
                 // No marker found — likely a marker-write race or manual
-                // tampering. Best-effort: reset the WinpkFilter static table
-                // anyway (idempotent for the table SwiftTunnel owns while
-                // connected).
-                if reset_winpkfilter_ipv6_block_filters().is_ok() {
+                // tampering. Best-effort: remove SwiftTunnel's IPv6 drop
+                // entries anyway (idempotent, and entries owned by other
+                // WinpkFilter consumers are preserved).
+                if remove_winpkfilter_ipv6_block_filters().is_ok() {
                     log::info!(
-                        "WinpkFilter IPv6 block filters cleared on {}",
+                        "WinpkFilter IPv6 block filters removed on {}",
                         friendly_name
                     );
                     delete_ipv6_marker();
@@ -10824,41 +10750,15 @@ mod tests {
         assert!(!interceptor.ipv6_was_disabled);
     }
 
-    #[test]
-    fn test_winpkfilter_ipv6_block_table_drops_public_and_nat64_ipv6() {
-        let handle = windows::Win32::Foundation::HANDLE(0x1234 as *mut std::ffi::c_void);
-        let table = ParallelInterceptor::build_ipv6_block_filter_table(handle);
-        let table_size = table.table_size;
-        let filters = unsafe { std::ptr::addr_of!(table.static_filters).read_unaligned() };
-
-        assert_eq!(table_size, 2);
-        for filter in filters {
-            let adapter_handle = filter.adapter_handle;
-            let direction_flags = filter.direction_flags;
-            let action = filter.filter_action;
-            let valid_fields = filter.valid_fields;
-            let network_filter = filter.network_filter;
-            let network_selector = network_filter.union_selector;
-            let ipv6_filter = unsafe { network_filter.network_layer.ipv6 };
-            let ipv6_valid_fields = ipv6_filter.valid_fields;
-            let dest_address = ipv6_filter.dest_address;
-            let dest_address_type = dest_address.address_type;
-
-            assert_eq!(adapter_handle, handle.0 as usize as u64);
-            assert_eq!(direction_flags, DirectionFlags::PACKET_FLAG_ON_SEND);
-            assert_eq!(action, FILTER_PACKET_DROP);
-            assert_eq!(valid_fields, FilterLayerFlags::NETWORK_LAYER_VALID);
-            assert_eq!(network_selector, IPV6);
-            assert_eq!(
-                ipv6_valid_fields,
-                IpV6FilterFlags::IP_V6_FILTER_DEST_ADDRESS
-            );
-            assert_eq!(dest_address_type, IP_SUBNET_V6_TYPE);
-        }
-    }
+    // The IPv6 block filter shape, prefix coverage, and table merge/removal
+    // behavior are tested in `super::ipv6_recovery`, where the filter
+    // builders now live.
 
     #[test]
     fn test_disable_ipv6_skips_winpkfilter_when_selected_adapter_has_no_ipv6() {
+        let _guard = crate::vpn::ipv6_recovery::IPV6_MARKER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
         interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
@@ -10886,6 +10786,9 @@ mod tests {
 
     #[test]
     fn test_disable_ipv6_skip_preserves_existing_restore_state() {
+        let _guard = crate::vpn::ipv6_recovery::IPV6_MARKER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
         interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
@@ -10909,6 +10812,9 @@ mod tests {
 
     #[test]
     fn test_disable_ipv6_probe_true_installs_winpkfilter_block() {
+        let _guard = crate::vpn::ipv6_recovery::IPV6_MARKER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
         interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
@@ -10937,6 +10843,9 @@ mod tests {
 
     #[test]
     fn test_disable_ipv6_probe_unknown_still_attempts_winpkfilter_block() {
+        let _guard = crate::vpn::ipv6_recovery::IPV6_MARKER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
         interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
@@ -10987,6 +10896,9 @@ mod tests {
 
     #[test]
     fn test_disable_ipv6_sets_flag_on_success() {
+        let _guard = crate::vpn::ipv6_recovery::IPV6_MARKER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
         interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());
@@ -11000,6 +10912,9 @@ mod tests {
 
     #[test]
     fn test_disable_ipv6_failure_preserves_restore_state() {
+        let _guard = crate::vpn::ipv6_recovery::IPV6_MARKER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         delete_ipv6_marker();
         let mut interceptor = ParallelInterceptor::new(Vec::new());
         interceptor.physical_adapter_name = Some("\\DEVICE\\{ETHERNET}".to_string());


### PR DESCRIPTION
## Summary
- replace the connect-time netsh advfirewall IPv6 block with WinpkFilter static outbound drop filters
- block public IPv6 (2000::/3) and NAT64 (64:ff9b::/96) on the selected physical adapter
- add WinpkFilter marker/recovery cleanup so disconnect/startup clears stale static filters after crashes
- keep legacy cleanup for older adapter-binding and Windows Firewall markers

## Why
SwiftTunnel already requires WinpkFilter for split tunneling. Using WinpkFilter for IPv6 leak prevention avoids touching Windows Firewall policy, avoids advfirewall failures on locked-down machines, and drops matching IPv6 before packets enter the user-mode worker queues.

## Failure-mode plan
- Primary success: public IPv6/NAT64 cannot bypass while the IPv4-only split tunnel is active.
- Repairable/retryable: adapter enumeration after binding can lag, so WinpkFilter adapter lookup retries briefly before failing.
- Fatal: if static filters cannot be installed, strict split tunnel fails instead of allowing IPv6 bypass.
- Diagnostic-only: legacy firewall/adaptor marker cleanup remains best-effort recovery for users upgrading mid-session.
- Partial success/races: marker is written before filter install so crash recovery can over-clean; install failure now resets the table, deletes the marker, and clears in-process disabled state before returning the error.
- Tests: cover filter-table shape, skip when adapter has no IPv6, success path, unknown probe fallback, and negative install failure rollback.

## Performance notes
- The new path should be lower overhead than app-level IPv6 dropping because the driver drops matching packets before user-mode copy/queue/parse work.
- It avoids adding a final pass-all static filter so normal IPv4 packets still flow through the existing split-tunnel packet loop.
- This removes the Windows Firewall dependency, but it does not eliminate all managed/internet-cafe driver conflicts if local control software conflicts with WinpkFilter itself.

## Validation
- CodeRabbit CLI uncommitted review: fixed 2 major issues, rerun raised 0 issues
- cargo fmt --check
- git diff --check
- npm test -- --run src/lib/repairCenter.test.ts src/lib/commands.test.ts src/lib/tauriCommandWiring.contract.test.ts
- npx tsc --noEmit
- cargo test ipv6_recovery --lib: blocked locally by known macOS windows-future/windows-core mismatch before project tests compile
- cargo check -p swifttunnel-core --target x86_64-pc-windows-msvc: blocked locally because this macOS environment lacks Windows-target C headers for ring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added Windows static packet-filter support for IPv6 blocking and recovery, with marker-based branching and safer restore behavior.
  * Updated disable/enable flows to refuse unsafe configurations, perform best-effort cleanup on failures, and preserve non-product filters during cleanup.
  * Improved marker handling to avoid races and more reliably record recovery state.

* **Tests**
  * Expanded and stabilized tests for IPv6 blocking, merge/remove behavior, marker round-trip, and recovery paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->