### PR TITLE
Fix plasma orb band rendering by adding clip-path to prevent blur leakage

### DIFF
--- a/swifttunnel-desktop/src/styles/globals.css
+++ b/swifttunnel-desktop/src/styles/globals.css
@@ -290,11 +290,16 @@ body {
     infinite;
 }
 
-/* swirling energy bands */
+/* swirling energy bands. Each band carries its own clip-path: the conic
+ * gradient paints the element's full square box, and once the band is
+ * promoted to a compositor layer (animated transform + blur) Chromium
+ * stops honoring the parent's clip — clip-path here applies after the
+ * blur, inside the band's own layer, so no square edge can leak. */
 .plasma-orb .band {
   position: absolute;
   inset: -8%;
   border-radius: 50%;
+  clip-path: circle(closest-side at 50% 50%);
   mix-blend-mode: screen;
 }
 .plasma-orb .band-1 {


### PR DESCRIPTION
## Summary
Fixed a visual rendering issue in the plasma orb animation where blurred energy bands were leaking beyond their circular boundaries in Chromium browsers.

## Changes
- Added `clip-path: circle(closest-side at 50% 50%)` to `.plasma-orb .band` elements
- Updated the comment to explain the clip-path behavior and why it's necessary for compositor layers

## Implementation Details
The plasma orb bands are promoted to compositor layers during animation (via animated transforms and blur effects). In Chromium, when an element becomes a compositor layer, the parent's clip-path is no longer honored. By applying clip-path directly to the band element itself, the clipping is applied after the blur effect within the band's own layer, preventing the square edges of the conic gradient from leaking outside the circular boundary.

https://claude.ai/code/session_019DspJWr2pX9Ym59sjMaWYk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the plasma orb visual effect rendering to improve display consistency, animation quality, and overall visual performance across different rendering contexts and browser environments. The optimization enhances animation playback smoothness, improves effect display reliability, refines visual compositing behavior, and preserves all existing visual characteristics and animation effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->