### PR TITLE
Track and display direct (non-relayed) game traffic in throughput graph

### DIFF
--- a/swifttunnel-core/src/vpn/parallel_interceptor.rs
+++ b/swifttunnel-core/src/vpn/parallel_interceptor.rs
@@ -642,6 +642,16 @@ pub struct ThroughputStats {
     pub bytes_tx: Arc<AtomicU64>,
     /// Bytes received through VPN tunnel
     pub bytes_rx: Arc<AtomicU64>,
+    /// Bytes sent by tunnel-process flows that SwiftTunnel classified but
+    /// passed through to the physical adapter instead of the relay (TCP
+    /// without Route Assist, whitelisted-region auto-routing bypass).
+    ///
+    /// Display/accounting only. Relay health checks must keep reading
+    /// `bytes_tx`/`bytes_rx`, which count relay traffic exclusively.
+    pub bytes_direct_tx: Arc<AtomicU64>,
+    /// Bytes received by tunnel-process flows outside the relay (direct
+    /// inbound counterpart of `bytes_direct_tx`).
+    pub bytes_direct_rx: Arc<AtomicU64>,
     /// Timestamp when stats were started
     pub started_at: std::time::Instant,
 }
@@ -651,6 +661,8 @@ impl Default for ThroughputStats {
         Self {
             bytes_tx: Arc::new(AtomicU64::new(0)),
             bytes_rx: Arc::new(AtomicU64::new(0)),
+            bytes_direct_tx: Arc::new(AtomicU64::new(0)),
+            bytes_direct_rx: Arc::new(AtomicU64::new(0)),
             started_at: std::time::Instant::now(),
         }
     }
@@ -661,6 +673,8 @@ impl ThroughputStats {
     pub fn reset(&self) {
         self.bytes_tx.store(0, Ordering::Relaxed);
         self.bytes_rx.store(0, Ordering::Relaxed);
+        self.bytes_direct_tx.store(0, Ordering::Relaxed);
+        self.bytes_direct_rx.store(0, Ordering::Relaxed);
     }
 
     /// Get current bytes TX
@@ -673,6 +687,16 @@ impl ThroughputStats {
         self.bytes_rx.load(Ordering::Relaxed)
     }
 
+    /// Get current direct (non-relay) bytes TX for tunnel-process flows
+    pub fn get_bytes_direct_tx(&self) -> u64 {
+        self.bytes_direct_tx.load(Ordering::Relaxed)
+    }
+
+    /// Get current direct (non-relay) bytes RX for tunnel-process flows
+    pub fn get_bytes_direct_rx(&self) -> u64 {
+        self.bytes_direct_rx.load(Ordering::Relaxed)
+    }
+
     /// Add to TX counter (called when packet sent through tunnel)
     pub fn add_tx(&self, bytes: u64) {
         self.bytes_tx.fetch_add(bytes, Ordering::Relaxed);
@@ -681,6 +705,16 @@ impl ThroughputStats {
     /// Add to RX counter (called when packet received through tunnel)
     pub fn add_rx(&self, bytes: u64) {
         self.bytes_rx.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Add to direct TX counter (tunnel-process packet bypassed to physical)
+    pub fn add_direct_tx(&self, bytes: u64) {
+        self.bytes_direct_tx.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Add to direct RX counter (inbound packet for a tunnel-process flow)
+    pub fn add_direct_rx(&self, bytes: u64) {
+        self.bytes_direct_rx.fetch_add(bytes, Ordering::Relaxed);
     }
 }
 
@@ -5342,6 +5376,20 @@ fn run_packet_reader(
                         // Batch passthrough (much cheaper than per-packet bypass reinjection).
                         let _ = passthrough_to_adapter.push(&packets[i]);
 
+                        // Throughput accounting for game traffic that is
+                        // handled but deliberately not relayed (TCP without
+                        // Route Assist, whitelisted-region bypass) so the UI
+                        // graph reflects it.
+                        if auto_routing_bypass
+                            || packet_is_tunnel_process_flow(
+                                data,
+                                &snapshot,
+                                FlowAccountingDirection::Outbound,
+                            )
+                        {
+                            throughput.add_direct_tx(packet_len);
+                        }
+
                         // Keep diagnostics accurate (bypass packets won't reach workers anymore).
                         if let Some(stats) = worker_stats.get(worker_id) {
                             stats.packets_bypassed.fetch_add(1, Ordering::Relaxed);
@@ -5443,7 +5491,19 @@ fn run_packet_reader(
                     let _ = passthrough_to_adapter.push(&packets[i]);
                 }
             } else {
-                // Inbound - passthrough to MSTCP
+                // Inbound - passthrough to MSTCP.
+                //
+                // No double counting with `bytes_rx`: relayed game packets
+                // arrive encapsulated, addressed to SwiftTunnel's own relay
+                // socket (not a tunnel-process port), and the decapsulated
+                // packets are injected to MSTCP by `run_v3_inbound_receiver`
+                // without re-entering this reader. So a tunnel-process port
+                // match here can only be direct (non-relayed) game traffic,
+                // such as TCP without Route Assist.
+                if packet_is_tunnel_process_flow(data, &snapshot, FlowAccountingDirection::Inbound)
+                {
+                    throughput.add_direct_rx(data.len() as u64);
+                }
                 let _ = passthrough_to_mstcp.push(&packets[i]);
             }
         }
@@ -6872,6 +6932,76 @@ fn tcp_payload(data: &[u8], ip_start: usize, transport_start: usize) -> Option<&
         return None;
     }
     data.get(payload_start..ip_end)
+}
+
+/// Direction of a packet for tunnel-process flow accounting.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum FlowAccountingDirection {
+    Outbound,
+    Inbound,
+}
+
+/// Check whether a packet belongs to a flow owned by a tunnel process, for
+/// throughput accounting only — never for routing. Outbound packets match on
+/// the source port, inbound packets on the destination port, against the
+/// snapshot's tunnel-owned UDP/TCP port sets.
+///
+/// This lets the UI throughput graph include game traffic that SwiftTunnel
+/// classified but did not relay (TCP without Route Assist, whitelisted-region
+/// bypass), which previously made the graph read zero while the game was
+/// visibly online.
+///
+/// Kept deliberately cheap: it runs on the reader hot path for bypassed and
+/// inbound packets, so it bails out before parsing anything when no tunnel
+/// process owns any ports (game not running).
+fn packet_is_tunnel_process_flow(
+    data: &[u8],
+    snapshot: &ProcessSnapshot,
+    direction: FlowAccountingDirection,
+) -> bool {
+    if snapshot.tunnel_udp_ports.is_empty() && snapshot.tunnel_tcp_ports.is_empty() {
+        return false;
+    }
+
+    let Some(ip_start) = parse_ipv4_header_offset(data) else {
+        return false;
+    };
+    if data.len() < ip_start + 20 {
+        return false;
+    }
+    let ihl = ((data[ip_start] & 0xF) as usize) * 4;
+    if ihl < 20 {
+        return false;
+    }
+
+    // Non-initial fragments carry no transport ports.
+    let fragment_bits = u16::from_be_bytes([data[ip_start + 6], data[ip_start + 7]]);
+    if (fragment_bits & 0x1FFF) != 0 {
+        return false;
+    }
+
+    let ports = match data[ip_start + 9] {
+        6 => &snapshot.tunnel_tcp_ports,
+        17 => &snapshot.tunnel_udp_ports,
+        _ => return false,
+    };
+    if ports.is_empty() {
+        return false;
+    }
+
+    let transport_start = ip_start + ihl;
+    // The local endpoint is the source port on outbound packets and the
+    // destination port on inbound packets.
+    let local_port_offset = match direction {
+        FlowAccountingDirection::Outbound => transport_start,
+        FlowAccountingDirection::Inbound => transport_start + 2,
+    };
+    let Some(port_bytes) = data.get(local_port_offset..local_port_offset + 2) else {
+        return false;
+    };
+    let local_port = u16::from_be_bytes([port_bytes[0], port_bytes[1]]);
+
+    ports.contains(&local_port)
 }
 
 fn should_route_to_vpn_with_inline_cache(
@@ -9568,6 +9698,172 @@ mod tests {
         let (src, dst) = parse_ports(&packet).unwrap();
         assert_eq!(src, 53400);
         assert_eq!(dst, 54400);
+    }
+
+    fn snapshot_with_tunnel_ports(udp_ports: &[u16], tcp_ports: &[u16]) -> ProcessSnapshot {
+        ProcessSnapshot {
+            connections: HashMap::new(),
+            pid_names: HashMap::new(),
+            tunnel_apps: HashSet::new(),
+            tunnel_pids: HashSet::new(),
+            explicit_tunnel_udp_ports: HashSet::new(),
+            explicit_tunnel_tcp_ports: HashSet::new(),
+            tunnel_udp_ports: udp_ports.iter().copied().collect(),
+            tunnel_tcp_ports: tcp_ports.iter().copied().collect(),
+            version: 0,
+            created_at: std::time::Instant::now(),
+        }
+    }
+
+    #[test]
+    fn test_accounting_outbound_matches_tunnel_tcp_source_port() {
+        let snapshot = snapshot_with_tunnel_ports(&[], &[50123]);
+        let frame = build_ipv4_frame(
+            6,
+            Ipv4Addr::new(192, 168, 1, 100),
+            Ipv4Addr::new(128, 116, 50, 100),
+            50123,
+            443,
+        );
+
+        assert!(packet_is_tunnel_process_flow(
+            &frame,
+            &snapshot,
+            FlowAccountingDirection::Outbound,
+        ));
+    }
+
+    #[test]
+    fn test_accounting_outbound_ignores_unrelated_source_port() {
+        let snapshot = snapshot_with_tunnel_ports(&[], &[50123]);
+        let frame = build_ipv4_frame(
+            6,
+            Ipv4Addr::new(192, 168, 1, 100),
+            Ipv4Addr::new(128, 116, 50, 100),
+            40000,
+            443,
+        );
+
+        assert!(!packet_is_tunnel_process_flow(
+            &frame,
+            &snapshot,
+            FlowAccountingDirection::Outbound,
+        ));
+    }
+
+    #[test]
+    fn test_accounting_inbound_matches_tunnel_tcp_destination_port() {
+        let snapshot = snapshot_with_tunnel_ports(&[], &[50123]);
+        // Inbound: remote server is the source, local tunnel port is the destination.
+        let frame = build_ipv4_frame(
+            6,
+            Ipv4Addr::new(128, 116, 50, 100),
+            Ipv4Addr::new(192, 168, 1, 100),
+            443,
+            50123,
+        );
+
+        assert!(packet_is_tunnel_process_flow(
+            &frame,
+            &snapshot,
+            FlowAccountingDirection::Inbound,
+        ));
+        assert!(
+            !packet_is_tunnel_process_flow(&frame, &snapshot, FlowAccountingDirection::Outbound),
+            "Inbound frame's source port (443) is not tunnel-owned"
+        );
+    }
+
+    #[test]
+    fn test_accounting_matches_udp_ports_against_udp_set_only() {
+        let snapshot = snapshot_with_tunnel_ports(&[51000], &[]);
+        let udp_frame = build_ipv4_frame(
+            17,
+            Ipv4Addr::new(192, 168, 1, 100),
+            Ipv4Addr::new(128, 116, 50, 100),
+            51000,
+            64000,
+        );
+        let tcp_frame = build_ipv4_frame(
+            6,
+            Ipv4Addr::new(192, 168, 1, 100),
+            Ipv4Addr::new(128, 116, 50, 100),
+            51000,
+            443,
+        );
+
+        assert!(packet_is_tunnel_process_flow(
+            &udp_frame,
+            &snapshot,
+            FlowAccountingDirection::Outbound,
+        ));
+        assert!(
+            !packet_is_tunnel_process_flow(
+                &tcp_frame,
+                &snapshot,
+                FlowAccountingDirection::Outbound,
+            ),
+            "TCP port must not match the UDP tunnel port set"
+        );
+    }
+
+    #[test]
+    fn test_accounting_bails_out_when_no_tunnel_ports() {
+        let snapshot = snapshot_with_tunnel_ports(&[], &[]);
+        let frame = build_ipv4_frame(
+            17,
+            Ipv4Addr::new(192, 168, 1, 100),
+            Ipv4Addr::new(128, 116, 50, 100),
+            51000,
+            64000,
+        );
+
+        assert!(!packet_is_tunnel_process_flow(
+            &frame,
+            &snapshot,
+            FlowAccountingDirection::Outbound,
+        ));
+    }
+
+    #[test]
+    fn test_accounting_skips_non_initial_fragments() {
+        let snapshot = snapshot_with_tunnel_ports(&[51000], &[]);
+        let mut frame = build_ipv4_frame(
+            17,
+            Ipv4Addr::new(192, 168, 1, 100),
+            Ipv4Addr::new(128, 116, 50, 100),
+            51000,
+            64000,
+        );
+        // Fragment offset 1 (non-initial): no transport header in this fragment.
+        let ip_start = 14;
+        frame[ip_start + 6..ip_start + 8].copy_from_slice(&0x0001u16.to_be_bytes());
+
+        assert!(!packet_is_tunnel_process_flow(
+            &frame,
+            &snapshot,
+            FlowAccountingDirection::Outbound,
+        ));
+    }
+
+    #[test]
+    fn test_throughput_stats_direct_counters_reset() {
+        let stats = ThroughputStats::default();
+        stats.add_tx(10);
+        stats.add_rx(20);
+        stats.add_direct_tx(30);
+        stats.add_direct_rx(40);
+
+        assert_eq!(stats.get_bytes_tx(), 10);
+        assert_eq!(stats.get_bytes_rx(), 20);
+        assert_eq!(stats.get_bytes_direct_tx(), 30);
+        assert_eq!(stats.get_bytes_direct_rx(), 40);
+
+        stats.reset();
+        assert_eq!(stats.get_bytes_tx(), 0);
+        assert_eq!(stats.get_bytes_rx(), 0);
+        assert_eq!(stats.get_bytes_direct_tx(), 0);
+        assert_eq!(stats.get_bytes_direct_rx(), 0);
     }
 
     #[test]

--- a/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
+++ b/swifttunnel-desktop/src-tauri/src/commands/vpn.rs
@@ -267,10 +267,11 @@ pub(crate) async fn disconnect_and_persist(state: &AppState) -> Result<(), Strin
         .disconnect()
         .await
         .map_err(|e| swifttunnel_core::vpn::user_friendly_error(&e));
-    // Clear the published handle whether disconnect succeeded or not — on
+    // Clear the published handles whether disconnect succeeded or not — on
     // failure the driver state is undefined and we'd rather report None to
     // the UI than hand it a stale pointer.
     *state.split_tunnel_handle.write() = None;
+    *state.throughput_stats.write() = None;
     drop(vpn);
 
     {
@@ -522,9 +523,21 @@ pub async fn vpn_connect(
         // Publish the inner split-tunnel driver handle so polling commands
         // can read throughput/diagnostics/ping without queuing behind the
         // outer vpn_connection mutex.
-        *state.split_tunnel_handle.write() = vpn.split_tunnel_handle();
+        let driver_handle = vpn.split_tunnel_handle();
+        // Also publish the interceptor's atomic throughput counters. The
+        // driver mutex can be busy for long stretches (process scans,
+        // auto-routing), so the 1Hz+ throughput poll must not depend on
+        // winning a try_lock against it. Locking here once is fine: connect
+        // has just finished, and this is an async command handler.
+        let throughput = match driver_handle.as_ref() {
+            Some(handle) => handle.lock().await.get_throughput_stats(),
+            None => None,
+        };
+        *state.split_tunnel_handle.write() = driver_handle;
+        *state.throughput_stats.write() = throughput;
     } else {
         *state.split_tunnel_handle.write() = None;
+        *state.throughput_stats.write() = None;
     }
     drop(vpn);
 
@@ -626,19 +639,34 @@ pub struct ThroughputResponse {
 pub async fn vpn_get_throughput(
     state: State<'_, AppState>,
 ) -> Result<Option<ThroughputResponse>, String> {
-    // Bypass the outer vpn_connection mutex by hitting the split-tunnel
-    // driver handle directly. Returns None until connect() finishes wiring it.
-    let driver = state.split_tunnel_handle.read().clone();
-    let stats = match driver {
-        Some(handle) => handle
-            .try_lock()
-            .ok()
-            .and_then(|driver| driver.get_throughput_stats()),
-        None => None,
-    };
+    // Read the throughput counters published at connect time. These are
+    // shared atomics, so this never contends on the driver mutex — the old
+    // try_lock path made the graph read zero whenever the driver was busy.
+    let mut stats = state.throughput_stats.read().clone();
+
+    if stats.is_none() {
+        // Fallback for sessions where the counters were not published (e.g.
+        // the interceptor was rebuilt outside vpn_connect). Opportunistic
+        // try_lock: a miss just means we report None this tick.
+        let driver = state.split_tunnel_handle.read().clone();
+        stats = match driver {
+            Some(handle) => handle
+                .try_lock()
+                .ok()
+                .and_then(|driver| driver.get_throughput_stats()),
+            None => None,
+        };
+        if stats.is_some() {
+            *state.throughput_stats.write() = stats.clone();
+        }
+    }
+
+    // bytes_up/bytes_down are what the UI graphs: total game traffic handled
+    // by SwiftTunnel — relayed bytes plus classified direct flows (TCP
+    // without Route Assist, whitelisted-region bypass).
     Ok(stats.map(|stats| ThroughputResponse {
-        bytes_up: stats.get_bytes_tx(),
-        bytes_down: stats.get_bytes_rx(),
+        bytes_up: stats.get_bytes_tx() + stats.get_bytes_direct_tx(),
+        bytes_down: stats.get_bytes_rx() + stats.get_bytes_direct_rx(),
         packets_tunneled: 0,
         packets_bypassed: 0,
     }))

--- a/swifttunnel-desktop/src-tauri/src/state.rs
+++ b/swifttunnel-desktop/src-tauri/src/state.rs
@@ -10,6 +10,7 @@ use swifttunnel_core::roblox_optimizer::RobloxOptimizer;
 use swifttunnel_core::settings::AppSettings;
 use swifttunnel_core::system_optimizer::SystemOptimizer;
 use swifttunnel_core::vpn::SplitTunnelDriver;
+use swifttunnel_core::vpn::ThroughputStats;
 use swifttunnel_core::vpn::connection::{ConnectionState, VpnConnection};
 use swifttunnel_core::vpn::servers::DynamicServerList;
 use tokio::sync::watch;
@@ -36,6 +37,11 @@ pub struct AppState {
     pub vpn_connection: Arc<tokio::sync::Mutex<VpnConnection>>,
     pub vpn_state_handle: watch::Receiver<ConnectionState>,
     pub split_tunnel_handle: Arc<RwLock<Option<Arc<tokio::sync::Mutex<SplitTunnelDriver>>>>>,
+    /// Clone of the interceptor's atomic throughput counters, published on
+    /// connect. Reading these never takes the driver mutex, so the UI's
+    /// throughput poll can't be starved by a busy driver (`try_lock` misses
+    /// used to make the graph read zero on some machines).
+    pub throughput_stats: Arc<RwLock<Option<ThroughputStats>>>,
     pub server_list: Arc<Mutex<DynamicServerList>>,
     /// Map of region_id -> (server_name, latency_ms)
     pub region_latencies: Arc<Mutex<HashMap<String, (String, u32)>>>,
@@ -80,6 +86,7 @@ impl AppState {
             vpn_connection: Arc::new(tokio::sync::Mutex::new(vpn_connection)),
             vpn_state_handle,
             split_tunnel_handle: Arc::new(RwLock::new(None)),
+            throughput_stats: Arc::new(RwLock::new(None)),
             server_list: Arc::new(Mutex::new(DynamicServerList::new_empty())),
             region_latencies: Arc::new(Mutex::new(HashMap::new())),
             settings: Arc::new(Mutex::new(settings)),

--- a/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
+++ b/swifttunnel-desktop/src/components/connect/ConnectTab.tsx
@@ -15,14 +15,17 @@ import {
   resolveConnectStatus,
   stateLabel,
 } from "./connectState";
-import { LiveGraph, type DataSample } from "./LiveGraph";
+import {
+  LiveGraph,
+  MAX_SAMPLES,
+  SAMPLE_INTERVAL_MS,
+  type DataSample,
+} from "./LiveGraph";
 import { StatusRing } from "./StatusRing";
 import { Button, EmptyState, Tooltip, InfoIcon, Toggle } from "../ui";
 import type { ServerRegion } from "../../lib/types";
 
 type ConnectStatus = ReturnType<typeof resolveConnectStatus>;
-
-const DATA_BUFFER_SIZE = 60;
 
 function formatElapsed(s: number): string {
   const h = Math.floor(s / 3600);
@@ -117,18 +120,25 @@ export function ConnectTab() {
   }, [save]);
 
   useEffect(() => {
-    if (!isConnected) return;
-    const id = setInterval(fetchThroughput, 1000);
-    return () => clearInterval(id);
-  }, [isConnected, fetchThroughput]);
-
-  useEffect(() => {
     if (!isConnected) {
       setDataHistory([]);
       prevBytesRef.current = null;
       return;
     }
-    const id = setInterval(() => {
+    // Fetch and sample in the same tick so each rate is computed from the
+    // bytes that fetch just delivered. Two separate 1s timers used to alias
+    // against each other and produce zero/double-rate spikes in the graph.
+    let cancelled = false;
+    let inFlight = false;
+    const sample = async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        await fetchThroughput();
+      } finally {
+        inFlight = false;
+      }
+      if (cancelled) return;
       const { bytesUp, bytesDown } = useVpnStore.getState();
       const now = Date.now();
       const prev = prevBytesRef.current;
@@ -137,16 +147,19 @@ export function ConnectTab() {
         const up = Math.max(0, ((bytesUp - prev.up) / dtMs) * 1000);
         const down = Math.max(0, ((bytesDown - prev.down) / dtMs) * 1000);
         setDataHistory((h) =>
-          [...h, { t: now, up, down }].slice(-DATA_BUFFER_SIZE),
+          [...h, { t: now, up, down }].slice(-MAX_SAMPLES),
         );
       }
       prevBytesRef.current = { up: bytesUp, down: bytesDown, t: now };
-    }, 1000);
+    };
+    void sample();
+    const id = setInterval(() => void sample(), SAMPLE_INTERVAL_MS);
     return () => {
+      cancelled = true;
       clearInterval(id);
       prevBytesRef.current = null;
     };
-  }, [isConnected]);
+  }, [isConnected, fetchThroughput]);
 
   useEffect(() => {
     if (!isConnected && !isTransitioning) return;

--- a/swifttunnel-desktop/src/components/connect/LiveGraph.tsx
+++ b/swifttunnel-desktop/src/components/connect/LiveGraph.tsx
@@ -1,9 +1,26 @@
-import { useLayoutEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 export type DataSample = { t: number; up: number; down: number };
 
-const DISPLAY_SAMPLES = 60;
-const SAMPLE_INTERVAL_MS = 1000;
+/**
+ * Cadence at which ConnectTab pushes new samples. The scroll animation is
+ * time-based, so a late sample degrades gracefully instead of stuttering.
+ */
+export const SAMPLE_INTERVAL_MS = 500;
+
+/** Number of samples kept and displayed (60 × 500ms = a 30s window). */
+export const MAX_SAMPLES = 60;
+
+/** EMA factor per sample (~2s time constant at the 500ms cadence). */
+const EMA_ALPHA = 0.2;
+
+/**
+ * Vertical rescale easing per 60fps frame. The scale snaps outward instantly
+ * when the line would clip, and eases back down smoothly.
+ */
+const Y_LERP_PER_FRAME = 0.08;
+const REFERENCE_FRAME_MS = 1000 / 60;
+const MIN_Y_MAX_BYTES = 8 * 1024;
 
 function formatRate(bytesPerSec: number): string {
   if (bytesPerSec < 1024) return `${Math.round(bytesPerSec)} B/s`;
@@ -12,6 +29,26 @@ function formatRate(bytesPerSec: number): string {
   if (bytesPerSec < 1024 * 1024 * 1024)
     return `${(bytesPerSec / (1024 * 1024)).toFixed(2)} MB/s`;
   return `${(bytesPerSec / (1024 * 1024 * 1024)).toFixed(2)} GB/s`;
+}
+
+/** Catmull-Rom-style smooth line through the given points. */
+function buildLinePath(pts: [number, number][]): string {
+  let line = `M${pts[0][0].toFixed(2)},${pts[0][1].toFixed(2)}`;
+  if (pts.length > 1) {
+    for (let i = 0; i < pts.length - 1; i++) {
+      const p0 = pts[Math.max(0, i - 1)];
+      const p1 = pts[i];
+      const p2 = pts[i + 1];
+      const p3 = pts[Math.min(pts.length - 1, i + 2)];
+      const t = 0.5;
+      const c1x = p1[0] + ((p2[0] - p0[0]) * t) / 6;
+      const c1y = p1[1] + ((p2[1] - p0[1]) * t) / 6;
+      const c2x = p2[0] - ((p3[0] - p1[0]) * t) / 6;
+      const c2y = p2[1] - ((p3[1] - p1[1]) * t) / 6;
+      line += ` C${c1x.toFixed(2)},${c1y.toFixed(2)} ${c2x.toFixed(2)},${c2y.toFixed(2)} ${p2[0].toFixed(2)},${p2[1].toFixed(2)}`;
+    }
+  }
+  return line;
 }
 
 interface LiveGraphProps {
@@ -35,97 +72,113 @@ export function LiveGraph({
   const PAD_R = 10;
   const plotW = W - PAD_L - PAD_R;
   const plotH = H - PAD_T - PAD_B;
-  const stepWidth = plotW / (DISPLAY_SAMPLES - 1);
+  const stepWidth = plotW / (MAX_SAMPLES - 1);
 
   const scrollRef = useRef<SVGGElement>(null);
-  const prevLengthRef = useRef(samples.length);
+  const lineRef = useRef<SVGPathElement>(null);
+  const areaRef = useRef<SVGPathElement>(null);
+  const tipRef = useRef<SVGGElement>(null);
+  const peakRef = useRef<HTMLSpanElement>(null);
+  const animYMaxRef = useRef(MIN_Y_MAX_BYTES);
+  const peakTextRef = useRef("");
 
   const smoothed = useMemo(() => {
     if (samples.length === 0) return [] as number[];
-    const alpha = 0.35;
     let emaUp = samples[0].up;
     let emaDown = samples[0].down;
     const out: number[] = [];
     for (const s of samples) {
-      emaUp = alpha * s.up + (1 - alpha) * emaUp;
-      emaDown = alpha * s.down + (1 - alpha) * emaDown;
+      emaUp = EMA_ALPHA * s.up + (1 - EMA_ALPHA) * emaUp;
+      emaDown = EMA_ALPHA * s.down + (1 - EMA_ALPHA) * emaDown;
       out.push(emaUp + emaDown);
     }
     return out;
   }, [samples]);
 
-  const { linePath, areaPath, lastPoint, yMax, currentRate } = useMemo(() => {
-    if (smoothed.length === 0) {
-      return {
-        linePath: "",
-        areaPath: "",
-        lastPoint: null as [number, number] | null,
-        yMax: 0,
-        currentRate: 0,
-      };
-    }
-    const rawMax = Math.max(...smoothed);
-    const yMaxFinal = Math.max(rawMax * 1.25, 8 * 1024);
-    const N = smoothed.length;
-    const toX = (i: number) => PAD_L + plotW - (N - 1 - i) * stepWidth;
-    const toY = (v: number) => PAD_T + plotH - (v / yMaxFinal) * plotH;
+  const currentRate = smoothed.length > 0 ? smoothed[smoothed.length - 1] : 0;
 
-    const pts: [number, number][] = smoothed.map((v, i) => [toX(i), toY(v)]);
+  // Latest data for the animation loop, refreshed on every render so the
+  // loop itself never has to be re-created when a sample arrives.
+  const frameData = useRef({ smoothed, lastSampleT: 0 });
+  frameData.current = {
+    smoothed,
+    lastSampleT: samples.length > 0 ? samples[samples.length - 1].t : 0,
+  };
 
-    let line = `M${pts[0][0].toFixed(2)},${pts[0][1].toFixed(2)}`;
-    if (pts.length > 1) {
-      for (let i = 0; i < pts.length - 1; i++) {
-        const p0 = pts[Math.max(0, i - 1)];
-        const p1 = pts[i];
-        const p2 = pts[i + 1];
-        const p3 = pts[Math.min(pts.length - 1, i + 2)];
-        const t = 0.5;
-        const c1x = p1[0] + ((p2[0] - p0[0]) * t) / 6;
-        const c1y = p1[1] + ((p2[1] - p0[1]) * t) / 6;
-        const c2x = p2[0] - ((p3[0] - p1[0]) * t) / 6;
-        const c2y = p2[1] - ((p3[1] - p1[1]) * t) / 6;
-        line += ` C${c1x.toFixed(2)},${c1y.toFixed(2)} ${c2x.toFixed(2)},${c2y.toFixed(2)} ${p2[0].toFixed(2)},${p2[1].toFixed(2)}`;
+  const active = samples.length >= 2;
+
+  useEffect(() => {
+    if (!active) return;
+    let raf = 0;
+    let lastFrame = performance.now();
+
+    const renderFrame = (nowFrame: number) => {
+      const dt = Math.max(0.1, nowFrame - lastFrame);
+      lastFrame = nowFrame;
+      const { smoothed, lastSampleT } = frameData.current;
+
+      if (smoothed.length >= 2) {
+        // Y scale: snap outward so the line never clips, ease back down.
+        const target = Math.max(MIN_Y_MAX_BYTES, Math.max(...smoothed) * 1.25);
+        let yMax = animYMaxRef.current;
+        if (target > yMax) {
+          yMax = target;
+        } else {
+          const f = 1 - Math.pow(1 - Y_LERP_PER_FRAME, dt / REFERENCE_FRAME_MS);
+          yMax += (target - yMax) * f;
+          if (yMax - target < target * 0.001) yMax = target;
+        }
+        animYMaxRef.current = yMax;
+
+        const N = smoothed.length;
+        const toX = (i: number) => PAD_L + plotW - (N - 1 - i) * stepWidth;
+        const toY = (v: number) =>
+          PAD_T + plotH - (Math.min(v, yMax) / yMax) * plotH;
+        const pts: [number, number][] = smoothed.map((v, i) => [
+          toX(i),
+          toY(v),
+        ]);
+
+        const line = buildLinePath(pts);
+        const bottomY = PAD_T + plotH;
+        const rightX = PAD_L + plotW;
+        const area = `${line} L${rightX.toFixed(2)},${bottomY.toFixed(2)} L${pts[0][0].toFixed(2)},${bottomY.toFixed(2)} Z`;
+
+        lineRef.current?.setAttribute("d", line);
+        areaRef.current?.setAttribute("d", area);
+
+        // Time-based scroll: a fresh sample starts one step beyond the right
+        // edge of the plot and slides into view over one sample interval.
+        const phase = Math.min(
+          1,
+          Math.max(0, (Date.now() - lastSampleT) / SAMPLE_INTERVAL_MS),
+        );
+        const offset = (1 - phase) * stepWidth;
+        if (scrollRef.current) {
+          scrollRef.current.style.transform = `translate3d(${offset}px, 0, 0)`;
+        }
+
+        const tip = pts[N - 1];
+        tipRef.current?.setAttribute(
+          "transform",
+          `translate(${tip[0].toFixed(2)}, ${tip[1].toFixed(2)})`,
+        );
+
+        const peakText = `→ ${formatRate(yMax)} peak`;
+        if (peakText !== peakTextRef.current && peakRef.current) {
+          peakTextRef.current = peakText;
+          peakRef.current.textContent = peakText;
+        }
       }
-    }
 
-    const bottomY = PAD_T + plotH;
-    const rightX = PAD_L + plotW;
-    const leftX = pts[0][0];
-    const area = `${line} L${rightX.toFixed(2)},${bottomY.toFixed(2)} L${leftX.toFixed(2)},${bottomY.toFixed(2)} Z`;
-
-    return {
-      linePath: line,
-      areaPath: area,
-      lastPoint: pts[pts.length - 1],
-      yMax: yMaxFinal,
-      currentRate: smoothed[smoothed.length - 1],
+      raf = requestAnimationFrame(renderFrame);
     };
-  }, [smoothed, plotW, plotH, stepWidth]);
 
-  useLayoutEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const prev = prevLengthRef.current;
-    prevLengthRef.current = samples.length;
-
-    if (samples.length <= 1 || samples.length < prev) {
-      el.style.transition = "none";
-      el.style.transform = "translate3d(0,0,0)";
-      return;
-    }
-    if (samples.length === prev) return;
-
-    el.style.transition = "none";
-    el.style.transform = `translate3d(${stepWidth}px, 0, 0)`;
-
-    const raf = requestAnimationFrame(() => {
-      el.style.transition = `transform ${SAMPLE_INTERVAL_MS}ms linear`;
-      el.style.transform = "translate3d(0, 0, 0)";
-    });
+    raf = requestAnimationFrame(renderFrame);
     return () => cancelAnimationFrame(raf);
-  }, [samples.length, stepWidth]);
+  }, [active, plotW, plotH, stepWidth]);
 
-  if (samples.length < 2) {
+  if (!active) {
     return (
       <div
         className="relative flex flex-col justify-between overflow-hidden rounded-[var(--radius-card)] px-4 py-4"
@@ -250,16 +303,13 @@ export function LiveGraph({
         ))}
 
         <g clipPath="url(#lg-clip)" mask="url(#lg-mask)">
-          <g
-            ref={scrollRef}
-            style={{
-              willChange: "transform",
-              transform: "translate3d(0,0,0)",
-            }}
-          >
-            <path d={areaPath} fill="url(#lg-fill)" />
+          {/* Geometry (path d, tip position, scroll offset) is driven from a
+              requestAnimationFrame loop, not React renders, so the chart
+              scrolls and rescales continuously between samples. */}
+          <g ref={scrollRef} style={{ willChange: "transform" }}>
+            <path ref={areaRef} fill="url(#lg-fill)" />
             <path
-              d={linePath}
+              ref={lineRef}
               fill="none"
               stroke={lineColor}
               strokeWidth="1.75"
@@ -267,45 +317,35 @@ export function LiveGraph({
               strokeLinejoin="round"
               filter="url(#lg-glow)"
             />
-            {lastPoint && (
-              <g>
-                <circle
-                  cx={lastPoint[0]}
-                  cy={lastPoint[1]}
-                  r="4"
-                  fill={fillColor}
-                  opacity="0.3"
-                >
-                  <animate
-                    attributeName="r"
-                    values="4;10;4"
-                    dur="2s"
-                    repeatCount="indefinite"
-                  />
-                  <animate
-                    attributeName="opacity"
-                    values="0.35;0;0.35"
-                    dur="2s"
-                    repeatCount="indefinite"
-                  />
-                </circle>
-                <circle
-                  cx={lastPoint[0]}
-                  cy={lastPoint[1]}
-                  r="2.5"
-                  fill={fillColor}
-                  stroke="var(--color-bg-card)"
-                  strokeWidth="1.5"
+            <g ref={tipRef}>
+              <circle r="4" fill={fillColor} opacity="0.3">
+                <animate
+                  attributeName="r"
+                  values="4;10;4"
+                  dur="2s"
+                  repeatCount="indefinite"
                 />
-              </g>
-            )}
+                <animate
+                  attributeName="opacity"
+                  values="0.35;0;0.35"
+                  dur="2s"
+                  repeatCount="indefinite"
+                />
+              </circle>
+              <circle
+                r="2.5"
+                fill={fillColor}
+                stroke="var(--color-bg-card)"
+                strokeWidth="1.5"
+              />
+            </g>
           </g>
         </g>
       </svg>
 
       <div className="pointer-events-none absolute bottom-1.5 left-3 right-3 flex justify-between font-mono text-[9px] text-text-dimmed">
         <span>0</span>
-        <span>→ {formatRate(yMax)} peak</span>
+        <span ref={peakRef} />
       </div>
     </div>
   );

--- a/swifttunnel-desktop/src/components/connect/LiveGraph.tsx
+++ b/swifttunnel-desktop/src/components/connect/LiveGraph.tsx
@@ -108,7 +108,12 @@ export function LiveGraph({
   const active = samples.length >= 2;
 
   useEffect(() => {
-    if (!active) return;
+    if (!active) {
+      // Fresh session: don't inherit the previous session's scale.
+      animYMaxRef.current = MIN_Y_MAX_BYTES;
+      peakTextRef.current = "";
+      return;
+    }
     let raf = 0;
     let lastFrame = performance.now();
 

--- a/swifttunnel-desktop/src/mocks/tauri-core.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-core.ts
@@ -76,6 +76,10 @@ const MOCK_SETTINGS: AppSettings = {
 let mockVpnConnected = false;
 let mockSystemMemTotalMb = 16384;
 let mockSystemMemUsedMb = 9800;
+// Cumulative throughput counters, like the real backend's atomic totals.
+let mockBytesUp = 0;
+let mockBytesDown = 0;
+let mockThroughputLastAt = 0;
 
 const handlers: Record<string, (...args: unknown[]) => unknown> = {
   auth_get_state: () => ({
@@ -149,15 +153,31 @@ const handlers: Record<string, (...args: unknown[]) => unknown> = {
     await new Promise((r) => setTimeout(r, 300));
   },
 
-  vpn_get_throughput: () =>
-    mockVpnConnected
-      ? {
-          bytes_up: Math.floor(Math.random() * 500000) + 100000,
-          bytes_down: Math.floor(Math.random() * 2000000) + 500000,
-          packets_tunneled: Math.floor(Math.random() * 10000),
-          packets_bypassed: Math.floor(Math.random() * 50000),
-        }
-      : null,
+  vpn_get_throughput: () => {
+    if (!mockVpnConnected) {
+      mockBytesUp = 0;
+      mockBytesDown = 0;
+      mockThroughputLastAt = 0;
+      return null;
+    }
+    // Accumulate at a wandering rate so the dev graph looks like a live
+    // session instead of random noise.
+    const now = Date.now();
+    const dtSec =
+      mockThroughputLastAt > 0 ? (now - mockThroughputLastAt) / 1000 : 0;
+    mockThroughputLastAt = now;
+    const wave = 0.5 + 0.5 * Math.sin(now / 4000);
+    mockBytesUp += Math.floor(dtSec * (20_000 + 60_000 * wave * Math.random()));
+    mockBytesDown += Math.floor(
+      dtSec * (80_000 + 400_000 * wave * Math.random()),
+    );
+    return {
+      bytes_up: mockBytesUp,
+      bytes_down: mockBytesDown,
+      packets_tunneled: 0,
+      packets_bypassed: 0,
+    };
+  },
 
   vpn_get_ping: () =>
     mockVpnConnected ? 12 + Math.floor(Math.random() * 10) : null,

--- a/swifttunnel-desktop/src/mocks/tauri-core.ts
+++ b/swifttunnel-desktop/src/mocks/tauri-core.ts
@@ -150,6 +150,13 @@ const handlers: Record<string, (...args: unknown[]) => unknown> = {
 
   vpn_disconnect: async () => {
     mockVpnConnected = false;
+    // Reset throughput state here, not just in vpn_get_throughput: the UI
+    // stops polling while disconnected, so a stale timestamp would otherwise
+    // attribute the whole disconnected interval to the first post-reconnect
+    // poll and spike the counters.
+    mockBytesUp = 0;
+    mockBytesDown = 0;
+    mockThroughputLastAt = 0;
     await new Promise((r) => setTimeout(r, 300));
   },
 


### PR DESCRIPTION
## Summary
This PR adds throughput accounting for game traffic that SwiftTunnel classifies but deliberately does not relay (TCP without Route Assist, whitelisted-region auto-routing bypass). Previously, this traffic was invisible to the UI throughput graph, making it appear as zero activity while the game was visibly online.

## Key Changes

**Backend (Rust)**
- Added `bytes_direct_tx` and `bytes_direct_rx` atomic counters to `ThroughputStats` to track non-relayed game traffic separately from relay traffic
- Implemented `packet_is_tunnel_process_flow()` helper function to identify packets belonging to tunnel-process flows by matching source/destination ports against the process snapshot's port sets
- Integrated direct traffic accounting into the packet reader hot path:
  - Outbound packets: account when bypassed to physical adapter and owned by tunnel process
  - Inbound packets: account when passed through to MSTCP and owned by tunnel process
- Added comprehensive unit tests for the flow accounting logic (port matching, fragment handling, protocol filtering)
- Modified `vpn_get_throughput()` to sum relay and direct traffic: `bytes_up = relay_tx + direct_tx`, `bytes_down = relay_rx + direct_rx`
- Published throughput stats as shared atomics at connect time to avoid contention with the driver mutex during high-frequency polling

**Frontend (TypeScript/React)**
- Refactored `LiveGraph` component to use `requestAnimationFrame` for continuous animation between samples instead of discrete CSS transitions
- Implemented time-based scroll animation: new samples start beyond the right edge and slide in over one sample interval
- Added dynamic Y-axis rescaling: snaps outward instantly when data would clip, eases back down smoothly
- Improved EMA smoothing factor (0.2 vs 0.35) and increased sample cadence from 1s to 500ms for smoother graph responsiveness
- Updated `ConnectTab` to fetch and sample in the same tick, preventing timer aliasing that previously caused zero/double-rate spikes
- Updated mock backend to accumulate throughput at a realistic wandering rate for development

## Implementation Details
- The flow accounting function is deliberately cheap: it bails out early when no tunnel process owns any ports (game not running) and skips non-initial IP fragments that carry no transport headers
- Relay health checks continue reading `bytes_tx`/`bytes_rx` exclusively; direct counters are display/accounting only
- The graph animation loop is decoupled from React renders, allowing smooth continuous scrolling and rescaling between sample arrivals
- Throughput stats are cloned and published as Arc pointers at connect time, enabling lock-free reads during the 1Hz+ polling loop

https://claude.ai/code/session_01AMGkzakYMEWnJrdebXTk5H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Throughput now distinguishes relayed vs direct traffic so upload/download totals include both.

* **Improvements**
  * Smoother, frame-driven throughput graph with faster sampling and better timing alignment.
  * Backend now publishes a stable throughput snapshot to reduce missing/zero graphs during polling.

* **Bug Fixes**
  * Cleared stale throughput on disconnect to avoid showing old counters.

* **Tests**
  * Added unit tests validating direct-flow detection and throughput counter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->